### PR TITLE
Update metrics-utility dependency to allow for version upgrades in py…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "dispatcherd>=2025.5.21",
     "croniter>=1.3.0",
     "apscheduler>=3.10.0",
-    "metrics-utility==0.7.20251112",
+    "metrics-utility>=0.7.20251112",
     "django-prometheus>=2.3.1",
     "pip>=25.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -880,7 +880,7 @@ requires-dist = [
     { name = "factory-boy", marker = "extra == 'test'", specifier = ">=3.3" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12" },
     { name = "ldap-filter", marker = "extra == 'ldap'", specifier = ">=1.0.1" },
-    { name = "metrics-utility", specifier = "==0.7.20251112" },
+    { name = "metrics-utility", specifier = ">=0.7.20251112" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "pip", specifier = ">=25.2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.4" },


### PR DESCRIPTION
…project.toml and uv.lock

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `metrics-utility` from an exact pin to a minimum version in `pyproject.toml` and `uv.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d20040a410e9d404050777e97adda277bb16dcd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->