### PR TITLE
Minor change to fix Dispatcherd settings being hardencoded

### DIFF
--- a/apps/tasks/dispatcherd_config.py
+++ b/apps/tasks/dispatcherd_config.py
@@ -32,6 +32,11 @@ def setup_dispatcherd_config() -> None:
     This function configures dispatcherd to work with the metrics service
     database and task queues. It can be called from any process that needs
     to submit tasks to dispatcherd.
+
+    Database connection settings always come from Django's DATABASES["default"]
+    which properly respects METRICS_SERVICE_DATABASES__default__* environment
+    variables. The YAML config file is used for other settings (channels,
+    queue routing, logging, etc.).
     """
     try:
         import dispatcherd.config
@@ -44,15 +49,16 @@ def setup_dispatcherd_config() -> None:
         config_file = get_config_file_path()
 
         if config_file.exists():
-            # Use configuration file
-            logger.info(f"Configuring dispatcherd from file: {config_file}")
-            os.environ["DISPATCHERD_CONFIG_FILE"] = str(config_file)
-            dispatcherd.config.setup()
+            # Load config file and merge with Django database settings
+            logger.info(f"Loading dispatcherd config from file: {config_file}")
+            config = _load_config_with_django_db(config_file)
         else:
-            # Fallback to Django settings-based configuration
+            # Build config entirely from Django settings
             logger.info("Configuration file not found, using Django settings")
             config = build_config_from_django_settings()
-            dispatcherd.config.setup(config)
+
+        # Configure dispatcherd with the merged config
+        dispatcherd.config.setup(config)
 
         # Mark as configured
         dispatcherd.config._configured = True
@@ -64,6 +70,57 @@ def setup_dispatcherd_config() -> None:
     except Exception as e:
         logger.error(f"Failed to configure dispatcherd: {e}")
         raise
+
+
+def _load_config_with_django_db(config_file: Path) -> dict[str, Any]:
+    """
+    Load dispatcherd config from YAML file but override database settings
+    with Django's DATABASES["default"] configuration.
+
+    This ensures database connection settings always come from Django settings
+    which properly respects METRICS_SERVICE_DATABASES__default__* environment
+    variables via Dynaconf.
+
+    Args:
+        config_file: Path to the dispatcherd YAML configuration file
+
+    Returns:
+        Configuration dictionary with database settings from Django
+    """
+    import yaml
+    from django.conf import settings as django_settings
+
+    # Load the YAML config file
+    with open(config_file) as f:
+        config = yaml.safe_load(f) or {}
+
+    # Get database configuration from Django settings
+    db_config = django_settings.DATABASES["default"]
+
+    # Build PostgreSQL connection config from Django settings
+    pg_config = {
+        "dbname": db_config["NAME"],
+        "user": db_config["USER"],
+        "password": db_config["PASSWORD"],
+        "host": db_config["HOST"],
+        "port": db_config["PORT"],
+    }
+
+    # Ensure brokers section exists
+    if "brokers" not in config:
+        config["brokers"] = {}
+    if "pg_notify" not in config["brokers"]:
+        config["brokers"]["pg_notify"] = {}
+
+    # Override database config with Django settings
+    config["brokers"]["pg_notify"]["config"] = pg_config
+
+    logger.info(
+        f"Configured dispatcherd with Django database settings: "
+        f"{pg_config['host']}:{pg_config['port']}/{pg_config['dbname']}"
+    )
+
+    return config
 
 
 def build_config_from_django_settings() -> dict[str, Any]:

--- a/config/dispatcherd.yaml
+++ b/config/dispatcherd.yaml
@@ -1,18 +1,18 @@
 ---
 # Dispatcherd Configuration for Metrics Service
 # This configuration enables task scheduling and execution across processes
+#
+# NOTE: Database connection settings are automatically loaded from Django's
+# DATABASES["default"] configuration at runtime. This allows proper support
+# for METRICS_SERVICE_DATABASES__default__* environment variables.
+# Do NOT add hardcoded database credentials here.
 
 version: 2
 
 brokers:
   pg_notify:
-    config:
-      # Database connection - configured for current Django settings
-      dbname: 'metrics_service'
-      user: 'metrics_service'
-      password: 'metrics_service'
-      host: '127.0.0.1'
-      port: '5432'
+    # Database config is injected at runtime from Django settings
+    # See apps/tasks/dispatcherd_config.py::_load_config_with_django_db()
 
     channels:
       - 'metrics_tasks' # Main task execution channel


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Dispatcherd now loads database settings from Django and injects them into the YAML config at runtime, removing hardcoded credentials.
> 
> - **Dispatcherd configuration**:
>   - Merge YAML config with Django `DATABASES["default"]` and pass explicit config to `dispatcherd.config.setup()` in `apps/tasks/dispatcherd_config.py`.
>   - Add `_load_config_with_django_db(config_file)` to override `brokers.pg_notify.config` with Django DB settings.
> - **Config file**:
>   - Remove hardcoded database credentials from `config/dispatcherd.yaml`; document that DB settings are injected at runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53c6e65164672272fb12b33b5ed382a6cd289f38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->