### PR TITLE
Integrate metrics-utility collector with AWX database

### DIFF
--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -146,7 +146,7 @@ def collect_config_metrics(**kwargs) -> dict[str, Any]:
                 "task_type": "collect_config_metrics",
                 "config_data": config_data,
                 "collector_type": "config",
-                "database_used": db_name,
+                "parameters_used": {"database": db_name},
             },
         )
 

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 # Constants for repeated strings
 MSG_METRICS_UTILITY_NOT_AVAILABLE = "metrics-utility is not available"
 LABEL_METRICS_COLLECTION = "Metrics Collection"
-LABEL_DB_CONNECTION = "Database connection string (optional)"
+LABEL_DB_CONNECTION = "Database name from Django settings (default: 'awx')"
 LABEL_START_DATE = "Start date for collection (ISO format)"
 LABEL_END_DATE = "End date for collection (ISO format)"
 EXAMPLE_START_DATE = "2024-01-01T00:00:00Z"
@@ -64,7 +64,7 @@ def collect_anonymous_metrics(**kwargs) -> dict[str, Any]:
 
     Args:
         **kwargs: Task data containing collection parameters:
-            - db (str): Database connection string (optional)
+            - database (str): Database name from Django settings (default: 'awx')
             - since (str): Start date for collection (optional)
             - until (str): End date for collection (optional)
             - custom_params (dict): Additional custom parameters (optional)
@@ -79,13 +79,16 @@ def collect_anonymous_metrics(**kwargs) -> dict[str, Any]:
 
     try:
         # Get parameters from kwargs
-        db = kwargs.get("db")
+        from django.db import connections
+
+        db_name = kwargs.get("database", "awx")
         since = kwargs.get("since")
         until = kwargs.get("until")
         custom_params = kwargs.get("custom_params")
 
         # Create collector instance
-        collector = anonymous(db=db, since=since, until=until, custom_params=custom_params)
+        db_connection = connections[db_name]
+        collector = anonymous(db=db_connection, since=since, until=until, custom_params=custom_params)
 
         # Gather data
         metrics_data = collector.gather()
@@ -96,7 +99,12 @@ def collect_anonymous_metrics(**kwargs) -> dict[str, Any]:
                 "task_type": "collect_anonymous_metrics",
                 "metrics_data": metrics_data,
                 "collector_type": "anonymous",
-                "parameters_used": {"db": db, "since": since, "until": until, "custom_params": custom_params},
+                "parameters_used": {
+                    "database": db_name,
+                    "since": since,
+                    "until": until,
+                    "custom_params": custom_params,
+                },
             },
         )
 
@@ -166,7 +174,7 @@ def collect_job_host_summary(**kwargs) -> dict[str, Any]:
 
     Args:
         **kwargs: Task data containing collection parameters:
-            - db (str): Database connection string (optional)
+            - database (str): Database name from Django settings (default: 'awx')
             - since (str): Start date for collection (optional)
             - until (str): End date for collection (optional)
 
@@ -179,13 +187,16 @@ def collect_job_host_summary(**kwargs) -> dict[str, Any]:
     log_task_execution("collect_job_host_summary", "processing", "Collecting job host summary metrics")
 
     try:
+        from django.db import connections
+
         # Get parameters from kwargs
-        db = kwargs.get("db")
+        db_name = kwargs.get("database", "awx")
         since = kwargs.get("since")
         until = kwargs.get("until")
 
+        db_connection = connections[db_name]
         # Create collector instance
-        collector = job_host_summary(db=db, since=since, until=until)
+        collector = job_host_summary(db=db_connection, since=since, until=until)
 
         # Gather data
         summary_data = collector.gather()
@@ -196,7 +207,7 @@ def collect_job_host_summary(**kwargs) -> dict[str, Any]:
                 "task_type": "collect_job_host_summary",
                 "summary_data": summary_data,
                 "collector_type": "job_host_summary",
-                "parameters_used": {"db": db, "since": since, "until": until},
+                "parameters_used": {"database": db_name, "since": since, "until": until},
             },
         )
 
@@ -216,7 +227,7 @@ def collect_host_metrics(**kwargs) -> dict[str, Any]:
 
     Args:
         **kwargs: Task data containing collection parameters:
-            - db (str): Database connection string (optional)
+            - database (str): Database name from Django settings (default: 'awx')
             - since (str): Start date for collection (optional)
 
     Returns:
@@ -228,12 +239,15 @@ def collect_host_metrics(**kwargs) -> dict[str, Any]:
     log_task_execution("collect_host_metrics", "processing", "Collecting host metrics")
 
     try:
+        from django.db import connections
+
         # Get parameters from kwargs
-        db = kwargs.get("db")
+        db_name = kwargs.get("database", "awx")
         since = kwargs.get("since")
 
+        db_connection = connections[db_name]
         # Create collector instance
-        collector = host_metric(db=db, since=since)
+        collector = host_metric(db=db_connection, since=since)
 
         # Gather data
         host_data = collector.gather()
@@ -244,7 +258,7 @@ def collect_host_metrics(**kwargs) -> dict[str, Any]:
                 "task_type": "collect_host_metrics",
                 "host_data": host_data,
                 "collector_type": "host_metric",
-                "parameters_used": {"db": db, "since": since},
+                "parameters_used": {"database": db_name, "since": since},
             },
         )
 
@@ -264,7 +278,7 @@ def collect_all_metrics(**kwargs) -> dict[str, Any]:
 
     Args:
         **kwargs: Task data containing collection parameters:
-            - db (str): Database connection string (optional)
+            - database (str): Database name from Django settings (default: 'awx')
             - since (str): Start date for collection (optional)
             - until (str): End date for collection (optional)
             - collectors (list): List of specific collectors to run (optional)
@@ -278,8 +292,11 @@ def collect_all_metrics(**kwargs) -> dict[str, Any]:
     log_task_execution("collect_all_metrics", "processing", "Collecting all metrics")
 
     try:
+        from django.db import connections
+
         # Get parameters from kwargs
-        db = kwargs.get("db")
+        db_name = kwargs.get("database", "awx")
+        db_connection = connections[db_name]
         since = kwargs.get("since")
         until = kwargs.get("until")
         collectors_list = kwargs.get("collectors", ["anonymous", "config", "host_metric"])
@@ -290,13 +307,13 @@ def collect_all_metrics(**kwargs) -> dict[str, Any]:
         for collector_name in collectors_list:
             try:
                 if collector_name == "anonymous":
-                    collector_instance = anonymous(db=db, since=since, until=until)
+                    collector_instance = anonymous(db=db_connection, since=since, until=until)
                 elif collector_name == "config":
-                    collector_instance = config(db=db)
+                    collector_instance = config(db=db_connection)
                 elif collector_name == "job_host_summary":
-                    collector_instance = job_host_summary(db=db, since=since, until=until)
+                    collector_instance = job_host_summary(db=db_connection, since=since, until=until)
                 elif collector_name == "host_metric":
-                    collector_instance = host_metric(db=db, since=since)
+                    collector_instance = host_metric(db=db_connection, since=since)
                 else:
                     logger.warning(f"Unknown collector: {collector_name}")
                     continue
@@ -315,7 +332,7 @@ def collect_all_metrics(**kwargs) -> dict[str, Any]:
                 "task_type": "collect_all_metrics",
                 "all_results": all_results,
                 "collectors_run": collectors_list,
-                "parameters_used": {"db": db, "since": since, "until": until},
+                "parameters_used": {"database": db_name, "since": since, "until": until},
             },
         )
 
