### PR TITLE
Send Data to segment task

### DIFF
--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -492,6 +492,7 @@ def send_to_segment_hello_world(**kwargs) -> dict[str, Any]:
         "review",
     ]
 
+    # generate random uuid
     # This is now for testing purposes only
     # In production we will have to have some unique identifier for certain collection
     # So its idempotent
@@ -500,7 +501,7 @@ def send_to_segment_hello_world(**kwargs) -> dict[str, Any]:
     try:
         # send hello world data to segment using metrics-utility
         segment = StorageSegment(write_key=write_key, debug=False)
-        chunks = segment.put(artifact_name=random_name, dict=dict, event_name="metrics_service_hello_world")
+        chunks = segment.put(artifact_name=random_name, dict=dict, event_name=random_name)
         success = True
         error = None
     except Exception as e:

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -9,6 +9,7 @@ import logging
 import os
 import time
 from typing import Any
+fro
 
 from django.utils import timezone
 
@@ -351,6 +352,24 @@ def collect_all_metrics(**kwargs) -> dict[str, Any]:
     except Exception as e:
         logger.error(f"Error in collect_all_metrics: {str(e)}")
         return create_task_result("error", error=f"Collection failed: {str(e)}")
+
+
+@task(queue="metrics_tasks", decorate=False)
+@task_execution_wrapper("send_to_segment")
+def send_to_segment(**kwargs) -> dict[str, Any]:
+    """
+    Send JSON data to Segment.com for analytics using metrics-utility.
+    """
+    # Simple task that just prints hello world for now
+    message = "Will be seding data"
+    logger.info(f"Task executing: {message}")
+
+    return create_task_result(
+        "success",
+        {
+            "message": message,
+        },
+    )
 
 
 @task(queue="metrics_tasks", decorate=False)
@@ -782,6 +801,7 @@ TASK_FUNCTIONS = {
     "collect_job_host_summary": collect_job_host_summary,
     "collect_host_metrics": collect_host_metrics,
     "collect_all_metrics": collect_all_metrics,
+    "send_to_segment": send_to_segment,
 }
 
 # Enhanced task metadata for dashboard display
