### PR TITLE
[AAP-55026] Add Prometheus metrics and health  check endpoints

### DIFF
--- a/apps/health/urls.py
+++ b/apps/health/urls.py
@@ -5,7 +5,10 @@ Health and system URLs.
 from django.contrib import admin
 from django.urls import path
 
+from . import views
+
 urlpatterns = [
     # Admin interface
     path("admin/", admin.site.urls),
+    path("health", views.health_check, name="health_check"),
 ]

--- a/apps/health/views.py
+++ b/apps/health/views.py
@@ -1,6 +1,5 @@
 from django.db import connection
 from django.http import JsonResponse
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 
 """
@@ -9,7 +8,6 @@ Health check views for Kubernetes monitoring.
 
 
 @require_GET
-@csrf_exempt  # Safe: Read-only endpoint for Kubernetes liveness/readiness probes, secured at network/ingress level
 def health_check(request):
     try:
         connection.ensure_connection()

--- a/apps/health/views.py
+++ b/apps/health/views.py
@@ -1,0 +1,19 @@
+from django.db import connection
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_GET
+
+"""
+  Health check views for Kubernetes monitoring.
+"""
+
+
+@require_GET
+@csrf_exempt
+def health_check(request):
+    try:
+        connection.ensure_connection()
+        return JsonResponse({"status": "ok"}, status=200)
+
+    except Exception as e:
+        return JsonResponse({"status": "error", "details": {"database": str(e)}}, status=503)

--- a/apps/health/views.py
+++ b/apps/health/views.py
@@ -4,12 +4,12 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET
 
 """
-  Health check views for Kubernetes monitoring.
+Health check views for Kubernetes monitoring.
 """
 
 
 @require_GET
-@csrf_exempt
+@csrf_exempt  # Safe: Read-only endpoint for Kubernetes liveness/readiness probes, secured at network/ingress level
 def health_check(request):
     try:
         connection.ensure_connection()

--- a/metrics_service/settings/defaults.py
+++ b/metrics_service/settings/defaults.py
@@ -31,6 +31,7 @@ SERVICE_ID = "generated-uuid"
 
 # Application definition
 DJANGO_APPS = [
+    "django_prometheus",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -73,6 +74,7 @@ LOCAL_APPS = [
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + DAB_APPS + LOCAL_APPS
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -84,6 +86,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "ansible_base.lib.middleware.logging.LogRequestMiddleware",
     "ansible_base.lib.middleware.logging.LogTracebackMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "metrics_service.urls"

--- a/metrics_service/settings/test.py
+++ b/metrics_service/settings/test.py
@@ -101,7 +101,7 @@ ROOT_URLCONF = "metrics_service.test_urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/metrics_service/test_urls.py
+++ b/metrics_service/test_urls.py
@@ -6,10 +6,16 @@ from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
+    # Core app (authentication, etc.)
+    path("", include("apps.core.urls")),
+    # Health and system endpoints
+    path("", include("apps.health.urls")),
     # Admin interface
     path("admin/", admin.site.urls),
     # Dashboard interface
     path("dashboard/", include("apps.dashboard.urls")),
     # API endpoints
     path("api/", include("apps.api.urls")),
+    # Prometheus metrics
+    path("", include("django_prometheus.urls")),
 ]

--- a/metrics_service/urls.py
+++ b/metrics_service/urls.py
@@ -2,13 +2,8 @@
 URL configuration for metrics_service project.
 """
 
-from ansible_base.lib.dynamic_config.dynamic_urls import (
-    api_version_urls,
-    root_urls,
-)
-from ansible_base.resource_registry.urls import (
-    urlpatterns as resource_api_urls,
-)
+from ansible_base.lib.dynamic_config.dynamic_urls import api_version_urls, root_urls
+from ansible_base.resource_registry.urls import urlpatterns as resource_api_urls
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView
 
