### PR TITLE
Fix duplicit tasks in scheduler

### DIFF
--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -271,6 +271,8 @@ class UnifiedTaskScheduler:
             for task in immediate_tasks:
                 if task.id not in self._db_task_jobs and task.is_ready_to_run():
                     logger.info(f"Found new immediate task: {task.name} (ID: {task.id}) - executing now")
+                    # Track immediate task to prevent duplicate submissions
+                    self._db_task_jobs[task.id] = f"db_immediate_{task.id}"
                     self._execute_database_task(task.id)
                     new_immediate += 1
 


### PR DESCRIPTION
Fix potential duplicit tasks for immediate_tasks, they should be added to scheduled tasks that are hold in memory in order to not run them again.

This can happen in scenario, where the scheduler sees pending immediate task - send it to dispatcherd, but dispatcherd can be computing something else - it goes to queue. Then the next scheduler round runs, see it pending and executes it again - this will create duplicate.

Not to mention that this will shut down the system, since dispatcherd may not recover from it, because it can fire tasks in neverending loop, if the immediate task will take longer than scheduler loop.