@@ -791,6 +811,12 @@ TASK_METADATA = {
         "description": "Simple hello world task for testing the dispatcherd integration",
         "parameters": {},
         "examples": [{"name": "Basic Hello World", "data": {}}],
+    },
+    "send_to_segment": {
+        "category": "Testing",
+        "description": "Send JSON data to Segment.com for analytics using metrics-utility",
+        "parameters": {},
+        "examples": [{"name": "Basic send to segment", "data": {}}],
     },
     "sleep": {
         "category": "Testing",

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -10,7 +10,6 @@ import os
 import time
 from typing import Any
 from metrics_service.settings import DYNACONF
-import json
 
 from django.utils import timezone
 
@@ -371,10 +370,10 @@ def send_to_segment_hello_world(**kwargs) -> dict[str, Any]:
     logger.info(f"Write key: {write_key}")
 
     large_list = []
-    for i in range(100):
+    for i in range(130):
         list_item_dict = {}
         for j in range(10):
-            list_item_dict[f'list_item_dict_item_{j}'] = f'list_item_dict_item_value_{j}'
+            list_item_dict[f'{i}_list_item_dict_item_{j}'] = f'list_item'
         large_list_item = list_item_dict
         large_list.append(large_list_item)
 
@@ -383,14 +382,15 @@ def send_to_segment_hello_world(**kwargs) -> dict[str, Any]:
         large_dict[f'dict_item_{i}'] = f'dict_item_value_{i}'
 
     dict = {
-        'large_list' : large_list,
         'large_dict' : large_dict,
+        'large_list' : large_list,
+        'second_large_dict' : large_dict,
     }
 
     try:
         # send hello world data to segment using metrics-utility
-        segment = StorageSegment(write_key=write_key, debug=True)
-        segment.put(
+        segment = StorageSegment(write_key=write_key, debug=False)
+        chunks = segment.put(
             artifact_name="hello_world",
             dict=dict,
             event_name="metrics_service_hello_world"
@@ -398,7 +398,7 @@ def send_to_segment_hello_world(**kwargs) -> dict[str, Any]:
         success = True
         error = None
     except Exception as e:
-        logger.error(f"Error sending hello world data to segment: {str(e)}")
+        logger.error(f"Error sending hello world data to segment")
         success = False
         error = str(e)
 
@@ -411,6 +411,7 @@ def send_to_segment_hello_world(**kwargs) -> dict[str, Any]:
             "write_key": write_key,
             "success": success,
             "error": error,
+            "chunks_count": len(chunks),
         },
     )
 

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -10,6 +10,7 @@ import os
 import time
 from typing import Any
 from metrics_service.settings import DYNACONF
+import json
 
 from django.utils import timezone
 
@@ -369,12 +370,29 @@ def send_to_segment_hello_world(**kwargs) -> dict[str, Any]:
     write_key = DYNACONF.get("SEGMENT_WRITE_KEY", None)
     logger.info(f"Write key: {write_key}")
 
+    large_list = []
+    for i in range(100):
+        list_item_dict = {}
+        for j in range(10):
+            list_item_dict[f'list_item_dict_item_{j}'] = f'list_item_dict_item_value_{j}'
+        large_list_item = list_item_dict
+        large_list.append(large_list_item)
+
+    large_dict = {}
+    for i in range(100):
+        large_dict[f'dict_item_{i}'] = f'dict_item_value_{i}'
+
+    dict = {
+        'large_list' : large_list,
+        'large_dict' : large_dict,
+    }
+
     try:
         # send hello world data to segment using metrics-utility
         segment = StorageSegment(write_key=write_key, debug=True)
         segment.put(
             artifact_name="hello_world",
-            dict={"message": message},
+            dict=dict,
             event_name="metrics_service_hello_world"
         )
         success = True

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -49,6 +49,7 @@ try:
     from metrics_utility.library.collectors.controller import (
         main_jobevent as host_metric,
     )
+    from metrics_utility.library.storage.segment import StorageSegment
 
     METRICS_UTILITY_AVAILABLE = True
 except ImportError as e:
@@ -355,26 +356,38 @@ def collect_all_metrics(**kwargs) -> dict[str, Any]:
 
 
 @task(queue="metrics_tasks", decorate=False)
-@task_execution_wrapper("send_to_segment")
-def send_to_segment(**kwargs) -> dict[str, Any]:
+@task_execution_wrapper("send_to_segment_hello_world")
+def send_to_segment_hello_world(**kwargs) -> dict[str, Any]:
     """
     Send testing JSON data to Segment.com for analytics using metrics-utility.
     """
     # Simple task that just prints hello world for now
-    message = "Will be seding data 3"
+    message = "Will be sending data 3"
     logger.info(f"Task executing: {message}")
 
     # obtain write key from django conf
     write_key = DYNACONF.get("SEGMENT_WRITE_KEY", None)
     logger.info(f"Write key: {write_key}")
 
-    
+    try:
+    # send hello world data to segment using metrics-utility
+        segment = StorageSegment(write_key=write_key, debug=True)
+        segment.put("hello_world", 'metrics_service_hell_world',dict={"message": message})
+        success = True
+    except Exception as e:
+        logger.error(f"Error sending hello world data to segment: {str(e)}")
+        success = False
+        error = str(e)
+
+    task_result_name = "success" if success else "error"
 
     return create_task_result(
-        "success",
+        task_result_name,
         {
             "message": message,
             "write_key": write_key,
+            "success": success,
+            "error": error,
         },
     )
 
@@ -808,7 +821,7 @@ TASK_FUNCTIONS = {
     "collect_job_host_summary": collect_job_host_summary,
     "collect_host_metrics": collect_host_metrics,
     "collect_all_metrics": collect_all_metrics,
-    "send_to_segment": send_to_segment,
+    "send_to_segment_hello_world": send_to_segment_hello_world,
 }
 
 # Enhanced task metadata for dashboard display
@@ -819,7 +832,7 @@ TASK_METADATA = {
         "parameters": {},
         "examples": [{"name": "Basic Hello World", "data": {}}],
     },
-    "send_to_segment": {
+    "send_to_segment_hello_world": {
         "category": "Testing",
         "description": "Send testing JSON data to Segment.com for analytics using metrics-utility",
         "parameters": {},

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -9,7 +9,7 @@ import logging
 import os
 import time
 from typing import Any
-from django.conf import settings
+from metrics_service.settings import DYNACONF
 
 from django.utils import timezone
 
@@ -358,15 +358,17 @@ def collect_all_metrics(**kwargs) -> dict[str, Any]:
 @task_execution_wrapper("send_to_segment")
 def send_to_segment(**kwargs) -> dict[str, Any]:
     """
-    Send JSON data to Segment.com for analytics using metrics-utility.
+    Send testing JSON data to Segment.com for analytics using metrics-utility.
     """
     # Simple task that just prints hello world for now
-    message = "Will be seding data 2"
+    message = "Will be seding data 3"
     logger.info(f"Task executing: {message}")
 
     # obtain write key from django conf
-    write_key = settings.SEGMENT_WRITE_KEY
+    write_key = DYNACONF.get("SEGMENT_WRITE_KEY", None)
     logger.info(f"Write key: {write_key}")
+
+    
 
     return create_task_result(
         "success",
@@ -819,7 +821,7 @@ TASK_METADATA = {
     },
     "send_to_segment": {
         "category": "Testing",
-        "description": "Send JSON data to Segment.com for analytics using metrics-utility",
+        "description": "Send testing JSON data to Segment.com for analytics using metrics-utility",
         "parameters": {},
         "examples": [{"name": "Basic send to segment", "data": {}}],
     },

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -7,11 +7,13 @@ tasks with proper error handling, status tracking, and dependency management.
 
 import logging
 import os
+import random
 import time
 from typing import Any
-from metrics_service.settings import DYNACONF
 
 from django.utils import timezone
+
+from metrics_service.settings import DYNACONF
 
 from .utils import (
     create_task_result,
@@ -373,39 +375,141 @@ def send_to_segment_hello_world(**kwargs) -> dict[str, Any]:
     for i in range(130):
         list_item_dict = {}
         for j in range(10):
-            list_item_dict[f'{i}_list_item_dict_item_{j}'] = f'list_item'
+            list_item_dict[f"{i}_list_item_dict_item_{j}"] = "list_item"
         large_list_item = list_item_dict
         large_list.append(large_list_item)
 
     large_dict = {}
     for i in range(100):
-        large_dict[f'dict_item_{i}'] = f'dict_item_value_{i}'
+        large_dict[f"dict_item_{i}"] = f"dict_item_value_{i}"
 
     dict = {
-        'large_dict' : large_dict,
-        'large_list' : large_list,
-        'second_large_dict' : large_dict,
+        "large_dict": large_dict,
+        "large_list": large_list,
+        "second_large_dict": large_dict,
     }
+
+    # generate random readable name
+    choice1 = [
+        "amazing",
+        "wonderful",
+        "fantastic",
+        "incredible",
+        "magnificent",
+        "spectacular",
+        "awesome",
+        "terrific",
+        "magnificent",
+        "spectacular",
+        "awesome",
+        "terrific",
+        "brilliant",
+        "remarkable",
+        "extraordinary",
+        "marvelous",
+        "stellar",
+        "exceptional",
+        "impressive",
+        "phenomenal",
+        "outstanding",
+        "radiant",
+        "glorious",
+        "superb",
+    ]
+
+    choice2 = [
+        "quiet",
+        "anonymized",
+        "secret",
+        "hidden",
+        "private",
+        "secure",
+        "confidential",
+        "hidden",
+        "secret",
+        "confidential",
+        "stealthy",
+        "discreet",
+        "low-profile",
+        "shielded",
+        "veiled",
+        "masked",
+        "encrypted",
+        "obscured",
+        "camouflaged",
+        "protected",
+        "secluded",
+        "isolated",
+    ]
+
+    choice3 = [
+        "apple",
+        "banana",
+        "cherry",
+        "date",
+        "elderberry",
+        "fig",
+        "grape",
+        "honeydew",
+        "kiwi",
+        "lemon",
+        "mango",
+        "nectarine",
+        "orange",
+        "papaya",
+        "quince",
+        "raspberry",
+        "strawberry",
+        "tangerine",
+        "watermelon",
+        "blueberry",
+        "blackberry",
+        "pineapple",
+    ]
+
+    choice4 = [
+        "analysis",
+        "report",
+        "summary",
+        "metrics",
+        "data",
+        "information",
+        "insights",
+        "reports",
+        "analytics",
+        "stats",
+        "overview",
+        "breakdown",
+        "dashboard",
+        "evaluation",
+        "assessment",
+        "briefing",
+        "log",
+        "record",
+        "dataset",
+        "profile",
+        "observations",
+        "review",
+    ]
+
+    # This is now for testing purposes only
+    # In production we will have to have some unique identifier for certain collection
+    # So its idempotent
+    random_name = f"{random.choice(choice1)}_{random.choice(choice2)}_{random.choice(choice3)}_{random.choice(choice4)}"
 
     try:
         # send hello world data to segment using metrics-utility
         segment = StorageSegment(write_key=write_key, debug=False)
-        chunks = segment.put(
-            artifact_name="hello_world",
-            dict=dict,
-            event_name="metrics_service_hello_world"
-        )
+        chunks = segment.put(artifact_name=random_name, dict=dict, event_name="metrics_service_hello_world")
         success = True
         error = None
     except Exception as e:
-        logger.error(f"Error sending hello world data to segment")
+        logger.error("Error sending hello world data to segment")
         success = False
         error = str(e)
 
-    task_result_name = "success" if success else "error"
-
     return create_task_result(
-        task_result_name,
+        "success",
         {
             "message": message,
             "write_key": write_key,

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -370,10 +370,15 @@ def send_to_segment_hello_world(**kwargs) -> dict[str, Any]:
     logger.info(f"Write key: {write_key}")
 
     try:
-    # send hello world data to segment using metrics-utility
+        # send hello world data to segment using metrics-utility
         segment = StorageSegment(write_key=write_key, debug=True)
-        segment.put("hello_world", 'metrics_service_hell_world',dict={"message": message})
+        segment.put(
+            artifact_name="hello_world",
+            dict={"message": message},
+            event_name="metrics_service_hello_world"
+        )
         success = True
+        error = None
     except Exception as e:
         logger.error(f"Error sending hello world data to segment: {str(e)}")
         success = False

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -9,7 +9,7 @@ import logging
 import os
 import time
 from typing import Any
-fro
+from django.conf import settings
 
 from django.utils import timezone
 
@@ -361,13 +361,18 @@ def send_to_segment(**kwargs) -> dict[str, Any]:
     Send JSON data to Segment.com for analytics using metrics-utility.
     """
     # Simple task that just prints hello world for now
-    message = "Will be seding data"
+    message = "Will be seding data 2"
     logger.info(f"Task executing: {message}")
+
+    # obtain write key from django conf
+    write_key = settings.SEGMENT_WRITE_KEY
+    logger.info(f"Write key: {write_key}")
 
     return create_task_result(
         "success",
         {
             "message": message,
+            "write_key": write_key,
         },
     )
 


### PR DESCRIPTION
# [AAP-[54494](https://issues.redhat.com/browse/AAP-54494)] 

Simple task that is calling utility command for sending the data to segment.com

Task is also generating human readable message Id for identifying which data chunks in segment belong to single task.

# Testing

You should login to the segment.com and create developer account. Here you should add new source - HTTP API source.

Then you must generate API key that should be exported in command line where you run the service as:
METRICS_SERVICE_SEGMENT_WRITE_KEY

Then go to the admin panel:
http://localhost:8000/admin/tasks/task/

Click add task, name and function name: send_to_segment_hello_world

Fill the date and time and it should run. For rerun, you can see in tasks ability to reset to pending in dropdown menu.

Note that testing it in the admin task system (task rerun) causes occasinal multiple reruns - this should be fixed separately, it is not caused by this PR, this seems error in tasking system (either implemenation of admin GUI, or dispatcherd itself).


