### PR TITLE
Add awx database settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,13 @@ services:
       METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
       METRICS_SERVICE_DATABASES__default__NAME: metrics_service
       METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode: prefer
+      METRICS_SERVICE_DATABASES__awx__ENGINE: django.db.backends.postgresql
+      METRICS_SERVICE_DATABASES__awx__HOST: postgres
+      METRICS_SERVICE_DATABASES__awx__PORT: 5432
+      METRICS_SERVICE_DATABASES__awx__USER: metrics_service
+      METRICS_SERVICE_DATABASES__awx__PASSWORD: metrics_service
+      METRICS_SERVICE_DATABASES__awx__NAME: awx
+      METRICS_SERVICE_DATABASES__awx__OPTIONS__sslmode: prefer
       METRICS_SERVICE_ALLOWED_HOSTS: localhost,127.0.0.1,metrics-service,0.0.0.0
       METRICS_SERVICE_DEBUG: "true"
       METRICS_SERVICE_ANONYMIZED_DATA: "true"
@@ -74,6 +81,13 @@ services:
       METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
       METRICS_SERVICE_DATABASES__default__NAME: metrics_service
       METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode: prefer
+      METRICS_SERVICE_DATABASES__awx__ENGINE: django.db.backends.postgresql
+      METRICS_SERVICE_DATABASES__awx__HOST: postgres
+      METRICS_SERVICE_DATABASES__awx__PORT: 5432
+      METRICS_SERVICE_DATABASES__awx__USER: metrics_service
+      METRICS_SERVICE_DATABASES__awx__PASSWORD: metrics_service
+      METRICS_SERVICE_DATABASES__awx__NAME: awx
+      METRICS_SERVICE_DATABASES__awx__OPTIONS__sslmode: prefer
       DJANGO_SETTINGS_MODULE: metrics_service.settings.development
       DISPATCHERD_ENABLED: "true"
     networks:

--- a/metrics_service/settings/defaults.py
+++ b/metrics_service/settings/defaults.py
@@ -121,6 +121,19 @@ DATABASES = {
         "OPTIONS": {
             "sslmode": "prefer",
         },
+    },
+    # Mock AWX database for collector testing
+    # Override with METRICS_SERVICE_DATABASES__awx__HOST, etc.
+    "awx": {
+        "ENGINE": "django.db.backends.postgresql",
+        "HOST": "127.0.0.1",
+        "PORT": "5432",
+        "USER": "metrics_service",
+        "PASSWORD": "metrics_service",
+        "NAME": "awx",
+        "OPTIONS": {
+            "sslmode": "prefer",
+        },
     }
 }
 

--- a/metrics_service/settings/defaults.py
+++ b/metrics_service/settings/defaults.py
@@ -134,7 +134,7 @@ DATABASES = {
         "OPTIONS": {
             "sslmode": "prefer",
         },
-    }
+    },
 }
 
 # Password validation

--- a/test_awx_connection.py
+++ b/test_awx_connection.py
@@ -1,23 +1,36 @@
 #!/usr/bin/env python
 """Test AWX database connection"""
 
-import os
+import subprocess
 import sys
 
-import django
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "metrics_service.settings.development")
-django.setup()
-
-from django.db import connections  # noqa: E402
-
 try:
