### PR TITLE
Adds dynaconf configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,20 +1,26 @@
 # Environment variables for Metrics Service
 # Copy this file to .env and customize for your environment
+#
+# Following AAP Phase 1 Dynaconf standards:
+# - All settings use METRICS_SERVICE_ prefix
+# - Nested settings use Django-style double underscores (__), e.g. METRICS_SERVICE_DATABASES__default__HOST
+# - Environment variables override settings from config/settings.yaml
 
 # Django Settings
-DJANGO_SETTINGS_MODULE=metrics_service.settings.development
+DJANGO_SETTINGS_MODULE=metrics_service.settings
 METRICS_SERVICE_SECRET_KEY=dev-secret-key-change-in-production
 METRICS_SERVICE_DEBUG=true
 METRICS_SERVICE_ENV=development
 
 # Database Configuration (PostgreSQL)
-METRICS_SERVICE_DB_ENGINE=django.db.backends.postgresql
-METRICS_SERVICE_DB_HOST=127.0.0.1
-METRICS_SERVICE_DB_PORT=55432
-METRICS_SERVICE_DB_USER=metrics_service
-METRICS_SERVICE_DB_PASSWORD=metrics_service
-METRICS_SERVICE_DB_NAME=metrics_service
-METRICS_SERVICE_DB_SSLMODE=prefer
+# Using dunder notation for nested settings
+METRICS_SERVICE_DATABASES__default__ENGINE=django.db.backends.postgresql
+METRICS_SERVICE_DATABASES__default__HOST=127.0.0.1
+METRICS_SERVICE_DATABASES__default__PORT=5432
+METRICS_SERVICE_DATABASES__default__USER=metrics_service
+METRICS_SERVICE_DATABASES__default__PASSWORD=metrics_service
+METRICS_SERVICE_DATABASES__default__NAME=metrics_service
+METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode=prefer
 
 # Test Database Configuration
 METRICS_SERVICE_TEST_DB_NAME=test_metrics_service

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ docker-compose exec metrics-service python manage.py createsuperuser
 ```
 
 Your service will be available at:
+
 - **Application**: http://localhost:8000
 - **API Documentation**: http://localhost:8000/api/docs/
 - **Admin Interface**: http://localhost:8000/admin/
@@ -84,24 +85,28 @@ metrics-service/
 ### Key Components
 
 **Core Models** (`apps/core/models.py`)
+
 - User management with Django-Ansible-Base
 - Organization and team hierarchy
 - RBAC permissions and roles
 
 **Task System** (`apps/tasks/`)
+
 - Feature-flag controlled task groups (System, Anonymized Data, Metrics Collection)
 - Automatic task routing with Django signals
-- APScheduler integration for cron-based scheduling  
+- APScheduler integration for cron-based scheduling
 - Dispatcherd background task execution
 - Task execution tracking and monitoring
 - Built-in task functions and metrics collection
 
 **API Layer** (`apps/api/v1/`)
+
 - RESTful endpoints with filtering and pagination
 - OpenAPI/Swagger documentation
 - Authentication and permission controls
 
 **Dashboard** (`apps/dashboard/`)
+
 - Real-time task monitoring
 - Task creation and management interface
 - Live status updates every 5 seconds
@@ -111,6 +116,7 @@ metrics-service/
 ### Authentication
 
 The API supports multiple authentication methods:
+
 - Session authentication (for web interface)
 - Token authentication
 - OAuth2 tokens (for third-party integrations)
@@ -142,12 +148,14 @@ GET /api/v1/tasks/available_functions/
 ### Built-in Task Functions
 
 **System Tasks** (always enabled):
+
 - `cleanup_old_data` - Clean up old system data
 - `cleanup_old_tasks` - Clean up completed/failed tasks
 - `send_notification_email` - Send notification emails
 - `process_user_data` - Process user data in background
 
 **Metrics Collection Tasks** (feature flag controlled):
+
 - `collect_anonymous_metrics` - Collect anonymous system metrics
 - `collect_config_metrics` - Collect configuration information
 - `collect_job_host_summary` - Collect job execution statistics
@@ -175,6 +183,7 @@ python manage.py metrics_service cron start
 ### Automatic Task Routing
 
 Tasks are automatically routed based on their properties:
+
 - **Immediate tasks** → Direct to dispatcherd
 - **Scheduled tasks** → APScheduler with DateTrigger
 - **Recurring tasks** → APScheduler with CronTrigger
@@ -184,6 +193,7 @@ No manual intervention required - create a task and it's automatically processed
 ### Task Groups & Feature Flags
 
 Control task execution with environment variables:
+
 ```bash
 # Enable/disable anonymized data collection
 METRICS_SERVICE_ANONYMIZED_DATA=true
@@ -226,6 +236,7 @@ pre-commit run
 ```
 
 The pre-commit configuration automatically:
+
 - Syncs requirements files when `pyproject.toml` or `uv.lock` changes
 - Ensures requirements files are always up-to-date before commits
 
@@ -261,9 +272,11 @@ python manage.py metrics_service init-system-tasks
 
 ## Configuration
 
-### Environment Variables
+Metrics Service uses [Dynaconf](https://www.dynaconf.com/) for settings management, following the [AAP Phase 1 standards](https://handbook.eng.ansible.com/proposals/0014-Django-Settings).
 
-Key configuration options:
+### Quick Start
+
+**Development Mode** (default):
 
 ```bash
 # Database
@@ -281,13 +294,54 @@ METRICS_SERVICE_ALLOWED_HOSTS=localhost,yourdomain.com
 # Task Feature Flags
 METRICS_SERVICE_ANONYMIZED_DATA=true
 METRICS_SERVICE_METRICS_COLLECTION=false
