### PR TITLE
Disable tasks UI for production

### DIFF
--- a/apps/api/v1/tasks/views.py
+++ b/apps/api/v1/tasks/views.py
@@ -34,8 +34,7 @@ Task Functions:
     - execute_db_task: Database operations
 
 Security:
-    - Authentication required for all operations
-    - RBAC permissions via DAB integration
+    - Developer mode must be enabled (DEVELOPER_MODE_ENABLED=True)
     - Input validation for all task parameters
     - Safe task function execution with proper isolation
     - Audit logging for all task operations
@@ -49,9 +48,9 @@ from django.utils import timezone
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
+from apps.core.permissions import DeveloperModeRequired
 from apps.core.utils import build_error_response
 from apps.tasks.models import Task, TaskExecution
 
@@ -72,11 +71,13 @@ class TaskViewSet(BaseViewSet):
     This ViewSet provides all the functionality from the manage_tasks.py command
     converted to REST API endpoints including creation, listing, monitoring,
     and control.
+
+    NOTE: This ViewSet is only accessible when DEVELOPER_MODE_ENABLED is True.
     """
 
     queryset = Task.objects.select_related("created_by").all()
     serializer_class = TaskSerializer
-    permission_classes = [AllowAny]  # Temporary for dashboard access
+    permission_classes = [DeveloperModeRequired]
     ordering_fields = ["id", "name", "status", "priority", "scheduled_time", "created", "started_at", "completed_at"]
     ordering = ["-id"]
 
@@ -577,11 +578,13 @@ class TaskViewSet(BaseViewSet):
 class TaskExecutionViewSet(BaseViewSet):
     """
     ViewSet for TaskExecution model to monitor task execution history.
+
+    NOTE: This ViewSet is only accessible when DEVELOPER_MODE_ENABLED is True.
     """
 
     queryset = TaskExecution.objects.select_related("task").all()
     serializer_class = TaskExecutionSerializer
-    permission_classes = [AllowAny]  # Temporary for dashboard access
+    permission_classes = [DeveloperModeRequired]
     ordering_fields = ["started_at", "completed_at", "execution_time_seconds", "status"]
     ordering = ["-started_at"]
 

--- a/apps/core/permissions.py
+++ b/apps/core/permissions.py
@@ -1,5 +1,5 @@
 """
-Custom permission classes for handling system auditor RBAC.
+Custom permission classes for handling system auditor RBAC and developer mode.
 
 This module provides Django REST Framework permission classes that integrate
 system auditor functionality with Django Ansible Base (DAB) RBAC permission
@@ -11,6 +11,8 @@ Classes:
     SystemAuditorAwarePermissions: Hybrid permission class that maintains DAB RBAC
         for regular users while providing system auditors with read-only access
         to all resources.
+    DeveloperModeRequired: Permission class that only allows access when
+        DEVELOPER_MODE_ENABLED is True.
 
 Permission Flow:
     1. Anonymous users: Denied access
@@ -23,16 +25,24 @@ Security Considerations:
     - Write operations (POST, PUT, PATCH, DELETE) are explicitly denied for system auditors
     - All permission checks are performed at both view and object levels
     - Integrates seamlessly with existing DAB RBAC infrastructure
+    - Developer mode endpoints are only accessible when DEVELOPER_MODE_ENABLED is True
 
 Usage:
     Apply to ViewSets that need system auditor support:
 
     class MyViewSet(BaseViewSet):
         permission_classes = [SystemAuditorAwarePermissions]