@@ -913,7 +930,7 @@ TASK_METADATA = {
     "collect_config_metrics": {
         "category": LABEL_METRICS_COLLECTION,
         "description": "Collect system configuration information and metadata",
-        "parameters": {"db": {"type": "string", "description": "Database connection string (optional)"}},
+        "parameters": {"db": {"type": "string", "description": "Database name from Django settings (default: 'awx')"}},
         "examples": [{"name": "Collect configuration", "data": {}}],
     },
     "collect_job_host_summary": {
@@ -945,7 +962,7 @@ TASK_METADATA = {
         "category": LABEL_METRICS_COLLECTION,
         "description": "Run multiple collectors in sequence to gather comprehensive metrics",
         "parameters": {
-            "db": {"type": "string", "description": LABEL_DB_CONNECTION},
+            "database": {"type": "string", "description": LABEL_DB_CONNECTION},
             "since": {"type": "string", "description": LABEL_START_DATE, "pattern": "datetime"},
             "until": {"type": "string", "description": LABEL_END_DATE, "pattern": "datetime"},
             "collectors": {

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -35,12 +35,7 @@ EXAMPLE_START_DATE = "2024-01-01T00:00:00Z"
 
 # Import metrics-utility collectors
 try:
-    from metrics_utility.library.collectors import (
-        anonymous,
-        config,
-        host_metric,
-        job_host_summary,
-    )
+    from metrics_utility.library.collectors import anonymous, config, host_metric, job_host_summary
 
     METRICS_UTILITY_AVAILABLE = True
 except ImportError as e:
@@ -117,11 +112,11 @@ def collect_config_metrics(**kwargs) -> dict[str, Any]:
     Collect configuration metrics using metrics-utility library.
 
     This task uses the config collector from metrics-utility to gather
-    system configuration information.
+    system configuration information from the AWX database.
 
     Args:
         **kwargs: Task data containing collection parameters:
-            - db (str): Database connection string (optional)
+            - database (str): Database name from Django settings (default: 'awx')
 
     Returns:
         dict: Task result with collected configuration data
@@ -132,13 +127,17 @@ def collect_config_metrics(**kwargs) -> dict[str, Any]:
     log_task_execution("collect_config_metrics", "processing", "Collecting configuration metrics")
 
     try:
-        # Get parameters from kwargs
-        db = kwargs.get("db")
+        from django.db import connections
 
-        # Create collector instance
-        collector = config(db=db)
+        # Get db name from kwargs, default to 'awx' (defined in defaults.py)
+        db_name = kwargs.get("database", "awx")
 
-        # Gather data
+        # Get the Django db connection for the AWX database
+        db_connection = connections[db_name]
+
+        # Create collector instance with Django database connection
+        collector = config(db=db_connection)
+
         config_data = collector.gather()
 
         return create_task_result(
@@ -147,7 +146,7 @@ def collect_config_metrics(**kwargs) -> dict[str, Any]:
                 "task_type": "collect_config_metrics",
                 "config_data": config_data,
                 "collector_type": "config",
-                "parameters_used": {"db": db},
+                "database_used": db_name,
             },
         )
 

--- a/metrics_service/settings/defaults.py
+++ b/metrics_service/settings/defaults.py
@@ -121,7 +121,20 @@ DATABASES = {
         "OPTIONS": {
             "sslmode": "prefer",
         },
-    }
+    },
+    # AWX database for metrics-utility collector integration
+    # Override with METRICS_SERVICE_DATABASES__awx__HOST, etc.
+    "awx": {
+        "ENGINE": "django.db.backends.postgresql",
+        "HOST": "127.0.0.1",
+        "PORT": "5432",
+        "USER": "metrics_service",
+        "PASSWORD": "metrics_service",
+        "NAME": "awx",
+        "OPTIONS": {
+            "sslmode": "prefer",
+        },
+    },
 }
 
 # Password validation

--- a/tests/unit/tasks/test_collector_integration.py
+++ b/tests/unit/tasks/test_collector_integration.py
@@ -1,0 +1,101 @@
+"""
+Test collector integration with AWX database.
+
+This module tests that collectors from metrics-utility can properly
+connect to and query the AWX database configured in Django settings.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import TestCase
+
+from apps.tasks.tasks import collect_config_metrics
+
+
+@pytest.mark.unit
+class TestCollectorDatabaseIntegration(TestCase):
+    """Test that collectors properly use Django database connections."""
+
+    @patch("apps.tasks.tasks.config")
+    @patch("django.db.connections.__getitem__")
+    def test_collect_config_metrics_uses_django_connection(self, mock_connections, mock_config_collector):
+        """Test that collect_config_metrics uses Django database connection."""
+        # Setup mock database connection
+        mock_db_connection = MagicMock()
+        mock_connections.return_value = mock_db_connection
+
+        # Setup mock collector return value
+        mock_collector_instance = MagicMock()
+        mock_collector_instance.gather.return_value = {
+            "controller_version": "4.5.0",
+            "install_uuid": "test-uuid",
+        }
+        mock_config_collector.return_value = mock_collector_instance
+
+        # Call the task function
+        result = collect_config_metrics(database="awx")
+
+        # Verify Django connections was accessed with 'awx'
+        mock_connections.assert_called_once_with("awx")
+
+        # Verify collector was called with the Django connection
+        mock_config_collector.assert_called_once_with(db=mock_db_connection)
+
+        # Verify collector.gather() was called
+        mock_collector_instance.gather.assert_called_once()
+
+        # Verify result is successful
+        assert result["status"] == "success"
+        assert result["data"]["collector_type"] == "config"
+        assert result["data"]["database_used"] == "awx"
+        assert "config_data" in result["data"]
+
+    @patch("apps.tasks.tasks.config")
+    @patch("django.db.connections.__getitem__")
+    def test_collect_config_metrics_defaults_to_awx_database(self, mock_connections, mock_config_collector):
+        """Test that collect_config_metrics defaults to 'awx' database."""
+        # Setup mocks
+        mock_db_connection = MagicMock()
+        mock_connections.return_value = mock_db_connection
+
+        mock_collector_instance = MagicMock()
+        mock_collector_instance.gather.return_value = {}
+        mock_config_collector.return_value = mock_collector_instance
+
+        # Call without specifying database
+        result = collect_config_metrics()
+
+        # Verify 'awx' was used as default
+        mock_connections.assert_called_once_with("awx")
+        assert result["data"]["database_used"] == "awx"
+
+    @patch("apps.tasks.tasks.config")
+    @patch("django.db.connections.__getitem__")
+    def test_collect_config_metrics_handles_collector_error(self, mock_connections, mock_config_collector):
+        """Test that collect_config_metrics handles errors from collector."""
+        # Setup mock to raise an exception
+        mock_db_connection = MagicMock()
+        mock_connections.return_value = mock_db_connection
+
+        mock_collector_instance = MagicMock()
+        mock_collector_instance.gather.side_effect = Exception("Database connection failed")
+        mock_config_collector.return_value = mock_collector_instance
+
+        # Call the task function
+        result = collect_config_metrics()
+
+        # Verify error is handled
+        assert result["status"] == "error"
+        assert "Collection failed" in result["error"]
+        assert "Database connection failed" in result["error"]
+
+    @patch("apps.tasks.tasks.METRICS_UTILITY_AVAILABLE", False)
+    def test_collect_config_metrics_handles_missing_metrics_utility(self):
+        """Test that collect_config_metrics handles missing metrics-utility."""
+        # Call the task function
+        result = collect_config_metrics()
+
+        # Verify appropriate error is returned
+        assert result["status"] == "error"
+        assert "metrics-utility is not available" in result["error"]

--- a/tests/unit/tasks/test_collector_integration.py
+++ b/tests/unit/tasks/test_collector_integration.py
@@ -8,22 +8,21 @@ connect to and query the AWX database configured in Django settings.
 from unittest.mock import MagicMock, patch
 
 import pytest
-from django.test import TestCase
 
 from apps.tasks.tasks import collect_config_metrics
 
 
 @pytest.mark.unit
-class TestCollectorDatabaseIntegration(TestCase):
+class TestCollectorDatabaseIntegration:
     """Test that collectors properly use Django database connections."""
 
     @patch("apps.tasks.tasks.config")
-    @patch("django.db.connections.__getitem__")
+    @patch("django.db.connections")
     def test_collect_config_metrics_uses_django_connection(self, mock_connections, mock_config_collector):
         """Test that collect_config_metrics uses Django database connection."""
         # Setup mock database connection
         mock_db_connection = MagicMock()
-        mock_connections.return_value = mock_db_connection
+        mock_connections.__getitem__.return_value = mock_db_connection
 
         # Setup mock collector return value
         mock_collector_instance = MagicMock()
@@ -37,7 +36,7 @@ class TestCollectorDatabaseIntegration(TestCase):
         result = collect_config_metrics(database="awx")
 
         # Verify Django connections was accessed with 'awx'
-        mock_connections.assert_called_once_with("awx")
+        mock_connections.__getitem__.assert_called_once_with("awx")
 
         # Verify collector was called with the Django connection
         mock_config_collector.assert_called_once_with(db=mock_db_connection)
@@ -47,17 +46,17 @@ class TestCollectorDatabaseIntegration(TestCase):
 
         # Verify result is successful
         assert result["status"] == "success"
-        assert result["data"]["collector_type"] == "config"
-        assert result["data"]["database_used"] == "awx"
-        assert "config_data" in result["data"]
+        assert result["collector_type"] == "config"
+        assert result["parameters_used"]["database"] == "awx"
+        assert "config_data" in result
 
     @patch("apps.tasks.tasks.config")
-    @patch("django.db.connections.__getitem__")
+    @patch("django.db.connections")
     def test_collect_config_metrics_defaults_to_awx_database(self, mock_connections, mock_config_collector):
         """Test that collect_config_metrics defaults to 'awx' database."""
         # Setup mocks
         mock_db_connection = MagicMock()
-        mock_connections.return_value = mock_db_connection
+        mock_connections.__getitem__.return_value = mock_db_connection
 
         mock_collector_instance = MagicMock()
         mock_collector_instance.gather.return_value = {}
@@ -67,16 +66,16 @@ class TestCollectorDatabaseIntegration(TestCase):
         result = collect_config_metrics()
 
         # Verify 'awx' was used as default
-        mock_connections.assert_called_once_with("awx")
-        assert result["data"]["database_used"] == "awx"
+        mock_connections.__getitem__.assert_called_once_with("awx")
+        assert result["parameters_used"]["database"] == "awx"
 
     @patch("apps.tasks.tasks.config")
-    @patch("django.db.connections.__getitem__")
+    @patch("django.db.connections")
     def test_collect_config_metrics_handles_collector_error(self, mock_connections, mock_config_collector):
         """Test that collect_config_metrics handles errors from collector."""
         # Setup mock to raise an exception
         mock_db_connection = MagicMock()
-        mock_connections.return_value = mock_db_connection
+        mock_connections.__getitem__.return_value = mock_db_connection
 
         mock_collector_instance = MagicMock()
         mock_collector_instance.gather.side_effect = Exception("Database connection failed")

--- a/tests/unit/tasks/test_tasks_comprehensive.py
+++ b/tests/unit/tasks/test_tasks_comprehensive.py
@@ -309,12 +309,8 @@ class TestTaskFunctionsRegistry(TestCase):
 
 
 @pytest.mark.unit
-class TestEdgeCasesAndErrorHandling(TestCase):
+class TestEdgeCasesAndErrorHandling:
     """Test edge cases and error handling scenarios."""
-
-    def setUp(self):
-        """Set up test environment."""
-        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass123")
 
     def test_task_execution_with_invalid_data(self):
         """Test task execution with invalid task data."""
@@ -328,12 +324,31 @@ class TestEdgeCasesAndErrorHandling(TestCase):
         result = tasks.process_user_data(user_id=None)
         assert "error" in result["status"]
 
-    def test_metrics_collection_edge_cases(self):
-        """Test metrics collection edge cases."""
-        # Test with empty parameters
+    @patch("apps.tasks.tasks.anonymous")
+    @patch("django.db.connections")
+    def test_metrics_collection_edge_cases(self, mock_connections, mock_collector):
+        """Test metrics collection works with Django database connections."""
+        # Setup mock database connection
+        mock_db_connection = object()
+        mock_connections.__getitem__.return_value = mock_db_connection
+
+        # Setup mock collector with proper gather method
+        from unittest.mock import MagicMock
+
+        mock_collector_instance = MagicMock()
+        mock_collector_instance.gather.return_value = {}
+        mock_collector.return_value = mock_collector_instance
+
+        # Call the function
         result = tasks.collect_anonymous_metrics()
-        assert isinstance(result, dict)
-        assert "success" in result["status"]
+
+        # Verify it worked
+        assert result["status"] == "success"
+        assert result["collector_type"] == "anonymous"
+
+        # Verify it used Django connections
+        mock_connections.__getitem__.assert_called_once_with("awx")
+        mock_collector.assert_called_once_with(db=mock_db_connection, since=None, until=None, custom_params=None)
 
     @patch("apps.tasks.tasks.logger")
     def test_error_logging(self, mock_logger):


### PR DESCRIPTION
# [AAP-54493] Integrate metrics-utility collector with AWX database

## Description
Implements collector integration for AAP-54493 by connecting the task system to metrics-utility collectors using Django database connections.

This PR enables `collect_config_metrics` and other collector tasks to query an AWX database configured in Django settings.

## Changes

### 1. Database Configuration (`metrics_service/settings/defaults.py`)
- Added AWX database configuration to `DATABASES` dictionary
- Allows connection to AWX database for metrics collection
- Can be overridden with environment variables (`METRICS_SERVICE_DATABASES__awx__HOST`, etc.)

### 2. Task Integration (`apps/tasks/tasks.py`)
- Updated `collect_config_metrics` to use Django's `connections` API
- Task now retrieves database connection object from Django settings
- Passes Django connection to metrics-utility collectors
- Parameters changed:
  - `db` (string) → `database` (database name, defaults to 'awx')
  - Returns `database_used` instead of connection object

### 3. Unit Tests (`tests/unit/tasks/test_collector_integration.py`)
- Tests Django database connection access
- Verifies connection is passed correctly to collectors
- Tests default behavior (uses 'awx' database)
- Tests error handling

## How It Works

```python
# In collect_config_metrics:
from django.db import connections

# Get database name (defaults to 'awx')
db_name = kwargs.get("database", "awx")

# Get Django database connection
db_connection = connections[db_name]

# Pass to metrics-utility collector
collector = config(db=db_connection)
config_data = collector.gather()
```

The collector can now execute SQL queries via `db_connection.cursor()` against the AWX database.

## Testing

Run unit tests:
```bash
pytest tests/unit/tasks/test_tasks_comprehensive.py -v
```
