### PR TITLE
AAP-54495 - Adds correct env var for url prefix.

### DIFF
--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -53,7 +53,7 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
     """
     from apps.tasks.tasks import TASK_FUNCTIONS
 
-    prefix = os.getenv("METRICS_URL_PREFIX")
+    prefix = os.getenv("METRICS_SERVICE_URL_PREFIX")
 
     root_url = "/api/v1/"
     if prefix:


### PR DESCRIPTION
# [AAP-54495] 
Continuation of https://github.com/ansible/metrics-service/pull/69.  I intended for this line of code to be part of that pr.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches dashboard API base URL prefix to read from `METRICS_SERVICE_URL_PREFIX` instead of `METRICS_URL_PREFIX`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56d51be2b7d1dd86bfa63ab3e4b1d85638fc4e94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->