### PR TITLE
Fix for dispatcherd config for local testing 

### DIFF
--- a/config/dispatcherd.yaml
+++ b/config/dispatcherd.yaml
@@ -6,10 +6,13 @@ version: 2
 
 brokers:
   pg_notify:
-    # Database connection inherits from Django settings
-    # The broker will use the same database connection as Django
-    # which is configured via METRICS_SERVICE_DATABASES__default__* env vars
-    use_django_db: true
+    config:
+      # Database connection - configured for current Django settings
+      dbname: 'metrics_service'
+      user: 'metrics_service'
+      password: 'metrics_service'
+      host: '127.0.0.1'
+      port: '5432'
 
     channels:
       - 'metrics_tasks' # Main task execution channel


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces `use_django_db` with explicit Postgres connection settings for `brokers.pg_notify` in `config/dispatcherd.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10a0f6885e95d13be2d04e7f28e8c65a8b1111bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->