### PR TITLE
cleanup, split compose into 4 containers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,6 +498,8 @@ But these only get applied during `manage.py metrics_service init-system-tasks`,
 
 Note: All metrics tasks are controlled by a single flag since anonymization requires collected data to work. This is an opt-out feature that sends anonymized usage data to Red Hat.
 
+(These can be overridden using environment variables as well, as in `METRICS_SERVICE_FEATURE_ENABLED__ANONYMIZED_DATA_COLLECTION=true`. Note the double underscore before the feature name.)
+
 **Automatic Database Initialization:**
 
 Feature flags are managed in the `dynamic_settings_setting` table:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,17 +469,19 @@ The project uses a custom User model (`core.User`) that extends AbstractDABUser 
 
 ### Feature Enabled Configuration
 
-Dispatcherd is permanently enabled. Other features can be controlled via the `FEATURE_ENABLED` setting:
+Optional features can be controlled via the `FEATURE_ENABLED` setting:
 
 ```python
 FEATURE_ENABLED = {
-    "ANONYMIZED_DATA_COLLECTION": True,  # Default enabled (customer opt-out)
+    "ANONYMIZED_DATA_COLLECTION": True,
 }
 ```
 
 **Environment Variable Mapping:**
 
-- `METRICS_SERVICE_FEATURE_ENABLED__ANONYMIZED_DATA_COLLECTION=true/false` → Controls all metrics collection and transmission
+- `METRICS_SERVICE_FEATURE_ENABLED__ANONYMIZED_DATA_COLLECTION=true/false` - Controls all metrics collection and transmission
+
+But these only get applied during `manage.py metrics_service init-system-tasks`, or when missing from DB.
 
 **Task Groups and Feature Flags:**
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ docker-compose exec metrics-service python manage.py createsuperuser
 Your service will be available at:
 
 - **Application**: http://localhost:8000
-- **API Documentation**: http://localhost:8000/api/docs/
-- **Admin Interface**: http://localhost:8000/admin/
+- **API Documentation**: http://localhost:8000/api/v1/docs/
 - **Task Dashboard**: http://localhost:8000/dashboard/
 
 ### Option 2: Local Development

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Tasks are automatically routed based on their properties:
 
 No manual intervention required - create a task and it's automatically processed!
 
+Dispatcher config lives in `apps/settings/dispatcherd.yaml` but can be overridden using `DISPATCHERD_CONFIG_FILE` (no prefix).
+
 ### Task Groups & Feature Flags
 
 We have these feature flags:
@@ -280,11 +282,6 @@ METRICS_SERVICE_DATABASES__default__USER=metrics_service
 METRICS_SERVICE_DATABASES__default__PASSWORD=metrics_service
 METRICS_SERVICE_DATABASES__default__NAME=metrics_service
 METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode=prefer
-
-# Task App
-METRICS_SERVICE_FEATURE_ENABLED__ANONYMIZED_DATA_COLLECTION="true"
-DISPATCHERD_CONFIG_FILE=/app/apps/settings/dispatcherd.yaml
-DISPATCHERD_ENABLED="true"
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Your service will be available at:
 ### Option 2: Local Development
 
 ```bash
-# Prerequisites: Python 3.11+, PostgreSQL 13+
+# Prerequisites: Python 3.12+, PostgreSQL 15+
 
 # Create virtual environment
 python -m venv venv

--- a/apps/settings/development.py
+++ b/apps/settings/development.py
@@ -3,29 +3,34 @@ Development environment overrides
 Inherits from ./defaults.py and adds dev-specific defaults
 """
 
-DEBUG = True
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
+
 ALLOW_SHARED_RESOURCE_CUSTOM_ROLES = False
 
-CSRF_TRUSTED_ORIGINS = [
-    "http://localhost:8000",
-    "http://127.0.0.1:8000",
-    "https://metrics-service:8000",
-]
-"""CSRF settings to allow origins to make requests, NOTE: Only use in development!"""
+SECRET_KEY = "dev-secret-key-change-in-production"
 
+# Cache settings - use dummy cache for development to avoid caching issues
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
     }
 }
-"""Cache settings - use dummy cache for development to avoid caching issues"""
 
+# CSRF settings to allow origins to make requests, NOTE: Only use in development!
+CSRF_TRUSTED_ORIGINS = [
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+    "https://metrics-service:8000",
+]
+
+DEBUG = True
+
+# Email backend for development (console output)
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-"""Email backend for development (console output)"""
 
+LOGGING__loggers__ansible_base__level = "DEBUG"
 LOGGING__loggers__django__level = "DEBUG"
 LOGGING__loggers__metrics_service__level = "DEBUG"
-LOGGING__loggers__ansible_base__level = "DEBUG"
 LOGGING__loggers = {
     "dynaconf_merge": True,
     # disable autoreload DEBUG - lists all watched files

--- a/apps/settings/test.py
+++ b/apps/settings/test.py
@@ -62,9 +62,6 @@ LOGGING = {
     },
 }
 
-# Disable dispatcherd during tests to avoid background processes
-DISPATCHERD_ENABLED = False
-
 # Disable feature enables during tests
 # NOTE: relies on get_feature_enabled_from_db falling back to directly using these settings when not in DB...
 # ...and on init-default-settings never happening during tests. If it does, @override_setings won't work.

--- a/apps/tasks/management/commands/metrics_service.py
+++ b/apps/tasks/management/commands/metrics_service.py
@@ -525,8 +525,7 @@ class Command(BaseCommand):
         """
         Start all 3 services as separate processes and monitor them.
 
-        This is the new simplified approach that directly spawns 3 processes
-        (like the Procfile commands) and exits when any one exits.
+        This is the new simplified approach that directly spawns 3 processes and exits when any one exits.
         """
         processes = []
         process_names = ["Django", "Dispatcher", "Scheduler"]

--- a/apps/tasks/settings.py
+++ b/apps/tasks/settings.py
@@ -1,10 +1,4 @@
 """Settings specific for tasks application."""
 
-DISPATCHERD_ENABLED = True
-"""Background Task Configuration (Dispatcherd)
-Dispatcherd is always enabled in this service (can be disabled in tests)
-Override with METRICS_SERVICE_DISPATCHERD_ENABLED environment variable"""
-
-
+# Segment Write Key
 SEGMENT_WRITE_KEY = "test-segment-write-key-change-in-production"
-"""Segment Write Key"""

--- a/settings.local.py.example
+++ b/settings.local.py.example
@@ -23,8 +23,6 @@ DATABASES__default__PASSWORD = "metrics_service"
 DATABASES__awx__HOST = "127.0.0.1"
 DATABASES__awx__PASSWORD = "mypassword"
 
-ALLOWED_HOSTS = ["localhost", "127.0.0.1", "0.0.0.0"]
-
 # Service Configuration
 ID = "generated-uuid"
 


### PR DESCRIPTION
draft, wip...

but...

* make sure we no longer need the `.env`  file and things have sane defaults
* make sure docker-compose only provides the vars that are needed
* clean up mentions of env vars which became just feature flags
* split Dockerfile into dev & prod - depending on whether /app is a volume
* split docker-compose app container into 4 - init, web, dispatcher, scheduler
* also add uv back for that one, mostly because the current txt requirements blow up, might undo this

... docker compose up now boots up and works :)

.. parts moved out to #115 and #117