### PR TITLE
dashboard: interpret METRICS_SERVICE_URL_PREFIX as actual prefix, not slug

### DIFF
--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -2,6 +2,7 @@
 Dashboard views for task management and monitoring.
 """
 
+import re
 from functools import wraps
 
 from django.conf import settings
@@ -29,6 +30,17 @@ def require_development_mode(view_func):
     return wrapper
 
 
+def url_for(path):
+    """
+    Transforms URL paths to use METRICS_SERVICE_URL_PREFIX, if present
+    When settings.URL_PREFIX is None, returns path prefixed with /api/
+    When settings.URL_PREFIX is set, returns path prefixed with /$prefix/, after slash sanitization
+    """
+
+    prefix = settings.URL_PREFIX or "/api/"
+    return re.sub(r"/+", "/", f"/{prefix}/{path}")
+
+
 @require_safe
 @require_development_mode
 def dashboard_view(request: HttpRequest) -> HttpResponse:
@@ -48,15 +60,9 @@ def dashboard_view(request: HttpRequest) -> HttpResponse:
 
     from apps.tasks.tasks import TASK_FUNCTIONS
 
-    prefix = settings.URL_PREFIX
-
-    root_url = "/api/v1/"
-    if prefix and prefix != "/":
-        root_url = f"/{prefix}/{root_url}".replace("//", "/")
-
     context = {
         "page_title": "Task Dashboard",
-        "api_base_url": root_url,
+        "api_base_url": url_for("/v1/"),  # /api/v1/ or /URL_PREFIX/v1/
         "user": request.user,
         "available_functions": list(TASK_FUNCTIONS.keys()),
         "database_driven": True,  # Flag to indicate this uses database tasks

--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -123,7 +123,7 @@ FEATURE_ENABLED = {
     "METRICS_COLLECTION_ENABLED": False,
 }
 
-# Used when generating API URLs in views, example "metrics-service"
+# Used when generating API URLs in views, example "/api/metrics/"; None means "/api/"
 URL_PREFIX = None
 
 


### PR DESCRIPTION
Issue: AAP-62516

Dashboard uses `METRICS_SERVICE_URL_PREFIX` to generate correct api urls for the JS frontend (development only) without it, `/api/v1/foo` is used, but with, say, an `/api/metrics/` prefix, `/api/metrics/v1/foo` will get used instead.

Previously, the value coming in was `metrics-service`, without slashes.
This changes the interpretation of the prefix to expect strings like `/api/` (default when None) or `/api/metrics/` as a prefix
(actually just better handling for '/' as a potential value, as this was mostly prepared in #87),
and adjusts the surrounding comments and docstrings accordingly.

(The reverse mapping is handled by the service_prefix middleware in apps.core.)