+
+    Apply to ViewSets that require developer mode:
+
+    class TaskViewSet(BaseViewSet):
+        permission_classes = [DeveloperModeRequired]
 """
 
 from ansible_base.rbac.api.permissions import AnsibleBaseObjectPermissions
-from rest_framework.permissions import SAFE_METHODS
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+from metrics_service.settings import DYNACONF
 
 
 class SystemAuditorAwarePermissions(AnsibleBaseObjectPermissions):
@@ -83,3 +93,35 @@ class SystemAuditorAwarePermissions(AnsibleBaseObjectPermissions):
 
         # For regular users, use DAB RBAC
         return super().has_object_permission(request, view, obj)
+
+
+class DeveloperModeRequired(BasePermission):
+    """
+    Permission class that only allows access when DEVELOPER_MODE_ENABLED is True.
+
+    Use this for development/debugging endpoints that should not be accessible
+    in production environments, such as the Tasks API and Dashboard.
+
+    The setting can be controlled via:
+    - Environment variable: METRICS_SERVICE_DEVELOPER_MODE_ENABLED=true
+    - config/settings.yaml: DEVELOPER_MODE_ENABLED: true
+
+    Example behavior:
+        Developer Mode ON:  GET /api/v1/tasks/ → 200 OK
+        Developer Mode OFF: GET /api/v1/tasks/ → 403 Forbidden
+
+    Usage:
+        class TaskViewSet(BaseViewSet):
+            permission_classes = [DeveloperModeRequired]
+    """
+
+    message = "This endpoint is only available when developer mode is enabled."
+
+    def has_permission(self, request, view):
+        """Check if developer mode is enabled via DYNACONF."""
+        developer_mode = DYNACONF.get("DEVELOPER_MODE_ENABLED", False)
+        return bool(developer_mode)
+
+    def has_object_permission(self, request, view, obj):
+        """Object-level permission check delegates to view-level check."""
+        return self.has_permission(request, view)

--- a/apps/core/permissions.py
+++ b/apps/core/permissions.py
@@ -40,9 +40,8 @@ Usage:
 """
 
 from ansible_base.rbac.api.permissions import AnsibleBaseObjectPermissions
+from django.conf import settings
 from rest_framework.permissions import SAFE_METHODS, BasePermission
-
-from metrics_service.settings import DYNACONF
 
 
 class SystemAuditorAwarePermissions(AnsibleBaseObjectPermissions):
@@ -118,8 +117,8 @@ class DeveloperModeRequired(BasePermission):
     message = "This endpoint is only available when developer mode is enabled."
 
     def has_permission(self, request, view):
-        """Check if developer mode is enabled via DYNACONF."""
-        developer_mode = DYNACONF.get("DEVELOPER_MODE_ENABLED", False)
+        """Check if developer mode is enabled via Django settings."""
+        developer_mode = getattr(settings, "DEVELOPER_MODE_ENABLED", False)
         return bool(developer_mode)
 
     def has_object_permission(self, request, view, obj):

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -1,13 +1,40 @@
 """
 Dashboard views for task management and monitoring.
+
+NOTE: The dashboard is only accessible when DEVELOPER_MODE_ENABLED is True.
 """
 
-from django.http import HttpRequest, HttpResponse
+from functools import wraps
+
+from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 from django.shortcuts import render
 from django.views.decorators.http import require_safe
 
