### PR TITLE
dispatcherd: set .brokers.pg_notify.config from Django when null

### DIFF
--- a/apps/tasks/dispatcherd_config.py
+++ b/apps/tasks/dispatcherd_config.py
@@ -25,6 +25,57 @@ def get_config_file_path() -> Path:
     return project_root / "config" / "dispatcherd.yaml"
 
 
+def fallback_dispatcherd_config() -> dict[str, Any]:
+    return {
+        "version": 2,
+        "brokers": {
+            "pg_notify": {
+                "config": None,
+                "channels": [
+                    "metrics_tasks",
+                    "metrics_cleanup",
+                    "metrics_notifications",
+                    "metrics_collectors",
+                    "metrics_utility",
+                ],
+            },
+        },
+        "service": {
+            "pool_kwargs": {"max_workers": 4},
+        },
+    }
+
+
+def load_dispatcherd_config(path) -> dict[str, Any]:
+    import yaml
+
+    try:
+        with open(path) as f:
+            return yaml.safe_load(f)
+    except Exception:
+        logger.warning(f"Failed to load configuration from {path}, using default")
+        return fallback_dispatcherd_config()
+
+
+def pg_config_from_django_settings() -> dict[str, Any]:
+    """
+    Build dispatcherd .brokers.pg_notify.config configuration fragment from Django database settings.
+    """
+    from django.conf import settings as django_settings
+
+    # Get database configuration
+    db_config = django_settings.DATABASES["default"]
+
+    # Create PostgreSQL connection config
+    return {
+        "dbname": db_config["NAME"],
+        "user": db_config["USER"],
+        "password": db_config["PASSWORD"],
+        "host": db_config["HOST"],
+        "port": db_config["PORT"],
+    }
+
+
 def setup_dispatcherd_config() -> None:
     """
     Setup dispatcherd configuration from file or Django settings.
@@ -46,13 +97,30 @@ def setup_dispatcherd_config() -> None:
         if config_file.exists():
             # Use configuration file
             logger.info(f"Configuring dispatcherd from file: {config_file}")
-            os.environ["DISPATCHERD_CONFIG_FILE"] = str(config_file)
-            dispatcherd.config.setup()
+            config = load_dispatcherd_config(config_file)
         else:
             # Fallback to Django settings-based configuration
-            logger.info("Configuration file not found, using Django settings")
-            config = build_config_from_django_settings()
-            dispatcherd.config.setup(config)
+            logger.info("Configuration file not found, using fallback")
+            config = fallback_dispatcherd_config()
+
+        # Update database connection in config
+        if "brokers" not in config:
+            config["brokers"] = {}
+        if "pg_notify" not in config["brokers"]:
+            config["brokers"]["pg_notify"] = {}
+        if "config" not in config["brokers"]["pg_notify"]:
+            config["brokers"]["pg_notify"]["config"] = None
+
+        # Update from Django settings
+        if config["brokers"]["pg_notify"]["config"] is None:
+            pg_config = pg_config_from_django_settings()
+            config["brokers"]["pg_notify"]["config"] = pg_config
+            logger.info(
+                f"Updated dispatcherd config for database: {pg_config['host']}:{pg_config['port']}/{pg_config['dbname']}"
+            )
+
+        # Setup dispatcherd
+        dispatcherd.config.setup(config)
 
         # Mark as configured
         dispatcherd.config._configured = True
@@ -66,58 +134,7 @@ def setup_dispatcherd_config() -> None:
         raise
 
 
-def build_config_from_django_settings() -> dict[str, Any]:
-    """
-    Build dispatcherd configuration from Django database settings.
-
-    Returns:
-        Dictionary containing dispatcherd configuration
-    """
-    try:
-        from django.conf import settings as django_settings
-
-        # Get database configuration
-        db_config = django_settings.DATABASES["default"]
-
-        # Create PostgreSQL connection config
-        pg_config = {
-            "dbname": db_config["NAME"],
-            "user": db_config["USER"],
-            "password": db_config["PASSWORD"],
-            "host": db_config["HOST"],
-            "port": db_config["PORT"],
-        }
-
-        # Build dispatcherd configuration
-        config = {
-            "version": 2,
-            "brokers": {
-                "pg_notify": {
-                    "config": pg_config,
-                    "channels": [
-                        "metrics_tasks",
-                        "metrics_cleanup",
-                        "metrics_notifications",
-                        "metrics_collectors",
-                        "metrics_utility",
-                    ],
-                },
-            },
-            "service": {
-                "pool_kwargs": {"max_workers": 4},
-            },
-        }
-
-        logger.info(
-            f"Built dispatcherd config for database: {pg_config['host']}:{pg_config['port']}/{pg_config['dbname']}"
-        )
-        return config
-
-    except Exception as e:
-        logger.error(f"Failed to build config from Django settings: {e}")
-        raise
-
-
+# FIXME: duplicate of setup_dispatcherd_config - merge
 def ensure_dispatcherd_configured() -> None:
     """
     Ensure dispatcherd is configured before attempting to submit tasks.
