### PR TITLE
Fix broken view reference in SettingSerializer

### DIFF
--- a/apps/dynamic_settings/v1/serializers.py
+++ b/apps/dynamic_settings/v1/serializers.py
@@ -7,7 +7,7 @@ from rest_framework import serializers
 from ..models import Setting
 
 
-class SettingSerializer(serializers.HyperlinkedModelSerializer):
+class SettingSerializer(serializers.ModelSerializer):
     """
     Serializer for Setting model following AAP and Controller patterns.
 
@@ -18,7 +18,6 @@ class SettingSerializer(serializers.HyperlinkedModelSerializer):
         model = Setting
         fields = [
             "id",
-            "url",
             "setting_key",
             "current_value",
             "previous_value",
@@ -28,14 +27,12 @@ class SettingSerializer(serializers.HyperlinkedModelSerializer):
         ]
         read_only_fields = [
             "id",
-            "url",
             "previous_value",
             "last_modified_by",
             "created",
             "modified",
         ]
         extra_kwargs = {
-            "url": {"view_name": "api:v1:settings-detail"},
             "setting_key": {"help_text": "The unique key for this setting (e.g., 'DEBUG', 'SECRET_KEY')"},
             "current_value": {"help_text": "The current value of this setting (JSON serialized)"},
         }


### PR DESCRIPTION
Change SettingSerializer from HyperlinkedModelSerializer to ModelSerializer and remove the url field that referenced non-existent view "api:v1:settings-detail".

The dynamic_settings API uses a singleton pattern without individual detail endpoints, so the url field was unnecessary.

# [AAP-XXXXX] Brief Title Describing the Change

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
- Why is this change needed?
- How does this change address the issue?

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces HyperlinkedModelSerializer with ModelSerializer for SettingSerializer and removes the obsolete url field and related config.
> 
> - **API / Serializers**:
>   - **`apps/dynamic_settings/v1/serializers.py`**:
>     - Change `SettingSerializer` base from `HyperlinkedModelSerializer` to `ModelSerializer`.
>     - Remove `url` from `fields`, `read_only_fields`, and `extra_kwargs` (including `view_name`).
>     - Retain help text for `setting_key` and `current_value`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be5f555830bc1132a24b3deaba16d742be182ef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->