### PR TITLE
Update dependencies to Django 5.2.7 and related packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311:latest
+FROM registry.access.redhat.com/ubi9/python-312:latest
 
 # Set working directory
 WORKDIR /app

--- a/apps/core/migrations/0010_remove_setting_source.py
+++ b/apps/core/migrations/0010_remove_setting_source.py
@@ -16,3 +16,4 @@ class Migration(migrations.Migration):
         ),
     ]
 
+

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -35,7 +35,19 @@ EXAMPLE_START_DATE = "2024-01-01T00:00:00Z"
 
 # Import metrics-utility collectors
 try:
-    from metrics_utility.library.collectors import anonymous, config, host_metric, job_host_summary
+    # TODO The AS is just a filler till this is corrected with a later PR
+    from metrics_utility.library.collectors.controller import (
+        config,
+    )
+    from metrics_utility.library.collectors.controller import (
+        job_host_summary as anonymous,
+    )
+    from metrics_utility.library.collectors.controller import (
+        main_host as job_host_summary,
+    )
+    from metrics_utility.library.collectors.controller import (
+        main_jobevent as host_metric,
+    )
 
     METRICS_UTILITY_AVAILABLE = True
 except ImportError as e:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -63,9 +63,9 @@ distlib==0.4.0 \
     --hash=sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16 \
     --hash=sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d
     # via virtualenv
