### PR TITLE
[AAP-54495] Adds url prefix env var logic

### DIFF
--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -4,6 +4,7 @@ Dashboard views for task management and monitoring.
 NOTE: The dashboard is only accessible when DEVELOPER_MODE_ENABLED is True.
 """
 
+import os
 from functools import wraps
 
 from django.conf import settings
@@ -52,9 +53,14 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
     """
     from apps.tasks.tasks import TASK_FUNCTIONS
 
+    prefix = os.getenv("METRICS_URL_PREFIX")
+
+    root_url = "/api/v1/"
+    if prefix:
+        root_url = f"/{prefix}{root_url}"
     context = {
         "page_title": "Task Dashboard",
-        "api_base_url": "/api/v1/",
+        "api_base_url": root_url,
         "user": request.user,
         "available_functions": list(TASK_FUNCTIONS.keys()),
         "database_driven": True,  # Flag to indicate this uses database tasks


### PR DESCRIPTION

# [AAP-54495] 

## Description
In aap-dev the task add modal on the dashboard does not work properly because it queries an endpoint that aap-dev doesn't know about, and thus the queries fail.  With this change we will be able to utilize an env var in aap-dev and in another other service to tell metrics-service about the url prefix for metrics-service.


Most of the remaining work will go into aap-dev repo but this pr will block that work from merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Dashboard now derives `api_base_url` from `METRICS_URL_PREFIX` (if set), instead of a hardcoded `/api/v1/`.
> 
> - **Dashboard backend**:
>   - Read `METRICS_URL_PREFIX` env var to build `root_url` (defaults to `/api/v1/`, prefixed when set).
>   - Update `dashboard_view` context to use computed `api_base_url`.
>   - Add `os` import for env var access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b1a7b401fa62a48649b70a036f4bf0450d0cb18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->