+# Just run - no configuration required
+python manage.py runserver
 ```
 
-### Settings Files
+**Production Mode**:
 
-Configuration is managed through:
-- **Environment variables** - Runtime configuration
-- **`config/settings.yaml`** - Complex configuration via Dynaconf
+```bash
+# Set environment mode and required secrets
+export METRICS_SERVICE_MODE=production
+export METRICS_SERVICE_SECRET_KEY="your-secure-random-key"
+export METRICS_SERVICE_ALLOWED_HOSTS="yourdomain.com,api.yourdomain.com"
+
+# Override defaults as needed
+export METRICS_SERVICE_DATABASES__default__HOST=prod-db.example.com
+export METRICS_SERVICE_DATABASES__default__PASSWORD=secure-password
+
+python manage.py runserver
+```
+
+### Configuration Methods
+
+Settings are loaded in order of precedence (lowest to highest):
+
+1. **`metrics_service/settings/defaults.py`** - Base Django defaults
+2. **`config/settings.yaml`** - Environment-specific configuration
+3. **`/etc/ansible-automation-platform/settings.yaml`** - System-wide AAP settings
+4. **Environment variables** with `METRICS_SERVICE_` prefix - **Highest priority**
+
+### Common Environment Variables
+
+| Variable                                       | Description                               | Required in Production       |
+| ---------------------------------------------- | ----------------------------------------- | ---------------------------- |
+| `METRICS_SERVICE_MODE`                         | Environment mode (development/production) | No (defaults to development) |
+| `METRICS_SERVICE_SECRET_KEY`                   | Django secret key                         | **Yes**                      |
+| `METRICS_SERVICE_DEBUG`                        | Enable debug mode                         | No                           |
+| `METRICS_SERVICE_DATABASES__default__HOST`     | Database host                             | No (has default)             |
+| `METRICS_SERVICE_DATABASES__default__PASSWORD` | Database password                         | No (has default)             |
+| `METRICS_SERVICE_ALLOWED_HOSTS`                | Allowed hosts (comma-separated)           | **Yes** (production)         |
+
+**Note:** Use double underscores (`__`) for nested settings:
+
+```bash
+# Nested database configuration
+export METRICS_SERVICE_DATABASES__default__HOST=localhost
+export METRICS_SERVICE_DATABASES__default__PORT=5432
+```
+
+For comprehensive configuration documentation, validators, troubleshooting, and testing information, see **[metrics_service/settings/README.md](metrics_service/settings/README.md)**.
 
 ## Deployment
 
@@ -331,3 +385,4 @@ This project is licensed under the Apache License - see the [LICENSE](LICENSE) f
 - **Documentation**: Check the [CLAUDE.md](CLAUDE.md) file for detailed development guidance
 - **Issues**: Report bugs and feature requests via GitHub issues
 - **API Documentation**: Interactive docs available at `/api/docs/` when running
+```

--- a/apps/api/v1/urls.py
+++ b/apps/api/v1/urls.py
@@ -5,7 +5,7 @@ URL configuration for API v1.
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from .views import OrganizationViewSet, UserViewSet
+from .views import ConfigView, OrganizationViewSet, UserViewSet
 
 app_name = "v1"
 
@@ -13,6 +13,7 @@ app_name = "v1"
 router = DefaultRouter()
 router.register(r"users", UserViewSet, basename="user")
 router.register(r"organizations", OrganizationViewSet, basename="organization")