-django==4.2.21 \
-    --hash=sha256:1d658c7bf5d31c7d0cac1cab58bc1f822df89255080fec81909256c30e6180b3 \
-    --hash=sha256:b54ac28d6aa964fc7c2f7335138a54d78980232011e0cd2231d04eed393dcb0d
+django==5.2.7 \
+    --hash=sha256:59a13a6515f787dec9d97a0438cd2efac78c8aca1c80025244b0fe507fe0754b \
+    --hash=sha256:e0f6f12e2551b1716a95a63a1366ca91bbcd7be059862c1b18f989b1da356cdd
     # via
     #   django-debug-toolbar
     #   django-stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,7 +261,7 @@ markers = [
     "slow: Slow running tests",
 ]
 filterwarnings = [
-    "ignore::django.utils.deprecation.RemovedInDjango50Warning",
+    "ignore::django.utils.deprecation.RemovedInDjango60Warning",
     "ignore::DeprecationWarning",
     "ignore::pytest.PytestUnraisableExceptionWarning",
     "ignore:Overriding setting DATABASES:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "Django>=5.2.7",
+    "Django==5.2.7",
     "djangorestframework>=3.15",
     "django-ansible-base[jwt_consumer,api_documentation,rbac,rest_filters]==2025.10.20",
     "django-split-settings>=1.2",
@@ -112,7 +112,7 @@ dev-dependencies = [
 
 [tool.black]
 line-length = 120
-target-version = ['py310']
+target-version = ['py312']
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -131,7 +131,7 @@ extend-exclude = '''
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py312"
 exclude = [
     ".bzr",
     ".direnv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ known_first_party = ["metrics_service", "apps"]
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "DJANGO", "FIRSTPARTY", "LOCALFOLDER"]
 
 [tool.mypy]
-python = "3.11"
+python = "3.12"
 plugins = ["mypy_django_plugin.main", "mypy_drf_plugin.main"]
 warn_return_any = true
 warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,20 +4,17 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "metrics-service"
-description = "AAP Service Template following modern standards"
+description = "AAP Metrics Service"
 readme = "README.md"
 requires-python = "==3.12.*"
 license = "MIT"
 authors = [
     {name = "AAP Emerging Services", email = "aap-emerging-services@redhat.com"},
 ]
-keywords = ["ansible", "automation", "platform", "service"]
+keywords = ["ansible", "metrics", "service"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
     "Framework :: Django :: 5.2.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "metrics-service"
 description = "AAP Service Template following modern standards"
 readme = "README.md"
-requires-python = "==3.12"
+requires-python = "==3.12.*"
 license = "MIT"
 authors = [
     {name = "AAP Emerging Services", email = "aap-emerging-services@redhat.com"},
@@ -20,16 +20,16 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.2.7",
 ]
 dynamic = ["version"]
 
 dependencies = [
-    "Django>=4.2,<5.0",
+    "Django>=5.2.7",
     "djangorestframework>=3.15",
-    "django-ansible-base[jwt_consumer,api_documentation,rbac,rest_filters]",
+    "django-ansible-base[jwt_consumer,api_documentation,rbac,rest_filters]==2025.10.20",
     "django-split-settings>=1.2",
-    "drf-spectacular>=0.27",
+    "drf-spectacular>=0.26.5",
     "django-cors-headers>=4.0",
     "psycopg[binary]>=3.1",
     "psycopg2-binary>=2.9.0",  # Required for dispatcherd PostgreSQL LISTEN/NOTIFY
@@ -41,7 +41,8 @@ dependencies = [
     "croniter>=1.3.0",
     "uv>=0.8.22",
     "apscheduler>=3.10.0",
-    "metrics-utility @ git+https://github.com/ansible/metrics-utility.git",
+    "metrics-utility==0.7.20251112",
+    "django-prometheus>=2.3.1",
     "pip>=25.2",
 ]
 

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -17,6 +17,10 @@ attrs==25.3.0
     #   -r requirements-pinned.txt
     #   jsonschema
     #   referencing
+backoff==2.2.1
+    # via
+    #   -r requirements-pinned.txt
+    #   segment-analytics-python
 boto3==1.35.96
     # via
     #   -r requirements-pinned.txt
@@ -71,7 +75,7 @@ distro==1.9.0
     # via
     #   -r requirements-pinned.txt
     #   metrics-utility
-django==4.2.21
+django==5.2.7
     # via
     #   -r requirements-pinned.txt
     #   channels
@@ -79,12 +83,13 @@ django==4.2.21
     #   django-cors-headers
     #   django-crum
     #   django-oauth-toolkit
+    #   django-prometheus
     #   djangorestframework
     #   drf-spectacular
     #   metrics-service
     #   metrics-utility
     #   social-auth-app-django
-django-ansible-base==2025.8.18
+django-ansible-base==2025.10.20
     # via
     #   -r requirements-pinned.txt
     #   metrics-service
@@ -100,6 +105,10 @@ django-oauth-toolkit==3.0.1
     # via
     #   -r requirements-pinned.txt
     #   metrics-service
+django-prometheus==2.4.1
+    # via
+    #   -r requirements-pinned.txt
+    #   metrics-service
 django-split-settings==1.3.2
     # via
     #   -r requirements-pinned.txt
@@ -110,7 +119,7 @@ djangorestframework==3.16.1
     #   django-ansible-base
     #   drf-spectacular
     #   metrics-service
-drf-spectacular==0.28.0
+drf-spectacular==0.26.5
     # via
     #   -r requirements-pinned.txt
     #   django-ansible-base
@@ -162,7 +171,7 @@ kubernetes==34.1.0
     # via
     #   -r requirements-pinned.txt
     #   metrics-utility
-metrics-utility @ git+https://github.com/ansible/metrics-utility.git@c79c3374e5ae93e03fcf2d30ccc1048ceca06619
+metrics-utility==0.7.20251112
     # via
     #   -r requirements-pinned.txt
     #   metrics-service
@@ -188,6 +197,10 @@ pip==25.2
     # via
     #   -r requirements-pinned.txt
     #   metrics-service
+prometheus-client==0.23.1
+    # via
+    #   -r requirements-pinned.txt
+    #   django-prometheus
 psycopg==3.2.10
     # via
     #   -r requirements-pinned.txt
@@ -218,6 +231,7 @@ pyjwt==2.10.1
     # via
     #   -r requirements-pinned.txt
     #   django-ansible-base
+    #   segment-analytics-python
     #   social-auth-core
 python-dateutil==2.9.0.post0
     # via
@@ -226,6 +240,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   kubernetes
     #   pandas
+    #   segment-analytics-python
 python3-openid==3.2.0
     # via
     #   -r requirements-pinned.txt
@@ -254,6 +269,7 @@ requests==2.32.5
     #   kubernetes
     #   metrics-utility
     #   requests-oauthlib
+    #   segment-analytics-python
     #   social-auth-core
 requests-oauthlib==2.0.0
     # via
@@ -273,6 +289,10 @@ s3transfer==0.10.4
     # via
     #   -r requirements-pinned.txt
     #   boto3
+segment-analytics-python==2.3.4
+    # via
+    #   -r requirements-pinned.txt
+    #   metrics-utility
 setuptools==80.9.0
     # via
     #   -r requirements-pinned.txt
@@ -299,6 +319,8 @@ typing-extensions==4.15.0
     # via
     #   -r requirements-pinned.txt
     #   jwcrypto
+    #   psycopg
+    #   referencing
 tzdata==2025.2
     # via
     #   -r requirements-pinned.txt

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -18,6 +18,10 @@ attrs==25.3.0 \
     # via
     #   jsonschema
     #   referencing
+backoff==2.2.1 \
+    --hash=sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba \
+    --hash=sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8
+    # via segment-analytics-python
 boto3==1.35.96 \
     --hash=sha256:bace02ef2181d176cedc1f8f90c95c301bb7c555db124cf80bc193cbb52a7c64 \
     --hash=sha256:e6acb2380791b13d8fd55062d9bbc6e27c3ddb3e73cff71c4ca02e6743780c67
@@ -120,23 +124,24 @@ distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
     # via metrics-utility
-django==4.2.21 \
-    --hash=sha256:1d658c7bf5d31c7d0cac1cab58bc1f822df89255080fec81909256c30e6180b3 \
-    --hash=sha256:b54ac28d6aa964fc7c2f7335138a54d78980232011e0cd2231d04eed393dcb0d
+django==5.2.7 \
+    --hash=sha256:59a13a6515f787dec9d97a0438cd2efac78c8aca1c80025244b0fe507fe0754b \
+    --hash=sha256:e0f6f12e2551b1716a95a63a1366ca91bbcd7be059862c1b18f989b1da356cdd
     # via
     #   channels
     #   django-ansible-base
     #   django-cors-headers
     #   django-crum
     #   django-oauth-toolkit
+    #   django-prometheus
     #   djangorestframework
     #   drf-spectacular
     #   metrics-service
     #   metrics-utility
     #   social-auth-app-django
-django-ansible-base==2025.8.18 \
-    --hash=sha256:2ad5bd979d93d2d1ae3b818c38641377991c70b2b93252424ac54b0351103681 \
-    --hash=sha256:fa54b32441942b98d6d26806d63daf2e6b4b0dd176bc841db64a0493cbf29ace
+django-ansible-base==2025.10.20 \
+    --hash=sha256:11562985d3c62989afb60065be5fb3b89b35f01ce5844132b2bb82f361f476e2 \
+    --hash=sha256:7c4383aaf9fd798d6c894a6546048158de451232c88f1750bbdd55a6fc23c3ee
     # via metrics-service
 django-cors-headers==4.7.0 \
     --hash=sha256:6fdf31bf9c6d6448ba09ef57157db2268d515d94fc5c89a0a1028e1fc03ee52b \
@@ -150,6 +155,10 @@ django-oauth-toolkit==3.0.1 \
     --hash=sha256:3ef00b062a284f2031b0732b32dc899e3bbf0eac221bbb1cffcb50b8932e55ed \
     --hash=sha256:7200e4a9fb229b145a6d808cbf0423b6d69a87f68557437733eec3c0cf71db02
     # via metrics-service
+django-prometheus==2.4.1 \
+    --hash=sha256:073628243d2a6de6a8a8c20e5b512872dfb85d66e1b60b28bcf1eca0155dad95 \
+    --hash=sha256:7fe5af7f7c9ad9cd8a429fe0f3f1bf651f0e244f77162147869eab7ec09cc5e7
+    # via metrics-service
 django-split-settings==1.3.2 \
     --hash=sha256:72bd7dd9f12602585681074d1f859643fb4f6b196b584688fab86bdd73a57dff \
     --hash=sha256:d3975aa3601e37f65c59b9977b6bcb1de8bc27496930054078589c7d56998a9d
@@ -161,9 +170,9 @@ djangorestframework==3.16.1 \
     #   django-ansible-base
     #   drf-spectacular
     #   metrics-service
-drf-spectacular==0.28.0 \
-    --hash=sha256:2c778a47a40ab2f5078a7c42e82baba07397bb35b074ae4680721b2805943061 \
-    --hash=sha256:856e7edf1056e49a4245e87a61e8da4baff46c83dbc25be1da2df77f354c7cb4
+drf-spectacular==0.26.5 \
+    --hash=sha256:aee55330a774ba8a9cbdb125714d1c9ee05a8aafd3ce3be8bfd26527649aeb44 \
+    --hash=sha256:c0002a820b11771fdbf37853deb371947caf0159d1afeeffe7598e964bc1db94
     # via
     #   django-ansible-base
     #   metrics-service
@@ -217,7 +226,9 @@ kubernetes==34.1.0 \
     --hash=sha256:8fe8edb0b5d290a2f3ac06596b23f87c658977d46b5f8df9d0f4ea83d0003912 \
     --hash=sha256:bffba2272534e224e6a7a74d582deb0b545b7c9879d2cd9e4aae9481d1f2cc2a
     # via metrics-utility
-metrics-utility @ git+https://github.com/ansible/metrics-utility.git@c79c3374e5ae93e03fcf2d30ccc1048ceca06619
+metrics-utility==0.7.20251112 \
+    --hash=sha256:47545d25e293c1e05ff0b320be18c68c8bb2c46191dc8866b09060fa4f37acfb \
+    --hash=sha256:bbaa329030ab80ada17f54d1655bc7c9ca251c6f0fa7be2e1d2ade66a584b83e
     # via metrics-service
 numpy==2.3.3 \
     --hash=sha256:067e3d7159a5d8f8a0b46ee11148fc35ca9b21f61e3c49fbd0a027450e65a33b \
@@ -258,6 +269,10 @@ pip==25.2 \
     --hash=sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2 \
     --hash=sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717
     # via metrics-service
+prometheus-client==0.23.1 \
+    --hash=sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce \
+    --hash=sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99
+    # via django-prometheus
 psycopg==3.2.10 \
     --hash=sha256:0bce99269d16ed18401683a8569b2c5abd94f72f8364856d56c0389bcd50972a \
     --hash=sha256:ab5caf09a9ec42e314a21f5216dbcceac528e0e05142e42eea83a3b28b320ac3
@@ -309,6 +324,7 @@ pyjwt==2.10.1 \
     --hash=sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
     # via
     #   django-ansible-base
+    #   segment-analytics-python
     #   social-auth-core
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
@@ -318,6 +334,7 @@ python-dateutil==2.9.0.post0 \
     #   croniter
     #   kubernetes
     #   pandas
+    #   segment-analytics-python
 python3-openid==3.2.0 \
     --hash=sha256:33fbf6928f401e0b790151ed2b5290b02545e8775f982485205a066f874aaeaf \
     --hash=sha256:6626f771e0417486701e0b4daff762e7212e820ca5b29fcc0d05f6f8736dfa6b
@@ -358,6 +375,7 @@ requests==2.32.5 \
     #   kubernetes
     #   metrics-utility
     #   requests-oauthlib
+    #   segment-analytics-python
     #   social-auth-core
 requests-oauthlib==2.0.0 \
     --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
@@ -393,6 +411,10 @@ s3transfer==0.10.4 \
     --hash=sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e \
     --hash=sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7
     # via boto3
+segment-analytics-python==2.3.4 \
+    --hash=sha256:ea2b6432bef1c017d24f69bf5f778e45c2385ec9df527242e2b42ee6cefd7367 \
+    --hash=sha256:f188e864cc0fed9fb141aff73c21bfaab783a1dd1b97ab1eff44340aed68f50b
+    # via metrics-utility
 setuptools==80.9.0 \
     --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
     --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c

--- a/tests/unit/tasks/test_tasks_views_extended.py
+++ b/tests/unit/tasks/test_tasks_views_extended.py
@@ -2,7 +2,7 @@
 Extended tests for task views and serializers to improve coverage.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -115,7 +115,7 @@ class TestTaskSerializer(TestCase):
 
     def test_task_with_scheduled_time(self):
         """Test task with scheduled time."""
-        scheduled_time = datetime.now(timezone.utc)
+        scheduled_time = datetime.now(UTC)
         data = {
             "name": "Scheduled Task",
             "function_name": "scheduled_function",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.12"
+requires-python = "==3.12.*"
 
 [[package]]
 name = "alabaster"
@@ -48,6 +48,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
 ]
 
 [[package]]
@@ -310,21 +319,21 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "4.2.21"
+version = "5.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/bb/2fad5edc1af2945cb499a2e322ac28e4714fc310bd5201ed1f5a9f73a342/django-4.2.21.tar.gz", hash = "sha256:b54ac28d6aa964fc7c2f7335138a54d78980232011e0cd2231d04eed393dcb0d", size = 10424638, upload-time = "2025-05-07T14:07:07.992Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/96/bd84e2bb997994de8bcda47ae4560991084e86536541d7214393880f01a8/django-5.2.7.tar.gz", hash = "sha256:e0f6f12e2551b1716a95a63a1366ca91bbcd7be059862c1b18f989b1da356cdd", size = 10865812, upload-time = "2025-10-01T14:22:12.081Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/4f/aeaa3098da18b625ed672f3da6d1cd94e188d1b2cc27c2c841b2f9666282/django-4.2.21-py3-none-any.whl", hash = "sha256:1d658c7bf5d31c7d0cac1cab58bc1f822df89255080fec81909256c30e6180b3", size = 7993839, upload-time = "2025-05-07T14:07:01.318Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ef/81f3372b5dd35d8d354321155d1a38894b2b766f576d0abffac4d8ae78d9/django-5.2.7-py3-none-any.whl", hash = "sha256:59a13a6515f787dec9d97a0438cd2efac78c8aca1c80025244b0fe507fe0754b", size = 8307145, upload-time = "2025-10-01T14:22:49.476Z" },
 ]
 
 [[package]]
 name = "django-ansible-base"
-version = "2025.8.18"
+version = "2025.10.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -335,9 +344,9 @@ dependencies = [
     { name = "inflection" },
     { name = "sqlparse" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/2e43ce5e76c8ac75559fbc9ac58f90aad150f2b9dcfca2c07bf37509e1df/django_ansible_base-2025.8.18.tar.gz", hash = "sha256:2ad5bd979d93d2d1ae3b818c38641377991c70b2b93252424ac54b0351103681", size = 305430, upload-time = "2025-08-18T13:48:28.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/00/3c876b87e5eb4f88c63621bc38048e004834a6e4c80dff40f8ed19730f3e/django_ansible_base-2025.10.20.tar.gz", hash = "sha256:11562985d3c62989afb60065be5fb3b89b35f01ce5844132b2bb82f361f476e2", size = 316742, upload-time = "2025-10-20T14:58:23.639Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/58/e4ef4bddd5ed13625f45cf5cdc0fddfca60317c24f32be04cd6926226fb2/django_ansible_base-2025.8.18-py3-none-any.whl", hash = "sha256:fa54b32441942b98d6d26806d63daf2e6b4b0dd176bc841db64a0493cbf29ace", size = 407962, upload-time = "2025-08-18T13:48:27.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/39/43528c3b0378bae3cce99f02d7021acc4a3d665735ddb152f7ba8386c6a8/django_ansible_base-2025.10.20-py3-none-any.whl", hash = "sha256:7c4383aaf9fd798d6c894a6546048158de451232c88f1750bbdd55a6fc23c3ee", size = 417093, upload-time = "2025-10-20T14:58:22.1Z" },
 ]
 
 [package.optional-dependencies]
@@ -413,6 +422,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fa/d3/d7628a7a4899bf5aafc9c1ec121c507470b37a247f7628acae6e0f78e0d6/django_oauth_toolkit-3.0.1.tar.gz", hash = "sha256:7200e4a9fb229b145a6d808cbf0423b6d69a87f68557437733eec3c0cf71db02", size = 99816, upload-time = "2024-09-07T14:07:57.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/40/e556bc19ba65356fe5f0e48ca01c50e81f7c630042fa7411b6ab428ecf68/django_oauth_toolkit-3.0.1-py3-none-any.whl", hash = "sha256:3ef00b062a284f2031b0732b32dc899e3bbf0eac221bbb1cffcb50b8932e55ed", size = 77299, upload-time = "2024-09-07T14:08:43.225Z" },
+]
+
+[[package]]
+name = "django-prometheus"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f4/cb39ddd2a41e07a274c4e162c076e906ae232d63b66bbabdea0300878877/django_prometheus-2.4.1.tar.gz", hash = "sha256:073628243d2a6de6a8a8c20e5b512872dfb85d66e1b60b28bcf1eca0155dad95", size = 24464, upload-time = "2025-06-25T15:45:37.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/50/9c5e022fa92574e5d20606687f15a2aa255e10512a17d11a8216fa117f72/django_prometheus-2.4.1-py2.py3-none-any.whl", hash = "sha256:7fe5af7f7c9ad9cd8a429fe0f3f1bf651f0e244f77162147869eab7ec09cc5e7", size = 29541, upload-time = "2025-06-25T15:45:35.433Z" },
 ]
 
 [[package]]
@@ -502,7 +524,7 @@ wheels = [
 
 [[package]]
 name = "drf-spectacular"
-version = "0.28.0"
+version = "0.26.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -512,9 +534,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "uritemplate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/b9/741056455aed00fa51a1df41fad5ad27c8e0d433b6bf490d4e60e2808bc6/drf_spectacular-0.28.0.tar.gz", hash = "sha256:2c778a47a40ab2f5078a7c42e82baba07397bb35b074ae4680721b2805943061", size = 237849, upload-time = "2024-11-30T08:49:02.355Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/a5/8a396485fb885391ff51dab988e6387ba9c72c80d42cce2d1c927365d104/drf-spectacular-0.26.5.tar.gz", hash = "sha256:aee55330a774ba8a9cbdb125714d1c9ee05a8aafd3ce3be8bfd26527649aeb44", size = 220768, upload-time = "2023-09-23T00:13:04.222Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/66/c2929871393b1515c3767a670ff7d980a6882964a31a4ca2680b30d7212a/drf_spectacular-0.28.0-py3-none-any.whl", hash = "sha256:856e7edf1056e49a4245e87a61e8da4baff46c83dbc25be1da2df77f354c7cb4", size = 103928, upload-time = "2024-11-30T08:48:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f7/118bc5eccedf0cf3ce0e1b09edd1bdb8becf778e92dc5f30ad339ee771c1/drf_spectacular-0.26.5-py3-none-any.whl", hash = "sha256:c0002a820b11771fdbf37853deb371947caf0159d1afeeffe7598e964bc1db94", size = 94071, upload-time = "2023-09-23T00:13:01.884Z" },
 ]
 
 [[package]]
@@ -766,6 +788,7 @@ dependencies = [
     { name = "django-ansible-base", extra = ["api-documentation", "jwt-consumer"] },
     { name = "django-cors-headers" },
     { name = "django-oauth-toolkit" },
+    { name = "django-prometheus" },
     { name = "django-split-settings" },
     { name = "djangorestframework" },
     { name = "drf-spectacular" },
@@ -841,23 +864,24 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'test'", specifier = ">=7.3" },
     { name = "croniter", specifier = ">=1.3.0" },
     { name = "dispatcherd", specifier = ">=2025.5.21" },
-    { name = "django", specifier = ">=4.2,<5.0" },
-    { name = "django-ansible-base", extras = ["api-documentation", "jwt-consumer", "rbac", "rest-filters"] },
+    { name = "django", specifier = ">=5.2.7" },
+    { name = "django-ansible-base", extras = ["api-documentation", "jwt-consumer", "rbac", "rest-filters"], specifier = "==2025.10.20" },
     { name = "django-auth-ldap", marker = "extra == 'ldap'", specifier = ">=5.2.0" },
     { name = "django-cors-headers", specifier = ">=4.0" },
     { name = "django-debug-toolbar", marker = "extra == 'dev'", specifier = ">=4.2" },
     { name = "django-oauth-toolkit", specifier = ">=2.2.0" },
+    { name = "django-prometheus", specifier = ">=2.3.1" },
     { name = "django-split-settings", specifier = ">=1.2" },
     { name = "django-stubs", extras = ["compatible-mypy"], marker = "extra == 'dev'", specifier = ">=4.2" },
     { name = "djangorestframework", specifier = ">=3.15" },
     { name = "djangorestframework-stubs", extras = ["compatible-mypy"], marker = "extra == 'dev'", specifier = ">=3.14" },
-    { name = "drf-spectacular", specifier = ">=0.27" },
+    { name = "drf-spectacular", specifier = ">=0.26.5" },
     { name = "dynaconf", specifier = ">=3.1.0" },
     { name = "factory-boy", marker = "extra == 'dev'", specifier = ">=3.3" },
     { name = "factory-boy", marker = "extra == 'test'", specifier = ">=3.3" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12" },
     { name = "ldap-filter", marker = "extra == 'ldap'", specifier = ">=1.0.1" },
-    { name = "metrics-utility", git = "https://github.com/ansible/metrics-utility.git" },
+    { name = "metrics-utility", specifier = "==0.7.20251112" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "pip", specifier = ">=25.2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.4" },
@@ -901,8 +925,8 @@ dev = [
 
 [[package]]
 name = "metrics-utility"
-version = "0.7.0.dev0"
-source = { git = "https://github.com/ansible/metrics-utility.git#c79c3374e5ae93e03fcf2d30ccc1048ceca06619" }
+version = "0.7.20251112"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
@@ -913,7 +937,12 @@ dependencies = [
     { name = "pandas" },
     { name = "psycopg" },
     { name = "requests" },
+    { name = "segment-analytics-python" },
     { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/13/7ee41c68c1112a6948c0c3d8b311022c4bc4d4a7b313c3626271cded1e63/metrics_utility-0.7.20251112.tar.gz", hash = "sha256:47545d25e293c1e05ff0b320be18c68c8bb2c46191dc8866b09060fa4f37acfb", size = 848860, upload-time = "2025-11-12T13:33:16.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/d4/ee87c6c61a3b921a68fa6b9f7933eff483c318555157931d21a6135a6b72/metrics_utility-0.7.20251112-py3-none-any.whl", hash = "sha256:bbaa329030ab80ada17f54d1655bc7c9ca251c6f0fa7be2e1d2ade66a584b83e", size = 353695, upload-time = "2025-11-12T13:33:14.435Z" },
 ]
 
 [[package]]
@@ -1074,6 +1103,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/53/3edb5d68ecf6b38fcbcc1ad28391117d2a322d9a1a3eff04bfdb184d8c3b/prometheus_client-0.23.1.tar.gz", hash = "sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce", size = 80481, upload-time = "2025-09-18T20:47:25.043Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/db/14bafcb4af2139e046d03fd00dea7873e48eafe18b7d2797e73d6681f210/prometheus_client-0.23.1-py3-none-any.whl", hash = "sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99", size = 61145, upload-time = "2025-09-18T20:47:23.875Z" },
 ]
 
 [[package]]
@@ -1414,6 +1452,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/0a/1cdbabf9edd0ea7747efdf6c9ab4e7061b085aa7f9bfc36bb1601563b069/s3transfer-0.10.4.tar.gz", hash = "sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7", size = 145287, upload-time = "2024-11-20T21:06:05.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl", hash = "sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e", size = 83175, upload-time = "2024-11-20T21:06:03.961Z" },
+]
+
+[[package]]
+name = "segment-analytics-python"
+version = "2.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "pyjwt" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/89/17a69db0da866488462685159c29859d71a2994e7644140f2e05716eb4f8/segment_analytics_python-2.3.4.tar.gz", hash = "sha256:f188e864cc0fed9fb141aff73c21bfaab783a1dd1b97ab1eff44340aed68f50b", size = 35571, upload-time = "2025-02-24T16:40:06.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/96/c9508caecf4dcfd6ce0bba63a9fd3546edddcc24070040239c4468aad408/segment_analytics_python-2.3.4-py2.py3-none-any.whl", hash = "sha256:ea2b6432bef1c017d24f69bf5f778e45c2385ec9df527242e2b42ee6cefd7367", size = 33335, upload-time = "2025-02-24T16:40:04.195Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -864,7 +864,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'test'", specifier = ">=7.3" },
     { name = "croniter", specifier = ">=1.3.0" },
     { name = "dispatcherd", specifier = ">=2025.5.21" },
-    { name = "django", specifier = ">=5.2.7" },
+    { name = "django", specifier = "==5.2.7" },
     { name = "django-ansible-base", extras = ["api-documentation", "jwt-consumer", "rbac", "rest-filters"], specifier = "==2025.10.20" },
     { name = "django-auth-ldap", marker = "extra == 'ldap'", specifier = ">=5.2.0" },
     { name = "django-cors-headers", specifier = ">=4.0" },


### PR DESCRIPTION
- Upgraded Django from 4.2.21 to 5.2.7 across all requirement files.
- Updated django-ansible-base to version 2025.10.20.
- Adjusted drf-spectacular version to 0.26.5.
- Specified metrics-utility version to 0.7.20251112.
- Added backoff and segment-analytics-python dependencies with their respective versions.
- Updated Python requirement to "==3.12.*" for compatibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades to Django 5.2.7 and Python 3.12.*, pins metrics-utility, adjusts collector imports, adds prometheus/analytics deps, and removes Setting.source.
> 
> - **Dependencies/Build**:
>   - Upgrade `Django` to `5.2.7`; update `django-ansible-base` to `2025.10.20`.
>   - Pin `metrics-utility` to `0.7.20251112`; set `requires-python` to `==3.12.*` and tool targets to py312.
>   - Adjust `drf-spectacular` to `0.26.5`.
>   - Add `django-prometheus` and `prometheus-client`; add `backoff` and `segment-analytics-python`.
>   - Update requirements/lock files accordingly.
>   - Docker: base image switched to `ubi9/python-312`.
> - **Code (tasks)**:
>   - Change metrics collector imports to `metrics_utility.library.collectors.controller` (map `config`, `anonymous`, `job_host_summary`, `host_metric`).
> - **Database**:
>   - Migration removes `Setting.source` field (`apps/core/migrations/0010_remove_setting_source.py`).
> - **Tests**:
>   - Use `datetime.UTC` in tests and minor timezone usage updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aba86fb3a1856dbd56cb9c81f7778d744634364f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->