### PR TITLE
Env var cleanup - use METRICS_SERVICE_MODE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 *.pot
 *.pyc
 __pycache__/
-local_settings.py
 staticfiles/
 .env
 media

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Metrics Service uses [Dynaconf](https://www.dynaconf.com/) for settings manageme
 **Development Mode** (default):
 
 > [!IMPORTANT]
-> The following example assumes those values exported as environment variables, 
+> The following example assumes those values exported as environment variables,
 > to set on the settings.local.py file remove the `METRICS_SERVICE_` prefix.
 
 ```bash
@@ -238,7 +238,6 @@ DJANGO_SETTINGS_MODULE=metrics_service.settings
 METRICS_SERVICE_MODE=development
 METRICS_SERVICE_SECRET_KEY=dev-secret-key-change-in-production
 METRICS_SERVICE_DEBUG="true"
-METRICS_SERVICE_DEVELOPER_MODE_ENABLED="true"
 METRICS_SERVICE_ALLOWED_HOSTS='["localhost","127.0.0.1","metrics-service","0.0.0.0"]'
 
 # Database

--- a/apps/core/permissions.py
+++ b/apps/core/permissions.py
@@ -1,18 +1,8 @@
 """
-Custom permission classes for developer mode.
-
-This module provides Django REST Framework permission classes that integrate
-with Django Ansible Base (DAB) RBAC permission system.
-
-Classes:
-    DeveloperModeRequired: Permission class that only allows access when
-        DEVELOPER_MODE_ENABLED is True.
-
-Security Considerations:
-    - Developer mode endpoints are only accessible when DEVELOPER_MODE_ENABLED is True
+Custom permission classes for develpment mode
 
 Usage:
-    Apply to ViewSets that require developer mode:
+    Apply to ViewSets that require development mode:
 
     class TaskViewSet(BaseViewSet):
         permission_classes = [DeveloperModeRequired]
@@ -24,14 +14,9 @@ from rest_framework.permissions import BasePermission
 
 class DeveloperModeRequired(BasePermission):
     """
-    Permission class that only allows access when DEVELOPER_MODE_ENABLED is True.
+    Permission class that only allows access when METRICS_SERVICE_MODE=development
 
-    Use this for development/debugging endpoints that should not be accessible
-    in production environments, such as the Tasks API and Dashboard.
-
-    The setting can be controlled via:
-    - Environment variable: METRICS_SERVICE_DEVELOPER_MODE_ENABLED=true
-    - config/settings.yaml: DEVELOPER_MODE_ENABLED: true
+    Used for endpoints that shouldn't be accessible in production, such as the Tasks API & Dashboard
 
     Example behavior:
         Developer Mode ON:  GET /api/v1/tasks/ → 200 OK
@@ -42,12 +27,11 @@ class DeveloperModeRequired(BasePermission):
             permission_classes = [DeveloperModeRequired]
     """
 
-    message = "This endpoint is only available when developer mode is enabled."
+    message = "This endpoint is only available when development mode is enabled."
 
     def has_permission(self, request, view):
-        """Check if developer mode is enabled via Django settings."""
-        developer_mode = getattr(settings, "DEVELOPER_MODE_ENABLED", False)
-        return bool(developer_mode)
+        """Check if development mode is enabled via Django settings."""
+        return settings.MODE == "development"
 
     def has_object_permission(self, request, view, obj):
         """Object-level permission check delegates to view-level check."""

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -2,7 +2,6 @@
 Dashboard views for task management and monitoring.
 """
 
-import os
 from functools import wraps
 
 from django.conf import settings
@@ -49,11 +48,11 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
 
     from apps.tasks.tasks import TASK_FUNCTIONS
 
-    prefix = os.getenv("METRICS_SERVICE_URL_PREFIX")
+    prefix = settings.URL_PREFIX
 
     root_url = "/api/v1/"
-    if prefix:
-        root_url = f"/{prefix}{root_url}"
+    if prefix and prefix != "/":
+        root_url = f"/{prefix}/{root_url}".replace("//", "/")
 
     context = {
         "page_title": "Task Dashboard",

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -1,7 +1,5 @@
 """
 Dashboard views for task management and monitoring.
-
-NOTE: The dashboard is only accessible when DEVELOPER_MODE_ENABLED is True.
 """
 
 import os
@@ -13,20 +11,19 @@ from django.shortcuts import render
 from django.views.decorators.http import require_safe
 
 
-def require_developer_mode(view_func):
+def require_development_mode(view_func):
     """
-    Decorator that restricts access to views when developer mode is disabled.
+    Decorator that restricts access to views when development mode is disabled.
 
-    Returns 403 Forbidden with a descriptive message when DEVELOPER_MODE_ENABLED is False.
+    Returns 403 Forbidden with a descriptive message when METRICS_SERVICE_MODE=development
     """
 
     @wraps(view_func)
     def wrapper(request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        developer_mode = getattr(settings, "DEVELOPER_MODE_ENABLED", False)
-        if not developer_mode:
+        if settings.MODE != "development":
             return HttpResponseForbidden(
-                "The dashboard is only available when developer mode is enabled. "
-                "Set METRICS_SERVICE_DEVELOPER_MODE_ENABLED=true to enable."
+                "The dashboard is only available when development mode is enabled. "
+                "Set METRICS_SERVICE_MODE=development to enable."
             )
         return view_func(request, *args, **kwargs)
 
@@ -34,7 +31,7 @@ def require_developer_mode(view_func):
 
 
 @require_safe
-@require_developer_mode
+@require_development_mode
 def dashboard_view(request: HttpRequest) -> HttpResponse:
     """
     Main dashboard view for task management.
@@ -43,14 +40,13 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
     task monitoring and management capabilities. All task data is
     fetched dynamically from the database via API endpoints.
 
-    NOTE: Only accessible when DEVELOPER_MODE_ENABLED is True.
-
     Args:
         request: HTTP request object
 
     Returns:
         HttpResponse: Rendered dashboard template
     """
+
     from apps.tasks.tasks import TASK_FUNCTIONS
 
     prefix = os.getenv("METRICS_SERVICE_URL_PREFIX")
@@ -58,6 +54,7 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
     root_url = "/api/v1/"
     if prefix:
         root_url = f"/{prefix}{root_url}"
+
     context = {
         "page_title": "Task Dashboard",
         "api_base_url": root_url,
@@ -65,4 +62,5 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
         "available_functions": list(TASK_FUNCTIONS.keys()),
         "database_driven": True,  # Flag to indicate this uses database tasks
     }
+
     return render(request, "dashboard.html", context)

--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -123,6 +123,9 @@ FEATURE_ENABLED = {
     "METRICS_COLLECTION_ENABLED": False,
 }
 
+# Used when generating API URLs in views, example "metrics-service"
+URL_PREFIX = None
+
 
 @post_hook
 def load_prometheus_middlewares(settings: Dynaconf) -> dict:

--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -7,12 +7,14 @@ from the `metrics_service.settings`.
 
 from dynaconf import Dynaconf, post_hook
 
+# Extra applications added after PSF templating
 extra_applications = [
     "django_prometheus",
     "django_extensions",
 ]
-"""Extra applications added after PSF templating."""
 
+# Default DAB applications layd out from PSF, add/remove according to the project needs,
+# adjust `pyproject` dab extra dependencies acording to apps added/removed here
 dab_applications = [
     "ansible_base.activitystream",
     "ansible_base.api_documentation",
@@ -23,33 +25,27 @@ dab_applications = [
     "ansible_base.rest_filters",
     "ansible_base.rest_pagination",
 ]
-"""Default DAB applications layd out from PSF, add/remove according to the project needs,
-adjust `pyproject` dab extra dependencies acording to apps added/removed here.
-"""
 
+# List of applications from the apps/ folder
 project_applications = [
     "apps.core",
     "apps.dynamic_settings",
     "apps.tasks",
     "apps.dashboard",
 ]
-"""List of applications from the apps/ folder."""
 
-
+# Final state of the INSTALLED_APPS that will merge with the rest of the settings
 INSTALLED_APPS = [
     "dynaconf_merge_unique",  # DO NOT REMOVE THIS
     *dab_applications,
     *project_applications,
     *extra_applications,
 ]
-"""Final state of the INSTALLED_APPS that will merge with the rest of the settings."""
 
-DEVELOPER_MODE_ENABLED = False
-"""Relax the permission system for developers"""
-
+# Enable debug mode
 DEBUG = False
-"""Enable debug mode"""
 
+# REST framework settings
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
@@ -74,16 +70,15 @@ REST_FRAMEWORK = {
     "DEFAULT_VERSION": "v1",
     "ALLOWED_VERSIONS": ["v1"],
 }
-"""REST framework settings."""
 
+# Title of Swagger the API documentation
 SPECTACULAR_SETTINGS__TITLE = "metrics_service API"
-"""Title of Swagger the API documentation."""
+# Description of Swagger the API documentation
 SPECTACULAR_SETTINGS__DESCRIPTION = "API documentation for the metrics_service"
-"""Description of Swagger the API documentation."""
+# Version of Swagger the API documentation
 SPECTACULAR_SETTINGS__VERSION = "v1"
-"""Version of Swagger the API documentation."""
+# Split components into request and response for generating clients
 SPECTACULAR_SETTINGS__COMPONENT_SPLIT_REQUEST = True
-"""Split components into request and response for generating clients."""
 
 CACHES = {
     "default": {
@@ -93,6 +88,7 @@ CACHES = {
 }
 CSRF_TRUSTED_ORIGINS = []
 
+# Databases settings, using PostgreSQL by default
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
@@ -119,14 +115,13 @@ DATABASES = {
         },
     },
 }
-"""Databases settings, using PostgreSQL by default."""
 
+# Feature flags
 # TODO: convert to DAB feature flags
 FEATURE_ENABLED = {
     "ANONYMIZED_DATA_COLLECTION": True,
     "METRICS_COLLECTION_ENABLED": False,
 }
-"""Feature flags."""
 
 
 @post_hook

--- a/apps/settings/test.py
+++ b/apps/settings/test.py
@@ -67,7 +67,6 @@ LOGGING = {
 
 # Disable dispatcherd during tests to avoid background processes
 DISPATCHERD_ENABLED = False
-DEVELOPER_MODE_ENABLED = True
 
 # Disable feature enables during tests
 FEATURE_ENABLED = {

--- a/apps/tasks/v1/views.py
+++ b/apps/tasks/v1/views.py
@@ -34,7 +34,6 @@ Task Functions:
     - hello_world: Test task
 
 Security:
-    - Developer mode must be enabled (DEVELOPER_MODE_ENABLED=True)
     - Input validation for all task parameters
     - Safe task function execution with proper isolation
     - Audit logging for all task operations
@@ -70,8 +69,6 @@ class TaskViewSet(BaseViewSet):
     This ViewSet provides all the functionality from the manage_tasks.py command
     converted to REST API endpoints including creation, listing, monitoring,
     and control.
-
-    NOTE: This ViewSet is only accessible when DEVELOPER_MODE_ENABLED is True.
     """
 
     queryset = Task.objects.select_related("created_by").all()
@@ -503,8 +500,6 @@ class TaskViewSet(BaseViewSet):
 class TaskExecutionViewSet(BaseViewSet):
     """
     ViewSet for TaskExecution model to monitor task execution history.
-
-    NOTE: This ViewSet is only accessible when DEVELOPER_MODE_ENABLED is True.
     """
 
     queryset = TaskExecution.objects.select_related("task").all()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,6 @@ services:
       METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode: prefer
       METRICS_SERVICE_ALLOWED_HOSTS: '["localhost","127.0.0.1","metrics-service","0.0.0.0"]'
       METRICS_SERVICE_DEBUG: "true"
-      METRICS_SERVICE_DEVELOPER_MODE_ENABLED: "true"
       METRICS_SERVICE_ANONYMIZED_DATA: "true"
       METRICS_SERVICE_METRICS_COLLECTION: "false"
       DJANGO_SETTINGS_MODULE: metrics_service.settings

--- a/settings.local.py.example
+++ b/settings.local.py.example
@@ -10,13 +10,15 @@ DEBUG = True
 
 # Database Configuration (PostgreSQL)
 # Using dunder notation for nested settings
-DATABASES__default__ENGINE = "django.db.backends.postgresql"
+
+# DATABASES__default__ENGINE = "django.db.backends.postgresql"
+# DATABASES__default__NAME = "metrics_service"
+# DATABASES__default__OPTIONS__sslmode = "prefer"
+# DATABASES__default__PORT = 5432
+# DATABASES__default__USER = "metrics_service"
+
 DATABASES__default__HOST = "127.0.0.1"
-DATABASES__default__PORT = 5432
-DATABASES__default__USER = "metrics_service"
 DATABASES__default__PASSWORD = "metrics_service"
-DATABASES__default__NAME = "metrics_service"
-DATABASES__default__OPTIONS__sslmode = "prefer"
 
 DATABASES__awx__HOST = "127.0.0.1"
 DATABASES__awx__PASSWORD = "mypassword"

--- a/settings.local.py.example
+++ b/settings.local.py.example
@@ -6,7 +6,7 @@
 # METRICS_SERVICE_LOG_LEVEL=DEBUG
 
 SECRET_KEY = "dev-secret-key-change-in-production"
-DEBUG = False
+DEBUG = True
 
 # Database Configuration (PostgreSQL)
 # Using dunder notation for nested settings

--- a/settings.local.py.example
+++ b/settings.local.py.example
@@ -21,9 +21,6 @@ DATABASES__default__OPTIONS__sslmode = "prefer"
 DATABASES__awx__HOST = "127.0.0.1"
 DATABASES__awx__PASSWORD = "mypassword"
 
-# Test Database Configuration
-TEST_DB_NAME = "test_metrics_service"
-
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
 
 # Service Configuration

--- a/tests/integration/test_urls_integration.py
+++ b/tests/integration/test_urls_integration.py
@@ -14,7 +14,7 @@ import contextlib
 import pytest
 from django.contrib.auth import get_user_model
 from django.http import Http404
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import NoReverseMatch, resolve, reverse
 from rest_framework.test import APIClient
 
@@ -202,6 +202,7 @@ class TestAuthenticationURLs(TestCase):
             username="testuser", email="test@example.com", password=get_test_password()
         )
 
+    @override_settings(MODE="development")
     def test_authentication_redirects(self):
         """Test authentication redirects."""
         # Test that unauthenticated users are redirected
@@ -221,6 +222,7 @@ class TestDashboardURLs(TestCase):
             username="testuser", email="test@example.com", password=get_test_password()
         )
 
+    @override_settings(MODE="development")
     def test_dashboard_access(self):
         """Test dashboard access through URLs."""
         # Test unauthenticated access
@@ -232,6 +234,7 @@ class TestDashboardURLs(TestCase):
         response = self.client.get("/dashboard/")
         assert response.status_code in [200, 302, 404]
 
+    @override_settings(MODE="development")
     def test_dashboard_subpages(self):
         """Test dashboard subpages."""
         # Test various dashboard subpages
@@ -423,6 +426,7 @@ class TestURLSecurity(TestCase):
             username="testuser", email="test@example.com", password=get_test_password()
         )
 
+    @override_settings(MODE="development")
     def test_secure_url_access(self):
         """Test that secure URLs require authentication."""
 

--- a/tests/unit/core/test_development_mode_permissions.py
+++ b/tests/unit/core/test_development_mode_permissions.py
@@ -1,7 +1,7 @@
 """
-Unit tests for Developer Mode permission functionality.
+Unit tests for development mode permission functionality.
 
-Tests that development endpoints are properly restricted when developer mode is disabled.
+Tests that development endpoints are properly restricted when development mode is disabled.
 """
 
 import pytest
@@ -15,26 +15,26 @@ User = get_user_model()
 
 @pytest.mark.unit
 @pytest.mark.django_db
-class TestDeveloperModeDisabled(TestCase):
-    """Test that endpoints are blocked when developer mode is disabled."""
+class TestDevelopmentModeDisabled(TestCase):
+    """Test that endpoints are blocked when development mode is disabled."""
 
     def setUp(self):
         """Set up test fixtures."""
         self.client = APIClient()
         self.user = User.objects.create_user(username="testuser", email="test@example.com", password="testpass123")  # noqa: S105
 
-    @override_settings(DEVELOPER_MODE_ENABLED=False)
-    def test_tasks_api_returns_403_when_developer_mode_disabled(self):
-        """Test that tasks API returns 403 when developer mode is disabled."""
+    @override_settings(MODE="production")
+    def test_tasks_api_returns_403_when_development_mode_disabled(self):
+        """Test that tasks API returns 403 when development mode is disabled."""
         self.client.force_authenticate(user=self.user)
 
         response = self.client.get("/api/v1/tasks/")
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    @override_settings(DEVELOPER_MODE_ENABLED=False)
-    def test_dashboard_returns_403_when_developer_mode_disabled(self):
-        """Test that dashboard returns 403 when developer mode is disabled."""
+    @override_settings(MODE="production")
+    def test_dashboard_returns_403_when_development_mode_disabled(self):
+        """Test that dashboard returns 403 when development mode is disabled."""
         self.client.force_authenticate(user=self.user)
 
         response = self.client.get("/dashboard/")

--- a/tests/unit/dashboard/test_dashboard_views.py
+++ b/tests/unit/dashboard/test_dashboard_views.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest, HttpResponse
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 
 from apps.core.models import User
 from apps.dashboard.views import dashboard_view
@@ -22,6 +22,7 @@ class TestDashboardViews(TestCase):
         self.factory = RequestFactory()
         self.user = User.objects.create_user(username="testuser", email="test@example.com")
 
+    @override_settings(MODE="development")
     @patch("apps.tasks.tasks.TASK_FUNCTIONS")
     def test_dashboard_view_with_anonymous_user(self, mock_task_functions):
         """Test dashboard view with anonymous user."""
@@ -39,6 +40,7 @@ class TestDashboardViews(TestCase):
         assert isinstance(response, HttpResponse)
         assert response.status_code == 200
 
+    @override_settings(MODE="development")
     @patch("apps.dashboard.views.render")
     @patch("apps.tasks.tasks.TASK_FUNCTIONS")
     def test_dashboard_view_context(self, mock_task_functions, mock_render):
@@ -84,6 +86,7 @@ class TestDashboardViews(TestCase):
         # Verify response is returned
         assert response == mock_response
 
+    @override_settings(MODE="development")
     @patch("apps.tasks.tasks.TASK_FUNCTIONS")
     def test_dashboard_view_empty_task_functions(self, mock_task_functions):
         """Test dashboard view when no task functions are available."""
@@ -110,6 +113,7 @@ class TestDashboardViews(TestCase):
         # This is indicated by the view having certain attributes
         assert hasattr(dashboard_view, "__wrapped__") or hasattr(dashboard_view, "view_func")
 
+    @override_settings(MODE="development")
     @patch("apps.tasks.tasks.TASK_FUNCTIONS")
     def test_dashboard_view_task_functions_import(self, mock_task_functions):
         """Test that TASK_FUNCTIONS is imported correctly within the view."""
@@ -149,6 +153,7 @@ class TestDashboardViews(TestCase):
         # Check return annotation
         assert sig.return_annotation == HttpResponse
 
+    @override_settings(MODE="development")
     @patch("apps.tasks.tasks.TASK_FUNCTIONS")
     def test_dashboard_view_superuser_access(self, mock_task_functions):
         """Test dashboard view access for superuser."""
@@ -181,6 +186,7 @@ class TestDashboardViews(TestCase):
         assert render
         assert require_safe
 
+    @override_settings(MODE="development")
     @patch("apps.tasks.tasks.TASK_FUNCTIONS")
     def test_dashboard_view_with_different_request_methods(self, mock_task_functions):
         """Test that dashboard view handles different request objects."""

--- a/tests/unit/tasks/test_tasks_api_views.py
+++ b/tests/unit/tasks/test_tasks_api_views.py
@@ -39,7 +39,7 @@ from tests.test_utils import get_test_password
 
 @pytest.mark.unit
 @pytest.mark.django_db
-@override_settings(DEVELOPER_MODE_ENABLED=True)
+@override_settings(MODE="development")
 class TestTaskViewSet(APITestCase):
     """Test TaskViewSet CRUD endpoints and custom actions."""
 
@@ -501,7 +501,7 @@ class TestTaskViewSet(APITestCase):
 
 @pytest.mark.unit
 @pytest.mark.django_db
-@override_settings(DEVELOPER_MODE_ENABLED=True)
+@override_settings(MODE="development")
 class TestTaskExecutionViewSet(APITestCase):
     """Test TaskExecutionViewSet endpoints."""
 
@@ -634,7 +634,7 @@ class TestTaskSerializers(TestCase):
 
 @pytest.mark.unit
 @pytest.mark.django_db
-@override_settings(DEVELOPER_MODE_ENABLED=True)
+@override_settings(MODE="development")
 class TestTaskFiltering(APITestCase):
     """Test task filtering, search, and pagination."""
 
@@ -705,16 +705,16 @@ class TestTaskPermissions(APITestCase):
             username="user", email="user@example.com", password=get_test_password()
         )
 
-    @override_settings(DEVELOPER_MODE_ENABLED=False)
-    def test_developer_mode_disabled_access_denied(self):
-        """Test requests are denied when developer mode is disabled."""
+    @override_settings(MODE="production")
+    def test_development_mode_disabled_access_denied(self):
+        """Test requests are denied when development mode is disabled."""
         url = reverse("tasks:v1:task-list")
         response = self.client.get(url)
 
-        # Should deny access when developer mode is disabled
+        # Should deny access when development mode is disabled
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    @override_settings(DEVELOPER_MODE_ENABLED=True)
+    @override_settings(MODE="development")
     def test_authenticated_user_can_list_tasks(self):
         """Test authenticated users can list tasks."""
         self.client.force_authenticate(user=self.regular_user)
@@ -724,7 +724,7 @@ class TestTaskPermissions(APITestCase):
 
         assert response.status_code == status.HTTP_200_OK
 
-    @override_settings(DEVELOPER_MODE_ENABLED=True)
+    @override_settings(MODE="development")
     def test_admin_user_full_access(self):
         """Test admin users have full access to task operations."""
         self.client.force_authenticate(user=self.admin_user)


### PR DESCRIPTION
Closes AAP-60451 (env var cleanup)
Related to AAP-62673 (metrics-service cleanup)
Related to AAP-60424 (less db config copies)
Related aap-dev PR: https://github.com/ansible/aap-dev/pull/404

`METRICS_SERVICE_MODE` has been added as part of the service framework work, and determines which  `app/settings/{mode}.py` gets used.

=> Replace DEVELOPER_MODE_ENABLED with MODE="development"
update tests to mock that mode now
(and s/developer/development/ so that we don't have both similar words there)

`local_settings.py` is no longer used, it's called `settings.local.py` now - update gitignore
update the `settings.local.py.example` to comment out bits already set in `app/settings/defaults.py`
`apps/settings/defaults.py`: move comments *above* the settings, instead of below each

remove last mentions of `TEST_DB_NAME`, handled by `app/settings/test.py` - django can dynamically create a prefixed name db

---

Obsolete env vars (not just by this pr):

* `METRICS_SERVICE_DEVELOPER_MODE_ENABLED` - replace with `METRICS_SERVICE_MODE`
* `METRICS_SERVICE_ENV` - replace with `METRICS_SERVICE_MODE`
* `METRICS_SERVICE_TEST_DB_NAME` - ensure test runs can create databases
* `METRICS_SERVICE_DB_*` - it's `METRICS_SERVICE_DATABASES__*__*` as per dynaconf
* `METRICS_URL_PREFIX` - replaced with `METRICS_SERVICE_URL_PREFIX`