+router.register(r"config", ConfigView, basename="config")
 
 urlpatterns = [
     # Nested API endpoints

--- a/apps/api/v1/views.py
+++ b/apps/api/v1/views.py
@@ -4,13 +4,16 @@ API v1 views for metrics_service following AAP standards.
 
 from ansible_base.lib.utils.views.django_app_api import AnsibleBaseDjangoAppApiView
 from ansible_base.oauth2_provider.permissions import OAuth2ScopePermission
+from ansible_base.rbac.api.permissions import AnsibleBaseObjectPermissions
 from drf_spectacular.utils import extend_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 
 from apps.core.models import Organization, User
 from apps.core.permissions import SystemAuditorAwarePermissions
+from metrics_service.settings import DYNACONF
 
 from .serializers import (
     OrganizationSerializer,
@@ -136,3 +139,39 @@ class OrganizationViewSet(AnsibleBaseDjangoAppApiView, viewsets.ModelViewSet):
                 return Response(status=status.HTTP_204_NO_CONTENT)
             except User.DoesNotExist:
                 return Response({"error": "User not found"}, status=status.HTTP_404_NOT_FOUND)
+
+
+class ConfigView(AnsibleBaseDjangoAppApiView, viewsets.ViewSet):
+    permission_classes = [IsAdminUser, AnsibleBaseObjectPermissions]
+
+    @extend_schema(operation_id="config_retrieve", description="Get current configuration", responses={200: dict})
+    def list(self, request):
+        return Response(DYNACONF.to_dict())
+
+    @extend_schema(
+        operation_id="config_update", description="Update current configuration", request=dict, responses={204: None}
+    )
+    @action(detail=False, methods=["post"])
+    def update_config(self, request):
+        DYNACONF.merge(request.data)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        operation_id="config_reload",
+        description="Reload current configuration from files and environment variables",
+        responses={204: {"message": "Configuration reloaded successfully"}},
+    )
+    @action(detail=False, methods=["post"])
+    def reload(self, request):
+        try:
+            DYNACONF.reload()
+            return Response({"message": "Configuration reloaded successfully"}, status=status.HTTP_204_NO_CONTENT)
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def config(self, request):
+        if request.method == "GET":
+            return Response(DYNACONF.to_dict())
+        elif request.method == "POST":
+            DYNACONF.merge(request.data)
+            return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/core/management/commands/reload_config_command.py
+++ b/apps/core/management/commands/reload_config_command.py
@@ -1,0 +1,56 @@
+"""
+Management command to reload dynaconf configuration.
+
+This command triggers a reload of the dynaconf settings, allowing configuration
+changes to be applied without restarting the entire application.
+"""
+
+import logging
+
+from django.core.management.base import BaseCommand
+
+from metrics_service.settings import DYNACONF
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Management command to reload dynaconf configuration."""
+
+    help = "Reload dynaconf configuration from files and environment variables"
+    dynaconf = DYNACONF
+
+    def add_arguments(self, parser):
+        """Add command line arguments."""
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="Show detailed information about the reload process",
+        )
+
+    def handle(self, *args, **options):
+        """Handle the command execution."""
+        verbose = options.get("verbose", False)
+
+        try:
+            if verbose:
+                self.stdout.write("Reloading dynaconf configuration...")
+
+            # Call the existing reload function
+            self.dynaconf.reload()
+
+            # Log the successful reload
+            logger.info("Dynaconf configuration reloaded successfully")
+            self.stdout.write(self.style.SUCCESS("✅ Configuration reloaded successfully"))
+
+            if verbose:
+                from metrics_service.settings import DYNACONF
+
+                self.stdout.write(f"Current environment: {DYNACONF.current_env}")
+                self.stdout.write(f"Loaded settings files: {DYNACONF.settings_files}")
+
+        except Exception as e:
+            error_msg = f"Failed to reload configuration: {str(e)}"
+            logger.error(error_msg)
+            self.stdout.write(self.style.ERROR(f"❌ {error_msg}"))
+            raise

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,90 +1,81 @@
-# Example Dynaconf settings file for metrics_service
-# Copy this file to settings.yaml and customize for your environment
+# Dynaconf settings file for metrics_service
+# Following AAP Phase 1 standards
+# Environment variables with METRICS_SERVICE_ prefix will override these values
 
-# Environment Configuration
-environment: default
+# Base configuration - used as baseline for all environments
+default:
+  # Security Settings
+  SECRET_KEY: 'your-secret-key-here-change-in-production'
+  ALLOWED_HOSTS:
+    - localhost
+    - 127.0.0.1
 
-# Security Settings
-secret_key: 'your-secret-key-here-change-in-production'
-allowed_hosts:
-  - localhost
-  - 127.0.0.1
+  # Database Configuration
+  DATABASES:
+    default:
+      ENGINE: django.db.backends.postgresql
+      HOST: localhost
+      PORT: 5432
+      USER: metrics_service
+      PASSWORD: metrics_service
+      NAME: metrics_service
+      OPTIONS:
+        sslmode: prefer
 
-# Database Configuration
-databases:
-  default:
-    engine: django.db.backends.postgresql
-    host: localhost
-    port: 55432
-    user: metrics_service
-    password: metrics_service
-    name: metrics_service
-    options:
-      sslmode: prefer
+  # Cache Configuration
+  CACHES:
+    default:
+      BACKEND: django.core.cache.backends.locmem.LocMemCache
+      LOCATION: default
 
-# Cache Configuration
-caches:
-  default:
-    backend: django.core.cache.backends.locmem.LocMemCache
-    location: default
-
-# Email Configuration
-email:
-  backend: django.core.mail.backends.smtp.EmailBackend
-  host: smtp.example.com
-  port: 587
-  use_tls: true
-  user: your_email@example.com
-  password: your_email_password
-  from_email: noreply@example.com
-
-# CORS Configuration
-cors:
-  allow_all_origins: false
-  allowed_origins:
+  # CORS Configuration
+  CORS_ALLOW_ALL_ORIGINS: false
+  CORS_ALLOWED_ORIGINS:
     - http://localhost:3000
     - http://127.0.0.1:3000
-  allow_credentials: true
 
-# Service Configuration
-service:
-  type: metrics-service
-  id: metrics-service-instance-id
+  # Service Configuration
+  SERVICE_TYPE: metrics-service
+  SERVICE_ID: metrics-service-instance-id
 
+  # Debug mode
+  DEBUG: false
+  # Resource Server Configuration (for AAP integration)
+  # Uncomment and configure for AAP Gateway integration
+  # RESOURCE_SERVER:
+  #   URL: https://aap-gateway:9080
+  #   SECRET_KEY: your-service-secret
+  #   VALIDATE_HTTPS: true
 
-# Dispatcherd Configuration
-dispatcherd:
-  workers: 4
-  max_tasks: 100
-  timeout: 3600
+  # Logging Configuration Override (optional)
+  # Uncomment to customize logging
+  # LOGGING:
+  #   version: 1
+  #   disable_existing_loggers: false
+  #   handlers:
+  #     file:
+  #       class: logging.handlers.RotatingFileHandler
+  #       filename: /var/log/metrics_service/metrics_service.log
+  #       maxBytes: 10485760
+  #       backupCount: 5
+  #       formatter: json
+  #   loggers:
+  #     metrics_service:
+  #       level: INFO
+  #       handlers: [console, file]
 
-# OAuth2 Configuration
-oauth2:
-  access_token_expire: 3600
-  refresh_token_expire: 86400
+# Development environment overrides
+# Inherits from default and adds dev-specific settings
+development:
+  DEBUG: true
+  CORS_ALLOW_ALL_ORIGINS: true
+  # Inherits SECRET_KEY and database settings from default - safe for local dev
 
-# JWT Configuration
-jwt:
-  expiration: 3600
-# Resource Server Configuration (for AAP integration)
-# Uncomment and configure for AAP Gateway integration
-# resource_server:
-#   url: https://aap-gateway:9080
-#   secret_key: your-service-secret
-#   validate_https: true
-
-# Logging Configuration Override
-# logging:
-#   version: 1
-#   disable_existing_loggers: false
-#   handlers:
-#     file:
-#       class: logging.handlers.RotatingFileHandler
-#       filename: /var/log/metrics_service/metrics_service.log
-#       maxBytes: 10485760
-#       backupCount: 5
-#       formatter: json
-#   loggers:
-#     metrics_service:
-#       level: INFO
-#       handlers: [console, file]
+# Production environment - NO sensitive defaults!
+# All sensitive values MUST be set via environment variables
+production:
+  DEBUG: false
+  CORS_ALLOW_ALL_ORIGINS: false
+  # Override inherited defaults with empty/invalid values to force explicit configuration
+  SECRET_KEY: 'PRODUCTION-SECRET-KEY-NOT-SET'  # Will fail validation - must be set via env var
+  ALLOWED_HOSTS: []  # Empty by default - must be explicitly set

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   postgres:
-    image: 'postgres:15'
+    image: "postgres:15"
     container_name: metrics-service-postgres
     environment:
       POSTGRES_DB: metrics_service
@@ -9,46 +9,73 @@ services:
       POSTGRES_PASSWORD: metrics_service
     healthcheck:
       test:
-        ['CMD', 'pg_isready', '-U', 'metrics_service', '-d', 'metrics_service']
+        ["CMD", "pg_isready", "-U", "metrics_service", "-d", "metrics_service"]
       interval: 10s
       timeout: 5s
       retries: 5
     ports:
-      - '55432:5432'
+      - "55432:5432"
     networks:
       - metrics-service
     volumes:
-      - 'metrics_service_db:/var/lib/postgresql/data'
+      - "metrics_service_db:/var/lib/postgresql/data"
 
   metrics-service:
     build:
       context: .
       dockerfile: Dockerfile
     container_name: metrics-service-app
-    command: 'uv run python manage.py metrics_service run --host 0.0.0.0 --port 8000 --workers 4'
+    command: "uv run python manage.py metrics_service run --host 0.0.0.0 --port 8000 --workers 4"
     volumes:
-      - './:/app:z'
+      - "./:/app:z"
     ports:
       - ${metrics_service_PORT:-8000}:8000
     depends_on:
       postgres:
         condition: service_healthy
     environment:
-      METRICS_SERVICE_ENV: development
+      METRICS_SERVICE_MODE: development
       METRICS_SERVICE_SECRET_KEY: dev-secret-key-change-in-production
-      METRICS_SERVICE_DB_ENGINE: django.db.backends.postgresql
-      METRICS_SERVICE_DB_HOST: postgres
-      METRICS_SERVICE_DB_PORT: 5432
-      METRICS_SERVICE_DB_USER: metrics_service
-      METRICS_SERVICE_DB_PASSWORD: metrics_service
-      METRICS_SERVICE_DB_NAME: metrics_service
-      METRICS_SERVICE_DB_SSLMODE: prefer
+      METRICS_SERVICE_DATABASES__default__ENGINE: django.db.backends.postgresql
+      METRICS_SERVICE_DATABASES__default__HOST: postgres
+      METRICS_SERVICE_DATABASES__default__PORT: 5432
+      METRICS_SERVICE_DATABASES__default__USER: metrics_service
+      METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
+      METRICS_SERVICE_DATABASES__default__NAME: metrics_service
+      METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode: prefer
       METRICS_SERVICE_ALLOWED_HOSTS: localhost,127.0.0.1,metrics-service,0.0.0.0
-      METRICS_SERVICE_DEBUG: 'true'
-      METRICS_SERVICE_ANONYMIZED_DATA: 'true'
-      METRICS_SERVICE_METRICS_COLLECTION: 'false'
+      METRICS_SERVICE_DEBUG: "true"
+      METRICS_SERVICE_ANONYMIZED_DATA: "true"
+      METRICS_SERVICE_METRICS_COLLECTION: "false"
       DJANGO_SETTINGS_MODULE: metrics_service.settings.development
       DISPATCHERD_CONFIG_FILE: /app/config/dispatcherd.yaml
+      DISPATCHERD_ENABLED: "true"
+    networks:
+      - metrics-service
+
+  metrics-dispatcher:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: metrics-service-dispatcher
+    command: "uv run python manage.py run_dispatcherd --workers=4 --timeout=3600"
+    volumes:
+      - "./:/app:z"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      METRICS_SERVICE_MODE: development
+      METRICS_SERVICE_SECRET_KEY: dev-secret-key-change-in-production
+      METRICS_SERVICE_DATABASES__default__ENGINE: django.db.backends.postgresql
+      METRICS_SERVICE_DATABASES__default__HOST: postgres
+      METRICS_SERVICE_DATABASES__default__PORT: 5432
+      METRICS_SERVICE_DATABASES__default__USER: metrics_service
+      METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
+      METRICS_SERVICE_DATABASES__default__NAME: metrics_service
+      METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode: prefer
+      DJANGO_SETTINGS_MODULE: metrics_service.settings.development
+      DISPATCHERD_ENABLED: "true"
     networks:
       - metrics-service
 

--- a/metrics_service/settings/README.md
+++ b/metrics_service/settings/README.md
@@ -1,0 +1,424 @@
+# Metrics Service Settings
+
+This document describes the settings configuration system for Metrics Service, which follows the AAP (Ansible Automation Platform) Phase 1 standards from [handbook proposal 0014-Django-Settings](https://handbook.eng.ansible.com/proposals/0014-Django-Settings).
+
+## Overview
+
+Metrics Service uses **Dynaconf** for settings management, providing a flexible, secure, and standardized approach to configuration across development and production environments.
+
+## Architecture
+
+### Settings Files
+
+```
+metrics_service/settings/
+├── __init__.py          # Main settings module - Dynaconf factory integration
+├── defaults.py          # Django defaults (base configuration)
+├── development.py       # Development-specific overrides (legacy)
+├── test.py             # Test environment settings
+└── README.md           # This file
+
+config/
+├── settings.yaml        # Environment-specific configuration (Dynaconf)
+└── settings.local.yaml  # Local overrides (git-ignored)
+```
+
+### Key Components
+
+1. **`defaults.py`**: Base Django settings with sensible defaults for all environments
+2. **`config/settings.yaml`**: Dynaconf configuration with environment-specific sections
+3. **Environment variables**: Highest priority overrides using `METRICS_SERVICE_` prefix
+4. **Validators**: Enforce security requirements in production
+
+## Configuration Precedence
+
+Settings are loaded in the following order (lowest to highest priority):
+
+1. **defaults.py** - Base Django constants
+2. **config/settings.yaml** (`default:` section) - Baseline for all environments
+3. **config/settings.yaml** (environment section) - Environment-specific overrides
+4. **/etc/ansible-automation-platform/settings.yaml** - System-wide AAP settings
+5. **/etc/ansible-automation-platform/metrics-service/settings.yaml** - Service-specific AAP settings
+6. **Environment variables** with `METRICS_SERVICE_` prefix - **Highest priority**
+
+This precedence is implemented using DAB's (Django Ansible Base) manual loaders:
+```python
+load_standard_settings_files(DYNACONF)  # Load system settings
+load_envvars(DYNACONF)                  # Load environment variables (highest priority)
+```
+
+## Environment Modes
+
+The environment mode is controlled by the `METRICS_SERVICE_MODE` environment variable.
+
+### Development Mode
+
+**Environment Variable:**
+```bash
+export METRICS_SERVICE_MODE=development
+```
+
+**Behavior:**
+- Uses defaults from `config/settings.yaml`
+- Validation **disabled** - allows default values for easy setup
+- DEBUG enabled
+- CORS allows all origins
+- No environment variables required
+
+**Use Case:** Local development and testing
+
+### Production Mode
+
+**Environment Variable:**
+```bash
+export METRICS_SERVICE_MODE=production
+```
+
+**Behavior:**
+- Validation **enforced** - requires explicit configuration
+- SECRET_KEY **must** be set via environment variable
+- Database credentials **must** be configured
+- DEBUG disabled by default
+- Empty ALLOWED_HOSTS (must be explicitly set)
+
+**Use Case:** Production deployments
+
+**Example Production Configuration:**
+```bash
+export METRICS_SERVICE_MODE=production
+export METRICS_SERVICE_SECRET_KEY="your-secure-random-key-here"
+export METRICS_SERVICE_DATABASES__default__HOST="prod-db.example.com"
+export METRICS_SERVICE_DATABASES__default__PASSWORD="secure-db-password"
+export METRICS_SERVICE_ALLOWED_HOSTS="app.example.com,metrics.example.com"
+```
+
+## Environment Variables
+
+All settings can be overridden using environment variables with the `METRICS_SERVICE_` prefix.
+
+### Flat Settings
+
+```bash
+export METRICS_SERVICE_DEBUG=true
+export METRICS_SERVICE_SECRET_KEY="my-secret-key"
+```
+
+### Nested Settings (Dunder Notation)
+
+For nested dictionaries, use double underscores (`__`):
+
+```bash
+# Database configuration
+export METRICS_SERVICE_DATABASES__default__HOST=localhost
+export METRICS_SERVICE_DATABASES__default__PORT=5432
+export METRICS_SERVICE_DATABASES__default__NAME=metrics_service
+export METRICS_SERVICE_DATABASES__default__USER=metrics_user
+export METRICS_SERVICE_DATABASES__default__PASSWORD=secure_password
+```
+
+This is equivalent to:
+```python
+DATABASES = {
+    "default": {
+        "HOST": "localhost",
+        "PORT": "5432",
+        "NAME": "metrics_service",
+        "USER": "metrics_user",
+        "PASSWORD": "secure_password"
+    }
+}
+```
+
+### Common Environment Variables
+
+| Variable | Description | Required in Production |
+|----------|-------------|----------------------|
+| `METRICS_SERVICE_MODE` | Environment mode (development/production) | No (defaults to development) |
+| `METRICS_SERVICE_SECRET_KEY` | Django secret key | **Yes** |
+| `METRICS_SERVICE_DEBUG` | Enable debug mode | No |
+| `METRICS_SERVICE_DATABASES__default__HOST` | Database host | No (has default) |
+| `METRICS_SERVICE_DATABASES__default__NAME` | Database name | No (has default) |
+| `METRICS_SERVICE_DATABASES__default__USER` | Database user | No (has default) |
+| `METRICS_SERVICE_DATABASES__default__PASSWORD` | Database password | No (has default) |
+| `METRICS_SERVICE_ALLOWED_HOSTS` | Allowed hosts (comma-separated) | **Yes** (production) |
+
+## Validators
+
+Dynaconf validators enforce configuration requirements in production mode.
+
+### SECRET_KEY Validators
+
+Prevents using default SECRET_KEY values:
+```python
+Validator("SECRET_KEY", ne="dev-secret-key-change-in-production")
+Validator("SECRET_KEY", ne="your-secret-key-here-change-in-production")
+Validator("SECRET_KEY", ne="PRODUCTION-SECRET-KEY-NOT-SET")
+```
+
+**Error Message:**
+```
+dynaconf.validator.ValidationError: SECRET_KEY must be set in production.
+Set METRICS_SERVICE_SECRET_KEY environment variable.
+```
+
+### Database Validators
+
+Ensures critical database settings exist:
+```python
+Validator("DATABASES.default.NAME", must_exist=True)
+Validator("DATABASES.default.HOST", must_exist=True)
+Validator("DATABASES.default.USER", must_exist=True)
+Validator("DATABASES.default.PASSWORD", must_exist=True)
+```
+
+**Note:** Validators only run when `validation=True` in the export call, which happens in production mode.
+
+## Configuration Files
+
+### config/settings.yaml
+
+The main Dynaconf configuration file with environment-specific sections:
+
+```yaml
+# Base configuration - inherited by all environments
+default:
+  SECRET_KEY: 'your-secret-key-here-change-in-production'
+  DEBUG: false
+  DATABASES:
+    default:
+      ENGINE: django.db.backends.postgresql
+      HOST: localhost
+      PORT: 5432
+      USER: metrics_service
+      PASSWORD: metrics_service
+      NAME: metrics_service
+
+# Development overrides
+development:
+  DEBUG: true
+  CORS_ALLOW_ALL_ORIGINS: true
+
+# Production - forces explicit configuration
+production:
+  DEBUG: false
+  SECRET_KEY: 'PRODUCTION-SECRET-KEY-NOT-SET'  # Will fail validation
+  ALLOWED_HOSTS: []
+```
+
+### config/settings.local.yaml (Optional)
+
+Create this file for personal local overrides. It's git-ignored and loads last (before environment variables):
+
+```yaml
+default:
+  DATABASES:
+    default:
+      PORT: 55432  # Local PostgreSQL on different port
+```
+
+### .env File (Optional)
+
+Dynaconf can load from `.env` files automatically. Copy `.env.example` to `.env`:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with your local settings:
+```bash
+METRICS_SERVICE_MODE=development
+METRICS_SERVICE_DATABASES__default__HOST=127.0.0.1
+METRICS_SERVICE_DATABASES__default__PORT=5432
+```
+
+## Testing
+
+### Running the Application
+
+**Development:**
+```bash
+# Uses defaults - no env vars required
+python manage.py runserver
+```
+
+**Production:**
+```bash
+# Requires explicit configuration
+export METRICS_SERVICE_MODE=production
+export METRICS_SERVICE_SECRET_KEY="$(python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())')"
+export METRICS_SERVICE_ALLOWED_HOSTS="localhost,127.0.0.1"
+python manage.py runserver
+```
+
+### Checking Configuration
+
+Verify settings are loaded correctly:
+```bash
+python manage.py check
+```
+
+View current settings:
+```bash
+python manage.py shell
+>>> from django.conf import settings
+>>> settings.SECRET_KEY
+>>> settings.DATABASES
+```
+
+### Unit Tests
+
+Comprehensive unit tests for the Dynaconf configuration are located at:
+
+**`tests/unit/test_dynaconf_settings.py`**
+
+**Test Coverage:**
+
+1. **TestDynaconfPrecedence** - Verifies settings precedence order
+   - Environment variables are loaded correctly
+   - Dynaconf can read environment variables
+   - Database defaults load properly
+   - CORS settings load correctly
+
+2. **TestDynaconfValidators** - Tests validator configuration
+   - Validators are registered
+   - SECRET_KEY validators configured correctly
+   - Database validators configured
+   - Settings pass validation
+
+3. **TestEnvironmentSwitching** - Tests environment mode switching
+   - Current environment is set correctly
+   - Development mode flag works
+
+4. **TestDynaconfFactory** - Tests DAB factory integration
+   - Factory creates Dynaconf instance
+   - Factory registers validators
+   - Environment variable prefix configured
+
+5. **TestSettingsFileLoading** - Tests file loading order
+   - defaults.py values loaded
+   - config/settings.yaml loaded
+
+**Running the Tests:**
+
+```bash
+# Run all Dynaconf settings tests
+export METRICS_SERVICE_SECRET_KEY="test-key"
+export DJANGO_SETTINGS_MODULE="metrics_service.settings"
+pytest tests/unit/test_dynaconf_settings.py -v
+
+# Run with coverage
+pytest tests/unit/test_dynaconf_settings.py --cov=metrics_service.settings
+
+# Run specific test class
+pytest tests/unit/test_dynaconf_settings.py::TestDynaconfValidators -v
+```
+
+**Note:** Tests require `METRICS_SERVICE_SECRET_KEY` to be set since they use the main settings module (not test settings).
+
+## Troubleshooting
+
+### Common Issues
+
+**1. ValidationError: SECRET_KEY must be set in production**
+
+**Solution:** Set the SECRET_KEY environment variable:
+```bash
+export METRICS_SERVICE_SECRET_KEY="your-secure-key-here"
+```
+
+**2. Application uses wrong environment**
+
+**Problem:** Set `METRICS_SERVICE_ENV` but it has no effect
+
+**Solution:** Use `METRICS_SERVICE_MODE` (not `_ENV`):
+```bash
+export METRICS_SERVICE_MODE=production  # ✓ Correct
+export METRICS_SERVICE_ENV=production   # ✗ Wrong variable name
+```
+
+**3. Environment variable not being read**
+
+**Problem:** Set `SOME_VARIABLE=value` but Dynaconf doesn't see it
+
+**Solution:** Use the correct prefix:
+```bash
+export METRICS_SERVICE_DEBUG=true  # ✓ Correct (has prefix)
+export DEBUG=true                  # ✗ Wrong (no prefix)
+```
+
+**4. Nested settings not working**
+
+**Problem:** `METRICS_SERVICE_DATABASES.default.HOST=localhost` doesn't work
+
+**Solution:** Use double underscores for nesting:
+```bash
+export METRICS_SERVICE_DATABASES__default__HOST=localhost  # ✓ Correct (double underscore)
+export METRICS_SERVICE_DATABASES.default.HOST=localhost    # ✗ Wrong (dots)
+```
+
+### Debugging
+
+**Check what Dynaconf loaded:**
+```python
+from metrics_service.settings import DYNACONF
+
+# See current environment
+print(DYNACONF.current_env)  # Should be DEVELOPMENT or PRODUCTION
+
+# See all loaded settings
+print(DYNACONF.as_dict())
+
+# Check specific setting
+print(DYNACONF.get('SECRET_KEY'))
+print(DYNACONF.get('DATABASES'))
+```
+
+**Check environment variable precedence:**
+```bash
+# 1. Check if env var is set
+echo $METRICS_SERVICE_DEBUG
+
+# 2. Run Python to see what Django sees
+python -c "from django.conf import settings; print(settings.DEBUG)"
+
+# 3. Compare with Dynaconf
+python -c "from metrics_service.settings import DYNACONF; print(DYNACONF.get('DEBUG'))"
+```
+
+## Migration from Old Settings
+
+If migrating from the old split-settings approach:
+
+**Old way (settings/development.py):**
+```python
+from .defaults import *
+DEBUG = True
+```
+
+**New way (config/settings.yaml):**
+```yaml
+development:
+  DEBUG: true
+```
+
+**Or via environment variable:**
+```bash
+export METRICS_SERVICE_DEBUG=true
+```
+
+The old `development.py` and `test.py` files still exist for backward compatibility but are not used when loading via the main settings module.
+
+## Additional Resources
+
+- [Dynaconf Documentation](https://www.dynaconf.com/)
+- [AAP Handbook Proposal 0014](https://handbook.eng.ansible.com/proposals/0014-Django-Settings)
+- [Django Settings Documentation](https://docs.djangoproject.com/en/stable/topics/settings/)
+- [Django Ansible Base](https://github.com/ansible/django-ansible-base)
+
+## Support
+
+For issues or questions about settings configuration:
+1. Check this README
+2. Review the unit tests in `tests/unit/test_dynaconf_settings.py`
+3. Check the Django check command output: `python manage.py check`
+4. File an issue in the metrics-service repository

--- a/metrics_service/settings/__init__.py
+++ b/metrics_service/settings/__init__.py
@@ -1,20 +1,85 @@
 import os
 from pathlib import Path
 
-from ansible_base.lib import dynamic_config
-from split_settings.tools import include
+from ansible_base.lib.dynamic_config import export, factory, load_envvars, load_standard_settings_files
+from dynaconf import Validator
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # Set environment before including any settings
-os.environ.setdefault("METRICS_SERVICE_ENV", "default")
-environment = os.environ.get("METRICS_SERVICE_ENV", "default")
+# Note: Factory uses METRICS_SERVICE_MODE as the env_switcher (not METRICS_SERVICE_ENV)
+os.environ.setdefault("METRICS_SERVICE_MODE", "development")
+environment = os.environ.get("METRICS_SERVICE_MODE", "development")
 
-# Include base Django-Ansible-Base settings
-settings_file = os.path.join(
-    os.path.dirname(dynamic_config.__file__),
-    "dynamic_settings.py",
+# Initialize Dynaconf following AAP Phase 1 standards using DAB factory
+# This follows the pattern from handbook proposal 0014-Django-Settings
+# The factory will load settings in this order:
+# 1. defaults.py (loaded as a settings_file)
+# 2. /etc/ansible-automation-platform/settings.yaml (auto-loaded by factory)
+# 3. config/settings.yaml (local overrides)
+# 4. Environment variables with METRICS_SERVICE_ prefix
+DYNACONF = factory(
+    module_name=__name__,
+    app_name="METRICS_SERVICE",
+    validators=[
+        # Security: Require SECRET_KEY to be explicitly set (not defaults)
+        # Note: Validators only run in production (validation=False in development at export time)
+        Validator(
+            "SECRET_KEY",
+            must_exist=True,
+            ne="dev-secret-key-change-in-production",  # From defaults.py
+            messages={
+                "operations": "SECRET_KEY must not use default value. Set METRICS_SERVICE_SECRET_KEY environment variable.",
+            },
+        ),
+        Validator(
+            "SECRET_KEY",
+            must_exist=True,
+            ne="your-secret-key-here-change-in-production",  # From config/settings.yaml default section
+            messages={
+                "operations": "SECRET_KEY must not use default value. Set METRICS_SERVICE_SECRET_KEY environment variable.",
+            },
+        ),
+        Validator(
+            "SECRET_KEY",
+            must_exist=True,
+            ne="PRODUCTION-SECRET-KEY-NOT-SET",  # From config/settings.yaml production section
+            messages={
+                "operations": "SECRET_KEY must be set in production. Set METRICS_SERVICE_SECRET_KEY environment variable.",
+            },
+        ),
+        # Database: Ensure critical database settings exist
+        Validator("DATABASES.default.NAME", must_exist=True),
+        Validator("DATABASES.default.HOST", must_exist=True),
+        Validator("DATABASES.default.USER", must_exist=True),
+        Validator("DATABASES.default.PASSWORD", must_exist=True),
+    ],
+    # Settings files to load (in order)
+    # Factory loads in this precedence (lowest to highest):
+    # 1. defaults.py
+    # 2. /etc/ansible-automation-platform/settings.yaml (from factory)
+    # 3. config/settings.yaml
+    # 4. config/settings.local.yaml
+    # 5. Environment variables (METRICS_SERVICE_*) - handled by Dynaconf loaders
+    settings_files=[
+        "defaults.py",
+        str(BASE_DIR / "config" / "settings.yaml"),
+        str(BASE_DIR / "config" / "settings.local.yaml"),
+    ],
+    environments=True,  # Enable environment-specific sections in YAML
+    merge_enabled=True,
+    load_dotenv=True,
 )
 
-# Include all settings files in order
-include("defaults.py", settings_file)
+# Load settings following AAP precedence (lowest to highest priority):
+# 1. settings_files (defaults.py, config/settings.yaml) - already loaded by factory
+# 2. Standard AAP settings from /etc/ansible-automation-platform/
+load_standard_settings_files(DYNACONF)
+# 3. Environment variables (METRICS_SERVICE_*) - highest priority
+load_envvars(DYNACONF)
+
+# Export Dynaconf settings back to Django settings module
+# In development mode, skip validation to allow defaults
+# In production/other modes, require all settings to be explicitly set
+is_development = "development" in DYNACONF.current_env.lower()
+export(__name__, DYNACONF, validation=not is_development)

--- a/metrics_service/settings/defaults.py
+++ b/metrics_service/settings/defaults.py
@@ -1,24 +1,33 @@
 """
 Base Django settings for metrics_service following AAP standards.
+
+These are default values that can be overridden by:
+1. config/settings.yaml (Dynaconf)
+2. Environment variables with METRICS_SERVICE_ prefix
+3. /etc/ansible-automation-platform/settings.yaml (production)
+
+All environment variable overrides are handled by Dynaconf in settings/__init__.py
 """
 
-import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("METRICS_SERVICE_SECRET_KEY", "dev-secret-key-change-in-production")
+# Override with METRICS_SERVICE_SECRET_KEY environment variable
+SECRET_KEY = "dev-secret-key-change-in-production"
 
 # SECURITY WARNING: don't run with debug turned on in production!
+# Override with METRICS_SERVICE_DEBUG environment variable
 DEBUG = True
 
 ALLOWED_HOSTS = ["*"]
 
 # Service identification for AAP
+# Override with METRICS_SERVICE_SERVICE_TYPE and METRICS_SERVICE_SERVICE_ID
 SERVICE_TYPE = "metrics-service"
-SERVICE_ID = os.environ.get("METRICS_SERVICE_ID", "generated-uuid")
+SERVICE_ID = "generated-uuid"
 
 # Application definition
 DJANGO_APPS = [
@@ -100,16 +109,17 @@ ASGI_APPLICATION = "metrics_service.asgi.application"
 
 # Database
 # PostgreSQL as default database
+# Override with METRICS_SERVICE_DATABASES__default__HOST, etc.
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "HOST": os.environ.get("METRICS_SERVICE_DB_HOST", "127.0.0.1"),
-        "PORT": os.environ.get("METRICS_SERVICE_DB_PORT", "55432"),
-        "USER": os.environ.get("METRICS_SERVICE_DB_USER", "metrics_service"),
-        "PASSWORD": os.environ.get("METRICS_SERVICE_DB_PASSWORD", "metrics_service"),
-        "NAME": os.environ.get("METRICS_SERVICE_DB_NAME", "metrics_service"),
+        "HOST": "127.0.0.1",
+        "PORT": "5432",
+        "USER": "metrics_service",
+        "PASSWORD": "metrics_service",
+        "NAME": "metrics_service",
         "OPTIONS": {
-            "sslmode": os.environ.get("METRICS_SERVICE_DB_SSLMODE", "prefer"),
+            "sslmode": "prefer",
         },
     }
 }
@@ -245,14 +255,15 @@ RESOURCE_SERVER: dict[str, str | bool | None] = {
 RESOURCE_SERVER_SYNC_ENABLED = False
 
 # Background Task Configuration (Dispatcherd)
-# Dispatcherd is always enabled in this service
+# Dispatcherd is always enabled in this service (can be disabled in tests)
+# Override with METRICS_SERVICE_DISPATCHERD_ENABLED environment variable
 DISPATCHERD_ENABLED = True
 
 # Feature Flags
+# Override with METRICS_SERVICE_FEATURE_FLAGS__ANONYMIZED_DATA_COLLECTION, etc.
 FEATURE_FLAGS = {
-    "DISPATCHERD_ENABLED": True,
-    "ANONYMIZED_DATA_COLLECTION": os.environ.get("METRICS_SERVICE_ANONYMIZED_DATA", "true").lower() == "true",
-    "METRICS_COLLECTION_ENABLED": os.environ.get("METRICS_SERVICE_METRICS_COLLECTION", "false").lower() == "true",
+    "ANONYMIZED_DATA_COLLECTION": True,
+    "METRICS_COLLECTION_ENABLED": False,
 }
 
 # Cache Configuration

--- a/metrics_service/settings/development.py
+++ b/metrics_service/settings/development.py
@@ -3,8 +3,6 @@ Development settings for metrics_service.
 These settings are optimized for local development with Docker.
 """
 
-import os
-
 from . import defaults
 
 # Import all settings from defaults module
@@ -74,16 +72,6 @@ CACHES = {
 
 # Email backend for development (console output)
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
-# Development-specific feature flags
-DISPATCHERD_ENABLED = True
-
-# Feature Flags
-FEATURE_FLAGS = {
-    "DISPATCHERD_ENABLED": True,
-    "ANONYMIZED_DATA_COLLECTION": os.environ.get("METRICS_SERVICE_ANONYMIZED_DATA", "true").lower() == "true",
-    "METRICS_COLLECTION_ENABLED": os.environ.get("METRICS_SERVICE_METRICS_COLLECTION", "false").lower() == "true",
-}
 
 
 # Static files serving in development

--- a/metrics_service/settings/test.py
+++ b/metrics_service/settings/test.py
@@ -160,6 +160,12 @@ LOGGING = {
 # Disable dispatcherd during tests to avoid background processes
 DISPATCHERD_ENABLED = False
 
+# Disable feature flags during tests
+FEATURE_FLAGS = {
+    "ANONYMIZED_DATA_COLLECTION": False,
+    "METRICS_COLLECTION_ENABLED": False,
+}
+
 # Test-specific apps - INSTALLED_APPS is already defined in defaults.py
 
 # Static files settings for tests

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -7,11 +7,11 @@ echo "🚀 Starting Metrics Service container..."
 echo "⏳ Waiting for database to be ready..."
 uv run python -c "
 import os, time, psycopg
-host = os.environ.get('METRICS_SERVICE_DB_HOST', 'postgres')
-port = os.environ.get('METRICS_SERVICE_DB_PORT', '5432')
-user = os.environ.get('METRICS_SERVICE_DB_USER', 'metrics_service')
-password = os.environ.get('METRICS_SERVICE_DB_PASSWORD', 'metrics_service')
-db = os.environ.get('METRICS_SERVICE_DB_NAME', 'metrics_service')
+host = os.environ.get('METRICS_SERVICE_DATABASES__default__HOST', 'postgres')
+port = os.environ.get('METRICS_SERVICE_DATABASES__default__PORT', '5432')
+user = os.environ.get('METRICS_SERVICE_DATABASES__default__USER', 'metrics_service')
+password = os.environ.get('METRICS_SERVICE_DATABASES__default__PASSWORD', 'metrics_service')
+db = os.environ.get('METRICS_SERVICE_DATABASES__default__NAME', 'metrics_service')
 
 max_attempts = 30
 attempt = 0

--- a/tests/unit/test_dynaconf_settings.py
+++ b/tests/unit/test_dynaconf_settings.py
@@ -1,0 +1,167 @@
+"""
+Tests for Dynaconf configuration and settings precedence.
+
+Following AAP Phase 1 standards from handbook proposal 0014-Django-Settings.
+Tests ensure proper precedence order and validator functionality.
+
+Note: These tests are marked as integration tests because they require
+the full dynaconf settings environment, not the test.py settings used by pytest.
+"""
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Set a valid SECRET_KEY for test module import
+# This allows Django settings to load without validation errors
+os.environ.setdefault("METRICS_SERVICE_SECRET_KEY", "your-secret-key-here-change-in-production")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "metrics_service.settings")
+
+# Mark all tests in this module as integration tests
+pytestmark = pytest.mark.integration
+
+
+class TestDynaconfPrecedence:
+    """Test settings precedence order following AAP standards.
+
+    Note: These tests verify the Dynaconf instance directly since Django
+    settings are cached and cannot be reliably reloaded in tests.
+    """
+
+    def test_dynaconf_can_read_env_vars(self):
+        """Test that Dynaconf can read environment variables via load_envvars."""
+        from metrics_service.settings import DYNACONF
+
+        # DYNACONF should have loaded the environment variable
+        assert DYNACONF.get("SECRET_KEY") == "your-secret-key-here-change-in-production"
+
+    def test_database_defaults_loaded(self):
+        """Test that database defaults from defaults.py are loaded."""
+        from django.conf import settings
+
+        # Database settings should be present
+        assert "default" in settings.DATABASES
+        assert settings.DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3"
+        assert settings.DATABASES["default"]["NAME"] is not None
+
+
+class TestDynaconfValidators:
+    """Test Dynaconf validators enforce security requirements.
+
+    Note: Since settings are already loaded, we test that validators
+    are properly configured rather than trying to trigger them.
+    """
+
+    def test_validators_are_registered(self):
+        """Test that validators are registered in DYNACONF."""
+        from metrics_service.settings import DYNACONF
+
+        validators_list = list(DYNACONF.validators)
+        assert len(validators_list) > 0
+
+    def test_secret_key_validators_configured(self):
+        """Test that SECRET_KEY validators are configured."""
+        from metrics_service.settings import DYNACONF
+
+        validators_list = list(DYNACONF.validators)
+        secret_key_validators = [v for v in validators_list if "SECRET_KEY" in v.names]
+
+        # Should have at least 2 validators for SECRET_KEY (one for each default value)
+        assert len(secret_key_validators) >= 2
+
+        # Check that validators check for default values
+        for validator in secret_key_validators:
+            # Validators should have 'ne' (not equal) operations for default keys
+            assert hasattr(validator, "operations")
+
+    def test_database_validators_configured(self):
+        """Test that database validators are configured."""
+        from metrics_service.settings import DYNACONF
+
+        validators_list = list(DYNACONF.validators)
+
+        # Should have validators for database settings
+        db_validators = [v for v in validators_list if any("DATABASES" in str(name) for name in v.names)]
+        assert len(db_validators) > 0
+
+    def test_settings_pass_validation(self):
+        """Test that current settings pass validation (since we're running)."""
+        from django.conf import settings
+
+        # If we got here, validation passed during settings load
+        assert settings.SECRET_KEY is not None
+        assert settings.DATABASES is not None
+
+
+class TestEnvironmentSwitching:
+    """Test environment-specific configuration sections."""
+
+    def test_current_environment_is_set(self):
+        """Test that current_env is properly set."""
+        from metrics_service.settings import DYNACONF
+
+        # Should have a current environment
+        assert DYNACONF.current_env is not None
+        assert isinstance(DYNACONF.current_env, str)
+
+    def test_is_development_mode_flag(self):
+        """Test that is_development_mode flag is set by factory."""
+        from metrics_service.settings import DYNACONF
+
+        # Factory should set is_development_mode based on environment
+        assert hasattr(DYNACONF, "is_development_mode")
+        assert isinstance(DYNACONF.is_development_mode, bool)
+
+
+class TestDynaconfFactory:
+    """Test that DAB factory pattern is properly configured."""
+
+    def test_factory_creates_dynaconf_instance(self):
+        """Test that factory creates a valid Dynaconf instance."""
+        from metrics_service.settings import DYNACONF
+
+        assert DYNACONF is not None
+        assert hasattr(DYNACONF, "validators")
+        assert hasattr(DYNACONF, "current_env")
+
+    def test_factory_registers_validators(self):
+        """Test that validators are registered with the Dynaconf instance."""
+        from metrics_service.settings import DYNACONF
+
+        # Check that validators were registered
+        # DYNACONF.validators is a ValidatorList which is iterable
+        validators_list = list(DYNACONF.validators)
+        assert len(validators_list) > 0
+
+        # Check for SECRET_KEY validators
+        secret_key_validators = [v for v in validators_list if "SECRET_KEY" in v.names]
+        assert len(secret_key_validators) > 0
+
+    def test_envvar_prefix_configured(self):
+        """Test that METRICS_SERVICE prefix is configured."""
+        from metrics_service.settings import DYNACONF
+
+        # Check that the prefix is configured by seeing if env vars work
+        # The fact that SECRET_KEY was loaded from METRICS_SERVICE_SECRET_KEY proves it works
+        assert DYNACONF.get("SECRET_KEY") is not None
+
+
+class TestSettingsFileLoading:
+    """Test that settings files are loaded in correct order."""
+
+    def test_defaults_py_loaded(self):
+        """Test that defaults.py values are loaded."""
+        with mock.patch.dict(os.environ, {"METRICS_SERVICE_SECRET_KEY": "valid-key"}):
+            import importlib
+
+            from metrics_service import settings as settings_module
+
+            importlib.reload(settings_module)
+
+            from django.conf import settings
+
+            # Values from defaults.py should be present
+            assert settings.SERVICE_TYPE == "metrics-service"
+            assert Path(settings_module.__file__).resolve().parent.parent.parent == settings.BASE_DIR


### PR DESCRIPTION
# [AAP-54496] Adds dynaconf configuration

## Description

This implements **Dynaconf** for configuration management. The implementation introduces a hierarchical configuration system where settings are loaded from `defaults.py`, `config/settings.yaml`, system-wide AAP files in `/etc/ansible-automation-platform/`, and finally environment variables with the `METRICS_SERVICE_` prefix (highest priority). It adds environment mode switching (development vs production) with validators that enforce security requirements in production (e.g., SECRET_KEY must be set via environment variable). The commit includes a new management command (`reload_config_command`) and REST API endpoints (`ConfigView`) for runtime configuration viewing, updating, and reloading. Comprehensive documentation was added in `metrics_service/settings/README.md` covering usage, troubleshooting, and migration guidance.

Limitations:

Configuration/Settings changes will not persist after an app restart.  That work will come in via a later PR.
Incomplete error handling.  We should provide better messaging within.