@@ -138,60 +155,6 @@ def ensure_dispatcherd_configured() -> None:
         raise
     except Exception as e:
         logger.error(f"Failed to ensure dispatcherd configuration: {e}")
-        raise
-
-
-def update_config_with_database_settings() -> None:
-    """
-    Update the dispatcherd YAML config file with current Django database settings.
-
-    This function reads the current Django database configuration and updates
-    the dispatcherd.yaml file with the correct database connection parameters.
-    """
-    try:
-        import yaml
-        from django.conf import settings as django_settings
-
-        config_file = get_config_file_path()
-
-        # Read existing config
-        if config_file.exists():
-            with open(config_file) as f:
-                config = yaml.safe_load(f)
-        else:
-            config = {}
-
-        # Get Django database settings
-        db_config = django_settings.DATABASES["default"]
-
-        # Update database connection in config
-        if "brokers" not in config:
-            config["brokers"] = {}
-        if "pg_notify" not in config["brokers"]:
-            config["brokers"]["pg_notify"] = {}
-
-        config["brokers"]["pg_notify"]["config"] = {
-            "dbname": db_config["NAME"],
-            "user": db_config["USER"],
-            "password": db_config["PASSWORD"],
-            "host": db_config["HOST"],
-            "port": db_config["PORT"],
-        }
-
-        # Ensure config directory exists
-        config_file.parent.mkdir(parents=True, exist_ok=True)
-
-        # Write updated config
-        with open(config_file, "w") as f:
-            yaml.dump(config, f, default_flow_style=False, sort_keys=False)
-
-        logger.info(f"Updated dispatcherd config file: {config_file}")
-
-    except ImportError:
-        logger.error("PyYAML not available for config file updates")
-        raise
-    except Exception as e:
-        logger.error(f"Failed to update config file: {e}")
         raise
 
 

--- a/config/dispatcherd.yaml
+++ b/config/dispatcherd.yaml
@@ -6,14 +6,7 @@ version: 2
 
 brokers:
   pg_notify:
-    config:
-      # Database connection - configured for current Django settings
-      dbname: 'metrics_service'
-      user: 'metrics_service'
-      password: 'metrics_service'
-      host: '127.0.0.1'
-      port: '5432'
-
+    config: null # overwritten by setup_dispatcherd_config
     channels:
       - 'metrics_tasks' # Main task execution channel
       - 'metrics_cleanup' # Cleanup and maintenance tasks

--- a/tests/unit/tasks/test_dispatcherd_config.py
+++ b/tests/unit/tasks/test_dispatcherd_config.py
@@ -7,18 +7,15 @@ full code coverage.
 
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-import yaml
 
 from apps.tasks.dispatcherd_config import (
-    build_config_from_django_settings,
     ensure_dispatcherd_configured,
     get_config_file_path,
     get_queue_for_function,
     setup_dispatcherd_config,
-    update_config_with_database_settings,
 )
 
 
@@ -79,111 +76,7 @@ class TestSetupDispatcherdConfig:
     # error handling) are difficult to implement due to the _configured check in
     # setup_dispatcherd_config interacting poorly with MagicMock's hasattr behavior.
     # The function is adequately tested through integration tests and the individual