-    awx_conn = connections["awx"]
-    with awx_conn.cursor() as cursor:
-        cursor.execute("SELECT COUNT(*) FROM main_job")
-        count = cursor.fetchone()[0]
-        sys.stdout.write("✅ AWX database connection successful!\n")
-        sys.stdout.write(f"✅ Found {count} jobs in main_job table\n")
+    result = subprocess.run(
+        [
+            "docker", "exec", "metrics-service-postgres",
+            "psql", "-U", "metrics_service", "-d", "awx",
+            "-c", "SELECT COUNT(*) FROM main_job"
+        ],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+
+    # Parse the count from psql output
+    lines = result.stdout.strip().split('\n')
+    count_line = [l for l in lines if l.strip().isdigit()]
+    if count_line:
+        count = count_line[0].strip()
+        sys.stdout.write("AWX database connection successful!\n")
+        sys.stdout.write(f"Found {count} jobs in main_job table\n")
+    else:
+        sys.stdout.write("Could not parse job count\n")
+        sys.stdout.write(result.stdout)
+
+except subprocess.CalledProcessError as e:
+    sys.stderr.write(f"AWX database connection failed: {e}\n")
+    sys.stderr.write(e.stderr)
+    sys.exit(1)
 except Exception as e:
-    sys.stderr.write(f"❌ AWX database connection failed: {e}\n")
+    sys.stderr.write(f"Error: {e}\n")
     sys.exit(1)

--- a/test_awx_connection.py
+++ b/test_awx_connection.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""Test AWX database connection"""
+
+import os
+import sys
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "metrics_service.settings.development")
+django.setup()
+
+from django.db import connections  # noqa: E402
+
+try:
+    awx_conn = connections["awx"]
+    with awx_conn.cursor() as cursor:
+        cursor.execute("SELECT COUNT(*) FROM main_job")
+        count = cursor.fetchone()[0]
+        sys.stdout.write("✅ AWX database connection successful!\n")
+        sys.stdout.write(f"✅ Found {count} jobs in main_job table\n")
+except Exception as e:
+    sys.stderr.write(f"❌ AWX database connection failed: {e}\n")
+    sys.exit(1)

--- a/test_awx_connection.py
+++ b/test_awx_connection.py
@@ -6,19 +6,27 @@ import sys
 
 try:
     result = subprocess.run(
-        [
-            "docker", "exec", "metrics-service-postgres",
-            "psql", "-U", "metrics_service", "-d", "awx",
-            "-c", "SELECT COUNT(*) FROM main_job"
+        [  # noqa: S607
+            "docker",
+            "exec",
+            "metrics-service-postgres",
+            "psql",
+            "-U",
+            "metrics_service",
+            "-d",
+            "awx",
+            "-c",
+            "SELECT COUNT(*) FROM main_job",
         ],
         capture_output=True,
         text=True,
-        check=True
+        check=True,
+        shell=False,
     )
 
     # Parse the count from psql output
-    lines = result.stdout.strip().split('\n')
-    count_line = [l for l in lines if l.strip().isdigit()]
+    lines = result.stdout.strip().split("\n")
+    count_line = [line for line in lines if line.strip().isdigit()]
     if count_line:
         count = count_line[0].strip()
         sys.stdout.write("AWX database connection successful!\n")


### PR DESCRIPTION
# [AAP-54493] Simple script to verify the AWX database connection works
  and can query data from the mock AWX database.

## Description
  - Added `awx` database configuration to `DATABASES` in
  `defaults.py`
  - Added AWX database environment variables to
  `docker-compose.yml` for both `metrics-service` and `metrics-dispatcher` services
  - Added `test_awx_connection.py` script to verify connection
  - Follows existing Dynaconf pattern with
  `METRICS_SERVICE_` prefix

  ## Configuration
  The AWX database connection uses the same PostgreSQL server as the metrics_service database (see architecture in  PR [#38](https://github.com/ansible/metrics-service/pull/38)).

  Can be overridden using environment variables:
  - `METRICS_SERVICE_DATABASES__awx__HOST`
  - `METRICS_SERVICE_DATABASES__awx__PORT`
  - `METRICS_SERVICE_DATABASES__awx__USER`
  - `METRICS_SERVICE_DATABASES__awx__PASSWORD`
  - `METRICS_SERVICE_DATABASES__awx__NAME`

  ## Testing
  Once PR [#38](https://github.com/ansible/metrics-service/pull/38) is merged:
  ```bash
  docker-compose up -d
  python3.12 test_awx_connection.py

  Depends on: PR #38