### PR TITLE
Adds default segment write key and setting validation.

### DIFF
--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -260,12 +260,6 @@ TASK_METADATA = {
         "description": "Dedicated task to send anonymized data to Segment.com",
         "parameters": {
             "data": {"type": "object", "required": True, "description": "Anonymized data to send"},
-            "segment_write_key": {
-                "type": "string",
-                "default": "NA",
-                "description": DESC_SEGMENT_WRITE_KEY,
-                "sensitive": True,
-            },
             "user_id": {"type": "string", "default": "anonymous-user", "description": DESC_USER_ID_TRACKING},
             "event_name": {"type": "string", "default": "metrics_sent", "description": DESC_EVENT_NAME_TRACKING},
         },

--- a/apps/tasks/tasks_collector.py
+++ b/apps/tasks/tasks_collector.py
@@ -573,7 +573,7 @@ def _prepare_segment_data(
     return segment_data
 
 
-def _send_to_segment(segment_write_key: str, user_id: str, event_name: str, segment_data: dict) -> str:
+def _send_to_segment(user_id: str, event_name: str, segment_data: dict) -> str:
     """Send data to Segment.com using direct analytics.track() for guaranteed single message."""
     try:
         import json
@@ -595,10 +595,12 @@ def _send_to_segment(segment_write_key: str, user_id: str, event_name: str, segm
             return "segment_not_available"
 
         # Import and configure Segment directly
+        from django.conf import settings
         from segment import analytics
 
-        analytics.write_key = segment_write_key
-
+        # Use Django settings to access Dynaconf-managed value (not os.getenv which
+        # only reads environment variables and ignores settings.yaml defaults)
+        analytics.write_key = getattr(settings, "METRICS_SERVICE_SEGMENT_WRITE_KEY", None)
         # Send one simple track message
         analytics.track(
             user_id=user_id,
@@ -647,7 +649,6 @@ def full_process(**kwargs) -> dict[str, Any]:
             - since (str): Start date for collection (optional)
             - until (str): End date for collection (optional)
             - salt (str): Salt for anonymization (optional, default: 'default-salt')
-            - segment_write_key (str): Segment.com write key for analytics (required)
             - user_id (str): User ID for Segment tracking (optional)
             - event_name (str): Event name for Segment tracking (default: 'metrics_collected')
             - collectors (list): List of specific collectors to run (optional)
@@ -673,15 +674,10 @@ def full_process(**kwargs) -> dict[str, Any]:
         until = kwargs.get("until")
         # Generate a unique UUID4 salt if not provided
         salt = kwargs.get("salt", str(uuid.uuid4()))
-        segment_write_key = kwargs.get("segment_write_key", "NA")
         user_id = kwargs.get("user_id", str(uuid.uuid4()))
         event_name = kwargs.get("event_name", "metrics_collected")
         collectors_list = kwargs.get("collectors", ["anonymized_rollups", "config", "job_host_summary"])
         send_to_segment = kwargs.get("send_to_segment", True)
-
-        # segment_write_key now has a default value, but still validate it's present
-        if send_to_segment and not segment_write_key:
-            return create_task_result("error", error="segment_write_key is required when send_to_segment is True")
 
         # Step 1: Collect metrics using multiple collectors
         log_task_execution("full_process", "processing", "Collecting metrics data")
@@ -694,7 +690,7 @@ def full_process(**kwargs) -> dict[str, Any]:
         # Step 3: Send to Segment.com if enabled
         segment_status = "skipped"
         if send_to_segment and SEGMENT_AVAILABLE:
-            segment_status = _send_to_segment(segment_write_key, user_id, event_name, segment_data)
+            segment_status = _send_to_segment(user_id, event_name, segment_data)
 
         return create_task_result(
             "success",
@@ -870,7 +866,6 @@ def full_process_anonymize(**kwargs) -> dict[str, Any]:
             - since (str): Start date for collection (optional)
             - until (str): End date for collection (optional)
             - salt (str): Salt for anonymization (optional, auto-generated UUID4)
-            - segment_write_key (str): Segment.com write key for analytics (has default)
             - user_id (str): User ID for Segment tracking (default: 'anonymous-user')
             - event_name (str): Event name for Segment tracking (default: 'anonymized_metrics_collected')
             - send_to_segment (bool): Whether to send data to Segment (default: True)
@@ -897,7 +892,6 @@ def full_process_anonymize(**kwargs) -> dict[str, Any]:
         until = kwargs.get("until")
         # Generate a unique UUID4 salt if not provided
         salt = kwargs.get("salt", str(uuid.uuid4()))
-        segment_write_key = kwargs.get("segment_write_key", "NA")
         user_id = kwargs.get("user_id", "anonymous-user")
         event_name = kwargs.get("event_name", "anonymized_metrics_collected")
         send_to_segment = kwargs.get("send_to_segment", True)
@@ -950,7 +944,7 @@ def full_process_anonymize(**kwargs) -> dict[str, Any]:
                 },
             }
             # Send actual anonymized data to Segment
-            segment_status = _send_to_segment(segment_write_key, user_id, event_name, segment_data)
+            segment_status = _send_to_segment(user_id, event_name, segment_data)
 
         return create_task_result(
             "success",
@@ -996,12 +990,11 @@ def debug_segment_messages(**kwargs) -> dict[str, Any]:
             "message": "Debug test - this should be ONE message only",
         }
 
-        segment_write_key = kwargs.get("segment_write_key", "NA")
         user_id = kwargs.get("user_id", "debug-user")
         event_name = kwargs.get("event_name", "debug_segment_test")
 
         # Call _send_to_segment directly with debug data
-        result = _send_to_segment(segment_write_key, user_id, event_name, debug_data)
+        result = _send_to_segment(user_id, event_name, debug_data)
 
         return create_task_result(
             "success",
@@ -1031,7 +1024,6 @@ def test_segment_track(**kwargs) -> dict[str, Any]:
     Args:
         **kwargs: Task data containing test parameters:
             - message (str): Test message content (default: 'Test message from metrics-service')
-            - segment_write_key (str): Segment.com write key (has default)
             - user_id (str): User ID for tracking (default: 'test-user')
             - event_name (str): Event name (default: 'test_track_message')
 
@@ -1043,7 +1035,6 @@ def test_segment_track(**kwargs) -> dict[str, Any]:
     try:
         # Get parameters from kwargs
         test_message = kwargs.get("message", "Test message from metrics-service")
-        segment_write_key = kwargs.get("segment_write_key", "NA")
         user_id = kwargs.get("user_id", "test-user")
         event_name = kwargs.get("event_name", "test_track_message")
 
@@ -1061,7 +1052,7 @@ def test_segment_track(**kwargs) -> dict[str, Any]:
 
         # Send to Segment.com if available
         if SEGMENT_AVAILABLE:
-            segment_status = _send_to_segment(segment_write_key, user_id, event_name, test_data)
+            segment_status = _send_to_segment(user_id, event_name, test_data)
         else:
             segment_status = "segment_not_available"
 
@@ -1099,7 +1090,6 @@ def send_to_segment(**kwargs) -> dict[str, Any]:
     Args:
         **kwargs: Task data containing transmission parameters:
             - data (dict): Anonymized data to send (required)
-            - segment_write_key (str): Segment.com write key (has default)
             - user_id (str): User ID for tracking (default: 'anonymous-user')
             - event_name (str): Event name (default: 'metrics_sent')
 
@@ -1114,13 +1104,12 @@ def send_to_segment(**kwargs) -> dict[str, Any]:
         if not anonymized_data:
             return create_task_result("error", error="No data provided for transmission")
 
-        segment_write_key = kwargs.get("segment_write_key", "NA")
         user_id = kwargs.get("user_id", "anonymous-user")
         event_name = kwargs.get("event_name", "metrics_sent")
 
         # Send to Segment.com if available
         if SEGMENT_AVAILABLE:
-            segment_status = _send_to_segment(segment_write_key, user_id, event_name, anonymized_data)
+            segment_status = _send_to_segment(user_id, event_name, anonymized_data)
         else:
             segment_status = "segment_not_available"
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -9,7 +9,7 @@ default:
   ALLOWED_HOSTS:
     - localhost
     - 127.0.0.1
-
+  METRICS_SERVICE_SEGMENT_WRITE_KEY: 'test-segment-write-key-change-in-production'
   # Database Configuration
   DATABASES:
     default:
@@ -70,7 +70,7 @@ development:
   DEBUG: false
   CORS_ALLOW_ALL_ORIGINS: true
   # Inherits SECRET_KEY and database settings from default - safe for local dev
-  
+
   LOGGING:
     version: 1
     disable_existing_loggers: false

--- a/metrics_service/settings/__init__.py
+++ b/metrics_service/settings/__init__.py
@@ -48,6 +48,14 @@ DYNACONF = factory(
                 "operations": "SECRET_KEY must be set in production. Set METRICS_SERVICE_SECRET_KEY environment variable.",
             },
         ),
+        Validator(
+            "METRICS_SERVICE_SEGMENT_WRITE_KEY",
+            must_exist=True,
+            ne="test-segment-write-key-change-in-production",  # Default test key
+            messages={
+                "operations": "METRICS_SERVICE_SEGMENT_WRITE_KEY must not use default value in production.",
+            },
+        ),
         # Database: Ensure critical database settings exist
         Validator("DATABASES.default.NAME", must_exist=True),
         Validator("DATABASES.default.HOST", must_exist=True),

--- a/tests/unit/tasks/test_tasks_collector_complete_coverage.py
+++ b/tests/unit/tasks/test_tasks_collector_complete_coverage.py
@@ -456,12 +456,12 @@ class TestTasksCollectorFullCoverage(TestCase):
 
         # Test when segment not available
         with patch("apps.tasks.tasks_collector.SEGMENT_AVAILABLE", False):
-            result = _send_to_segment("key", "user", "event", {"data": "test"})
+            result = _send_to_segment("user", "event", {"data": "test"})
             assert result == "segment_not_available"
 
         # Test successful send
         with patch("segment.analytics") as mock_analytics:
-            result = _send_to_segment("key", "user", "event", {"data": "test"})
+            result = _send_to_segment("user", "event", {"data": "test"})
             mock_analytics.track.assert_called_once()
             mock_analytics.flush.assert_called_once()
             assert result == "success"
@@ -469,7 +469,7 @@ class TestTasksCollectorFullCoverage(TestCase):
         # Test exception during send
         with patch("segment.analytics") as mock_analytics:
             mock_analytics.track.side_effect = Exception("Segment error")
-            result = _send_to_segment("key", "user", "event", {"data": "test"})
+            result = _send_to_segment("user", "event", {"data": "test"})
             assert "error:" in result
             mock_logger.error.assert_called()
 
@@ -500,7 +500,7 @@ class TestTasksCollectorFullCoverage(TestCase):
         full_process(send_to_segment=False)
 
         # Test with segment_write_key validation
-        full_process(send_to_segment=True, segment_write_key="")
+        full_process(send_to_segment=True)
 
         # Test with all parameters
         kwargs = {
@@ -508,7 +508,6 @@ class TestTasksCollectorFullCoverage(TestCase):
             "since": "2024-01-01T00:00:00Z",
             "until": "2024-12-31T23:59:59Z",
             "salt": "custom-salt",
-            "segment_write_key": "test-key",
             "user_id": "test-user",
             "event_name": "test-event",
             "collectors": ["config"],
@@ -617,7 +616,7 @@ class TestTasksCollectorFullCoverage(TestCase):
         debug_segment_messages()
 
         # Test with custom parameters
-        kwargs = {"segment_write_key": "test-key", "user_id": "debug-user", "event_name": "debug-event"}
+        kwargs = {"user_id": "debug-user", "event_name": "debug-event"}
         debug_segment_messages(**kwargs)
 
         # Test exception handling
@@ -640,7 +639,6 @@ class TestTasksCollectorFullCoverage(TestCase):
         # Test with custom parameters
         kwargs = {
             "message": "Custom test message",
-            "segment_write_key": "test-key",
             "user_id": "test-user",
             "event_name": "test-event",
         }
@@ -801,7 +799,7 @@ class TestTasksCollectorFullCoverage(TestCase):
         # Test _send_to_segment error logging
         with patch("apps.tasks.tasks_collector.SEGMENT_AVAILABLE", True), patch("segment.analytics") as mock_analytics:
             mock_analytics.track.side_effect = Exception("Segment error")
-            _send_to_segment("key", "user", "event", {"data": "test"})
+            _send_to_segment("user", "event", {"data": "test"})
             mock_logger.error.assert_called()
 
     def test_segment_import_paths(self):


### PR DESCRIPTION
# [AAP-54495] Segment write key and settings validation

## Description
This pr adds functionality to consume a segement write key from an env var.  It does provide a default 1 too, and mandates that the default 1 not be used in production because it won't work.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use settings-managed Segment write key with a default and production validator; refactor tasks to remove `segment_write_key` parameter and update tests accordingly.
> 
> - **Settings**:
>   - Add `METRICS_SERVICE_SEGMENT_WRITE_KEY` default in `config/settings.yaml`.
>   - Enforce production validation via Dynaconf `Validator` in `metrics_service/settings/__init__.py`.
> - **Segment integration refactor**:
>   - `_send_to_segment` now reads `analytics.write_key` from `settings.METRICS_SERVICE_SEGMENT_WRITE_KEY`; removes `segment_write_key` arg.
>   - Remove `segment_write_key` from task parameters/metadata and all call sites (`full_process`, `full_process_anonymize`, `send_to_segment`, `test_segment_track`, `debug_segment_messages`).
>   - Drop prior runtime validation of missing `segment_write_key`.
> - **Tests**:
>   - Update unit tests to new `_send_to_segment(user_id, event_name, data)` signature and removal of `segment_write_key` kwargs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccd6883c81d4ddfaa25217e883ab2ee4a812dafb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->