@@ -28,4 +23,6 @@ urlpatterns = [
     path("api/v1/", include(api_version_urls)),  # General DAB v1 endpoints
     # Root URLs
     path("", include(root_urls)),
+    # Prometheus urls
+    path("", include("django_prometheus.urls")),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,7 @@ dynamic = ["version"]
 dependencies = [
     "Django==5.2.7",
     "djangorestframework>=3.15",
-    "django-ansible-base[jwt_consumer,api_documentation,rbac,rest_filters]",
-    "django-prometheus>=2.3.1",
+    "django-ansible-base[jwt_consumer,api_documentation,rbac,rest_filters]==2025.10.20",
     "django-split-settings>=1.2",
     "drf-spectacular>=0.26.5",
     "django-cors-headers>=4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dynamic = ["version"]
 dependencies = [
     "Django==5.2.7",
     "djangorestframework>=3.15",
-    "django-ansible-base[jwt_consumer,api_documentation,rbac,rest_filters]==2025.10.20",
+    "django-ansible-base[jwt_consumer,api_documentation,rbac,rest_filters]",
+    "django-prometheus>=2.3.1",
     "django-split-settings>=1.2",
     "drf-spectacular>=0.26.5",
     "django-cors-headers>=4.0",
@@ -283,4 +284,4 @@ exclude_lines = [
     "raise NotImplementedError",
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
-] 
+]

--- a/tests/integration/test_urls_integration.py
+++ b/tests/integration/test_urls_integration.py
@@ -221,8 +221,8 @@ class TestAuthenticationURLs(TestCase):
 
     def test_logout_url(self):
         """Test logout URL functionality."""
-        # Test logout URL
-        response = self.client.get("/logout/")
+        # Test logout URL - LogoutView requires POST by default
+        response = self.client.post("/logout/")
         assert response.status_code in [200, 302, 404]
 
     def test_authentication_redirects(self):

--- a/tests/unit/general/test_health_metrics.py
+++ b/tests/unit/general/test_health_metrics.py
@@ -29,7 +29,7 @@ class TestHealthEndpoint:
             response = client.get("/health")
             assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
-    def test_health_check_works_without_authentication(self, client):
+    def test_health_check_works_without_authentication(self, client, db):
         """Test that health endpoint doesn't require authentication."""
         response = client.get("/health")
         assert response.json() == {"status": "ok"}

--- a/tests/unit/general/test_health_metrics.py
+++ b/tests/unit/general/test_health_metrics.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for health check and metrics endpoints.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from rest_framework import status
+
+
+@pytest.mark.unit
+class TestHealthEndpoint:
+    """Test cases for /health endpoint."""
+
+    def test_health_check_returns_200_when_database_is_healthy(self, client, db):
+        """Test that health endpoint returns 200 when database is accessible."""
+        response = client.get("/health")
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_health_check_returns_correct_json_structure(self, client, db):
+        """Test that health endpoint returns {"status": "ok"} when healthy."""
+        response = client.get("/health")
+        assert response.json() == {"status": "ok"}
+
+    def test_health_check_returns_503_when_database_fails(self, client, db):
+        """Test that health endpoint returns 503 when database connection fails."""
+
+        with patch("django.db.connection.ensure_connection", side_effect=Exception("DB Error")):
+            response = client.get("/health")
+            assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+    def test_health_check_works_without_authentication(self, client):
+        """Test that health endpoint doesn't require authentication."""
+        response = client.get("/health")
+        assert response.json() == {"status": "ok"}
+        assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.unit
+class TestMetricsEndpoint:
+    """Test cases for /metrics endpoint."""
+
+    def test_metrics_endpoint_returns_200(self, client, db):
+        """Test that metrics endpoint returns 200."""
+        response = client.get("/metrics")
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_metrics_endpoint_returns_prometheus_format(self, client, db):
+        """Test that metrics endpoint returns text/plain content type."""
+        response = client.get("/metrics")
+        assert response.status_code == status.HTTP_200_OK
+        assert "text/plain" in response["Content-Type"]
+
+    def test_metrics_endpoint_contains_django_metrics(self, client, db):
+        """Test that metrics endpoint contains Django metrics."""
+        # TODO: Your code here!
+        # Hint: Use response.content.decode() to get the text
+        # Check that it contains strings like "django_" or "python_"
+        # Example: assert 'django_http_requests_total' in response.content.decode()
+        response = client.get("/metrics")
+        assert "django_" in response.content.decode()
+
+    def test_metrics_endpoint_works_without_authentication(self, client):
+        """Test that metrics endpoint doesn't require authentication."""
+        response = client.get("/metrics")
+        assert response.status_code == status.HTTP_200_OK
+        assert "django_" in response.content.decode()

--- a/tests/unit/general/test_main_urls.py
+++ b/tests/unit/general/test_main_urls.py
@@ -45,6 +45,7 @@ class TestMainURLsFileContent(TestCase):
         assert 'path("api/v1/", include(resource_api_urls))' in content
         assert 'path("api/v1/", include(api_version_urls))' in content
         assert 'path("", include(root_urls))' in content
+        assert 'path("", include("django_prometheus.urls"))' in content
 
     def test_urls_file_docstring(self):
         """Test that the main urls.py file has proper docstring."""
@@ -65,7 +66,7 @@ class TestMainURLsFileContent(TestCase):
             lines = f.readlines()
 
         # Test that the file has expected number of lines
-        assert len(lines) >= 30  # Should have at least 30 lines
+        assert len(lines) >= 25  # Should have at least 25 lines
 
         # Test that the file has proper indentation
         urlpatterns_line = None

--- a/uv.lock
+++ b/uv.lock
@@ -864,7 +864,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=1.3.0" },
     { name = "dispatcherd", specifier = ">=2025.5.21" },
     { name = "django", specifier = "==5.2.7" },
-    { name = "django-ansible-base", extras = ["api-documentation", "jwt-consumer", "rbac", "rest-filters"], specifier = "==2025.10.20" },
+    { name = "django-ansible-base", extras = ["api-documentation", "jwt-consumer", "rbac", "rest-filters"] },
     { name = "django-auth-ldap", marker = "extra == 'ldap'", specifier = ">=5.2.0" },
     { name = "django-cors-headers", specifier = ">=4.0" },
     { name = "django-debug-toolbar", marker = "extra == 'dev'", specifier = ">=4.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -864,7 +864,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=1.3.0" },
     { name = "dispatcherd", specifier = ">=2025.5.21" },
     { name = "django", specifier = "==5.2.7" },
-    { name = "django-ansible-base", extras = ["api-documentation", "jwt-consumer", "rbac", "rest-filters"] },
+    { name = "django-ansible-base", extras = ["api-documentation", "jwt-consumer", "rbac", "rest-filters"], specifier = "==2025.10.20" },
     { name = "django-auth-ldap", marker = "extra == 'ldap'", specifier = ">=5.2.0" },
     { name = "django-cors-headers", specifier = ">=4.0" },
     { name = "django-debug-toolbar", marker = "extra == 'dev'", specifier = ">=4.2" },


### PR DESCRIPTION
# Add Prometheus metrics and health check endpoints (AAP-55026)

## Description:
Adds Prometheus metrics endpoint and health check endpoint to the metrics-service application for monitoring and observability in Kubernetes deployments.

### New Endpoints

  - **`/metrics`** - Exposes Prometheus-compatible metrics in
  text format
    - Provides Django application metrics (HTTP requests, database queries, cache operations)
    - No authentication required (secured at network/ingress
  level)
    - Content-Type: `text/plain; version=0.0.4`

  - **`/health`** - Health check endpoint for Kubernetes probes
    - Returns HTTP 200 with `{"status": "ok"}` when healthy
    - Returns HTTP 503 with error details when database is unreachable
    - No authentication required

  ### Implementation Details

  **Dependencies:**
  - Added`django-prometheus>=2.3.1` to pyproject.toml

  **Configuration:**
  - Added `django_prometheus` to`INSTALLED_APPS` (first position for accurate metrics)
  - Added`PrometheusBeforeMiddleware` and `PrometheusAfterMiddleware` to capture request metrics
  - Configured `/metrics` URL endpoint via`django_prometheus.urls`

  **Health Check:**
  - Created `apps/health/views.py`with database connectivity check
  - Configured `/health` URL in`apps/health/urls.py`
  - Uses`connection.ensure_connection()` to verify database availability

  **Testing:**
  - Added comprehensive unit tests `tests/unit/general/test_health_metrics.py`
  - Tests cover success cases, failure cases, and authentication
   bypass
  - Includes mocked database failure scenarios

  ## Acceptance Criteria Met

  - ✅ AC1: `/metrics` endpoint is
  available
  - ✅ AC2: `/metrics` exposes
  default Django metrics (request
  latency, DB connections, cache
  hits/misses)
  - ✅ AC3: `/health` endpoint is
  available
  - ✅ AC4: `/health` returns HTTP
  200 when application and database
   are accessible
  - ✅ AC5: `/health` returns HTTP
  503 when critical dependency
  check fails
  - ✅ AC6: Both endpoints do not
  require authentication

  ## Testing

  ### Manual Testing

  ```bash
  # Start the service
  python manage.py metrics_service
  run

  # Test health endpoint
  curl -i http://localhost:8000/health
  # Expected: HTTP 200, {"status":
  "ok"}

  # Test metrics endpoint
  curl http://localhost:8000/metrics
  # Expected: HTTP 200, Prometheus text format with django_ metrics

  Automated Testing

  pytest tests/unit/general/test_health_metrics.py -v

  Notes
  - Marked as demo-worthy in JIRA ticket

  Related Links

  - JIRA: https://issues.redhat.com/browse/AAP-55026
  - django-prometheus docs: https://pypi.org/project/django-prometheus/

  ---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expose `/metrics` via django-prometheus and a DB-backed `/health` endpoint; wire URLs/middleware, add dependency, and comprehensive tests.
> 
> - **Endpoints**:
>   - Add `/health` in `apps/health/views.py` with DB connectivity check; route in `apps/health/urls.py` and included in `metrics_service/urls.py` and `metrics_service/test_urls.py`.
>   - Expose Prometheus `/metrics` by including `django_prometheus.urls` in root/test URLs.
> - **Settings**:
>   - Add `django_prometheus` to `INSTALLED_APPS` and insert `PrometheusBeforeMiddleware`/`PrometheusAfterMiddleware` in `MIDDLEWARE` (`metrics_service/settings/defaults.py`).
>   - Point test `TEMPLATES['DIRS']` to `BASE_DIR / "templates"`.
> - **Dependencies**:
>   - Add `django-prometheus>=2.3.1`; unpin `django-ansible-base` version in `pyproject.toml`.
> - **Tests**:
>   - New unit tests for `/health` and `/metrics` in `tests/unit/general/test_health_metrics.py`.
>   - Update URL-related tests to assert new inclusions and adjust logout to POST.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62cc20d944adefb265696284028ddac52e88337c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->