### PR TITLE
execute_db_task: move handle_post_execution before recurring status reset

### DIFF
--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -394,16 +394,17 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
 
         update_task_status(task, execution, status=status, result_data=result, error_message=error_message)
 
+        log_task_execution(task.name, "completed", f"Task execution finished with status: {status}")
+
+        # Handle post-execution tasks
+        handle_post_execution(task)
+
         # For recurring tasks, reset status to pending for next execution
         if task.is_recurring:
             task.status = "pending"
             task._skip_signals = True
             task.save()
             logger.info(f"Reset recurring task {task.name} (ID: {task.id}) status to pending for next execution")
-        log_task_execution(task.name, "completed", f"Task execution finished with status: {status}")
-
-        # Handle post-execution tasks
-        handle_post_execution(task)
 
         return result
 


### PR DESCRIPTION
`handle_post_execution` only triggers dependent tasks when `task.status == 'completed'`
so `trigger_dependent_tasks` would never run for recurring tasks - fixing that