-    # helper functions (get_config_file_path, build_config_from_django_settings) are
-    # thoroughly tested below.
-
-
-class TestBuildConfigFromDjangoSettings:
-    """Tests for build_config_from_django_settings function."""
-
-    @patch("django.conf.settings")
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_builds_valid_config(self, mock_logger, mock_settings):
-        """Test that function builds valid dispatcherd config from Django settings."""
-        mock_settings.DATABASES = {
-            "default": {
-                "NAME": "test_db",
-                "USER": "test_user",
-                "PASSWORD": "test_pass",
-                "HOST": "localhost",
-                "PORT": "5432",
-            }
-        }
-
-        config = build_config_from_django_settings()
-
-        assert config["version"] == 2
-        assert "brokers" in config
-        assert "pg_notify" in config["brokers"]
-        assert config["brokers"]["pg_notify"]["config"]["dbname"] == "test_db"
-        assert config["brokers"]["pg_notify"]["config"]["user"] == "test_user"
-        assert config["brokers"]["pg_notify"]["config"]["password"] == "test_pass"  # noqa: S105
-        assert config["brokers"]["pg_notify"]["config"]["host"] == "localhost"
-        assert config["brokers"]["pg_notify"]["config"]["port"] == "5432"
-
-    @patch("django.conf.settings")
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_includes_all_channels(self, mock_logger, mock_settings):
-        """Test that config includes all required channels."""
-        mock_settings.DATABASES = {
-            "default": {
-                "NAME": "test_db",
-                "USER": "test_user",
-                "PASSWORD": "test_pass",
-                "HOST": "localhost",
-                "PORT": "5432",
-            }
-        }
-
-        config = build_config_from_django_settings()
-
-        channels = config["brokers"]["pg_notify"]["channels"]
-        assert "metrics_tasks" in channels
-        assert "metrics_cleanup" in channels
-        assert "metrics_notifications" in channels
-        assert "metrics_collectors" in channels
-        assert "metrics_utility" in channels
-
-    @patch("django.conf.settings")
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_includes_service_config(self, mock_logger, mock_settings):
-        """Test that config includes service configuration."""
-        mock_settings.DATABASES = {
-            "default": {
-                "NAME": "test_db",
-                "USER": "test_user",
-                "PASSWORD": "test_pass",
-                "HOST": "localhost",
-                "PORT": "5432",
-            }
-        }
-
-        config = build_config_from_django_settings()
-
-        assert "service" in config
-        assert "pool_kwargs" in config["service"]
-        assert config["service"]["pool_kwargs"]["max_workers"] == 4
-
-    @patch("django.conf.settings")
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_logs_database_info(self, mock_logger, mock_settings):
-        """Test that function logs database connection info."""
-        mock_settings.DATABASES = {
-            "default": {
-                "NAME": "test_db",
-                "USER": "test_user",
-                "PASSWORD": "test_pass",
-                "HOST": "localhost",
-                "PORT": "5432",
-            }
-        }
-
-        build_config_from_django_settings()
-
-        mock_logger.info.assert_called_once()
-        assert "localhost:5432/test_db" in str(mock_logger.info.call_args)
-
-    @patch("django.conf.settings")
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_raises_on_missing_settings(self, mock_logger, mock_settings):
-        """Test that function raises exception when Django settings are invalid."""
-        mock_settings.DATABASES = {}
-
-        with pytest.raises(KeyError):
-            build_config_from_django_settings()
-
-        mock_logger.error.assert_called()
-        assert "Failed to build config from Django settings" in str(mock_logger.error.call_args)
+    # helper functions (get_config_file_path) are thoroughly tested below.
 
 
 class TestEnsureDispatcherdConfigured:
@@ -211,173 +104,6 @@ class TestEnsureDispatcherdConfigured:
             ensure_dispatcherd_configured()
 
         mock_logger.error.assert_called_with("Dispatcherd not available")