+from metrics_service.settings import DYNACONF
+
+
+def require_developer_mode(view_func):
+    """
+    Decorator that restricts access to views when developer mode is disabled.
+
+    Returns 403 Forbidden with a descriptive message when DEVELOPER_MODE_ENABLED is False.
+    """
+
+    @wraps(view_func)
+    def wrapper(request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        developer_mode = DYNACONF.get("DEVELOPER_MODE_ENABLED", False)
+        if not developer_mode:
+            return HttpResponseForbidden(
+                "The dashboard is only available when developer mode is enabled. "
+                "Set METRICS_SERVICE_DEVELOPER_MODE_ENABLED=true to enable."
+            )
+        return view_func(request, *args, **kwargs)
+
+    return wrapper
+
 
 @require_safe
+@require_developer_mode
 def dashboard_view(request: HttpRequest) -> HttpResponse:
     """
     Main dashboard view for task management.
@@ -15,6 +42,8 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
     This view renders the task dashboard interface with real-time
     task monitoring and management capabilities. All task data is
     fetched dynamically from the database via API endpoints.
+
+    NOTE: Only accessible when DEVELOPER_MODE_ENABLED is True.
 
     Args:
         request: HTTP request object

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -6,11 +6,10 @@ NOTE: The dashboard is only accessible when DEVELOPER_MODE_ENABLED is True.
 
 from functools import wraps
 
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
 from django.shortcuts import render
 from django.views.decorators.http import require_safe
-
-from metrics_service.settings import DYNACONF
 
 
 def require_developer_mode(view_func):
@@ -22,7 +21,7 @@ def require_developer_mode(view_func):
 
     @wraps(view_func)
     def wrapper(request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        developer_mode = DYNACONF.get("DEVELOPER_MODE_ENABLED", False)
+        developer_mode = getattr(settings, "DEVELOPER_MODE_ENABLED", False)
         if not developer_mode:
             return HttpResponseForbidden(
                 "The dashboard is only available when developer mode is enabled. "

--- a/metrics_service/settings/defaults.py
+++ b/metrics_service/settings/defaults.py
@@ -23,6 +23,10 @@ SECRET_KEY = "dev-secret-key-change-in-production"
 # Override with METRICS_SERVICE_DEBUG environment variable
 DEBUG = False
 
+# Developer mode flag for enabling development-specific features
+# Override with METRICS_SERVICE_DEVELOPER_MODE environment variable
+DEVELOPER_MODE = False
+
 ALLOWED_HOSTS = ["*"]
 
 # Service identification for AAP

--- a/metrics_service/settings/defaults.py
+++ b/metrics_service/settings/defaults.py
@@ -24,8 +24,8 @@ SECRET_KEY = "dev-secret-key-change-in-production"
 DEBUG = False
 
 # Developer mode flag for enabling development-specific features
-# Override with METRICS_SERVICE_DEVELOPER_MODE environment variable
-DEVELOPER_MODE = False
+# Override with METRICS_SERVICE_DEVELOPER_MODE_ENABLED environment variable
+DEVELOPER_MODE_ENABLED = False
 
 ALLOWED_HOSTS = ["*"]
 

--- a/metrics_service/settings/test.py
+++ b/metrics_service/settings/test.py
@@ -172,6 +172,7 @@ LOGGING = {
 
 # Disable dispatcherd during tests to avoid background processes
 DISPATCHERD_ENABLED = False
+DEVELOPER_MODE_ENABLED = True
 
 # Disable feature enables during tests
 FEATURE_ENABLED = {

--- a/tests/unit/core/test_developer_mode_permissions.py
+++ b/tests/unit/core/test_developer_mode_permissions.py
@@ -1,0 +1,42 @@
+"""
+Unit tests for Developer Mode permission functionality.
+
+Tests that development endpoints are properly restricted when developer mode is disabled.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestDeveloperModeDisabled(TestCase):
+    """Test that endpoints are blocked when developer mode is disabled."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass123")
+
+    @override_settings(DEVELOPER_MODE_ENABLED=False)
+    def test_tasks_api_returns_403_when_developer_mode_disabled(self):
+        """Test that tasks API returns 403 when developer mode is disabled."""
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get("/api/v1/tasks/")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @override_settings(DEVELOPER_MODE_ENABLED=False)
+    def test_dashboard_returns_403_when_developer_mode_disabled(self):
+        """Test that dashboard returns 403 when developer mode is disabled."""
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get("/dashboard/")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
# [AAP-59463]
https://issues.redhat.com/browse/AAP-59463

AI Assistance:
Assisted-by: Cursor

## Description

Add settings DEVELOPER_MODE_ENABLED as default false

Using dynaconf, task API is disabled and dashboard is also disabled using permission classes.

## Testing

As default, DEVELOPER MODE is disabled
try:
curl -s -u admin:admin -w "\nHTTP Status: %{http_code}\n" http://localhost:8000/api/v1/tasks/ | head -20

This should return forbidden

This also too:
http://localhost:8000/dashboard/


For testing everything is enabled, you can set as env variable:

export METRICS_SERVICE_DEVELOPER_MODE_ENABLED=true
And run the server again

http://localhost:8000/dashboard/