-
-
-class TestUpdateConfigWithDatabaseSettings:
-    """Tests for update_config_with_database_settings function."""
-
-    @patch("django.conf.settings")
-    @patch("apps.tasks.dispatcherd_config.get_config_file_path")
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_updates_existing_config_file(self, mock_logger, mock_get_path, mock_settings):
-        """Test that function updates existing config file with Django settings."""
-        existing_config = {
-            "version": 1,
-            "brokers": {"pg_notify": {"config": {"dbname": "old_db"}}},
-        }
-        mock_settings.DATABASES = {
-            "default": {
-                "NAME": "new_db",
-                "USER": "new_user",
-                "PASSWORD": "new_pass",
-                "HOST": "new_host",
-                "PORT": "5433",
-            }
-        }
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        mock_path.parent = MagicMock()
-        mock_get_path.return_value = mock_path
-
-        with patch("builtins.open", mock_open(read_data=yaml.dump(existing_config))):
-            update_config_with_database_settings()
-
-        mock_logger.info.assert_called_with(f"Updated dispatcherd config file: {mock_path}")
-
-    @patch("django.conf.settings")
-    @patch("apps.tasks.dispatcherd_config.get_config_file_path")
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_creates_new_config_file_when_not_exists(self, mock_logger, mock_get_path, mock_settings):
-        """Test that function creates new config file when it doesn't exist."""
-        mock_settings.DATABASES = {
-            "default": {
-                "NAME": "test_db",
-                "USER": "test_user",
-                "PASSWORD": "test_pass",
-                "HOST": "localhost",
-                "PORT": "5432",
-            }
-        }
-        mock_path = MagicMock()
-        mock_path.exists.return_value = False
-        mock_path.parent = MagicMock()
-        mock_get_path.return_value = mock_path
-
-        MagicMock()
-        with patch("builtins.open", mock_open()):
-            update_config_with_database_settings()
-
-        # Verify parent directory was created
-        mock_path.parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
-
-    @patch("django.conf.settings")
-    @patch("apps.tasks.dispatcherd_config.get_config_file_path")
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_preserves_version_in_config(self, mock_logger, mock_get_path, mock_settings):
-        """Test that function preserves version in config when updating."""
-        existing_config = {"version": 2, "other_key": "other_value"}
-        mock_settings.DATABASES = {
-            "default": {
-                "NAME": "test_db",
-                "USER": "test_user",
-                "PASSWORD": "test_pass",
-                "HOST": "localhost",
-                "PORT": "5432",
-            }
-        }
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        mock_path.parent = MagicMock()
-        mock_get_path.return_value = mock_path
-
-        written_data = None
-
-        def write_side_effect(data, *args, **kwargs):
-            nonlocal written_data
-            written_data = data
-
-        with (
-            patch("builtins.open", mock_open(read_data=yaml.dump(existing_config))),
-            patch("yaml.dump", side_effect=write_side_effect),
-        ):
-            update_config_with_database_settings()
-
-    @patch("django.conf.settings")
-    @patch("apps.tasks.dispatcherd_config.get_config_file_path")
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_updates_database_connection_params(self, mock_logger, mock_get_path, mock_settings):
-        """Test that function updates database connection parameters correctly."""
-        existing_config = {"brokers": {"pg_notify": {"config": {}}}}
-        mock_settings.DATABASES = {
-            "default": {
-                "NAME": "metrics_db",
-                "USER": "metrics_user",
-                "PASSWORD": "secret_pass",
-                "HOST": "db.example.com",
-                "PORT": "5432",
-            }
-        }
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        mock_path.parent = MagicMock()
-        mock_get_path.return_value = mock_path
-
-        captured_configs = []
-
-        def yaml_dump_side_effect(data, f, **kwargs):
-            captured_configs.append(data)
-
-        with (
-            patch("builtins.open", mock_open(read_data=yaml.dump(existing_config))),
-            patch("yaml.dump", side_effect=yaml_dump_side_effect),
-        ):
-            update_config_with_database_settings()
-
-        assert len(captured_configs) > 0, "yaml.dump was not called"
-        updated_config = captured_configs[0]
-        assert isinstance(updated_config, dict), f"Expected dict but got {type(updated_config)}"
-        assert "brokers" in updated_config, f"'brokers' key not found in {updated_config.keys()}"
-        db_config = updated_config["brokers"]["pg_notify"]["config"]
-        assert db_config["dbname"] == "metrics_db"
-        assert db_config["user"] == "metrics_user"
-        assert db_config["password"] == "secret_pass"  # noqa: S105
-        assert db_config["host"] == "db.example.com"
-        assert db_config["port"] == "5432"
-
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_raises_on_yaml_import_error(self, mock_logger):
-        """Test that function raises ImportError when PyYAML is not available."""
-        with patch.dict("sys.modules", {"yaml": None}), pytest.raises(ImportError):
-            update_config_with_database_settings()
-
-        mock_logger.error.assert_called_with("PyYAML not available for config file updates")
-
-    @patch("django.conf.settings")
-    @patch("apps.tasks.dispatcherd_config.get_config_file_path")
-    @patch("apps.tasks.dispatcherd_config.logger")
-    def test_raises_on_file_write_error(self, mock_logger, mock_get_path, mock_settings):
-        """Test that function raises exception on file write errors."""
-        mock_settings.DATABASES = {
-            "default": {
-                "NAME": "test_db",
-                "USER": "test_user",
-                "PASSWORD": "test_pass",
-                "HOST": "localhost",
-                "PORT": "5432",
-            }
-        }
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        mock_get_path.return_value = mock_path
-
-        with (
-            patch("builtins.open", side_effect=OSError("Permission denied")),
-            pytest.raises(IOError, match="Permission denied"),
-        ):
-            update_config_with_database_settings()
-
-        mock_logger.error.assert_called()
-        assert "Failed to update config file" in str(mock_logger.error.call_args)
 
 
 class TestGetQueueForFunction:


### PR DESCRIPTION
split dispatcherd_config logic into fallback config, loading config, computing db config from django settings,

and update setup_dispatcherd_config to load the config if found, use fallback otherwise, and update the config from django db settings when null

removed unused update_config_with_database_settings

draft: untested, some of the removed test should just be changed to test the new code