### PR TITLE
config updates

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,15 +43,48 @@ jobs:
 
       - name: "Run pytest"
         env:
-          METRICS_SERVICE_DATABASES__default__HOST: localhost
-          METRICS_SERVICE_DATABASES__default__PORT: 5432
-          METRICS_SERVICE_DATABASES__default__USER: metrics_service
-          METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
-          METRICS_SERVICE_DATABASES__default__NAME: metrics_service
-          METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode: disable
-          METRICS_SERVICE_DATABASES__awx__HOST: "127.0.0.1"
-          METRICS_SERVICE_DATABASES__awx__PASSWORD: mypassword
-          DJANGO_SETTINGS_MODULE: metrics_service.settings
-          METRICS_SERVICE_MODE: test
+          METRICS_SERVICE_DB_HOST: localhost
+          METRICS_SERVICE_DB_PORT: 5432
+          METRICS_SERVICE_DB_USER: metrics_service
+          METRICS_SERVICE_DB_PASSWORD: metrics_service
+          METRICS_SERVICE_TEST_DB_NAME: metrics_service
+          METRICS_SERVICE_DB_SSLMODE: disable
+          DJANGO_SETTINGS_MODULE: metrics_service.settings.test
         run: |
           uv run pytest -s -v --cov=. --cov-report=xml
+
+      - name: "Upload code coverage report"
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+
+      - name: "Save off PR number"
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: echo "PR $PR_NUM" > pr_number.txt
+
+      - name: "Upload PR number"
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt
+
+      - name: "Send code coverage report to Sonar Cloud (on push)"
+        uses: SonarSource/sonarqube-scan-action@v6
+        if: github.event_name != 'pull_request'
+        env:
+          SONAR_HOST_URL: https://sonarcloud.io
+          SONAR_ORGANIZATION: ansible
+          SONAR_PROJECT_KEY: ansible_metrics-service
+          SONAR_TOKEN: ${{ secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT }}
+        with:
+          projectBaseDir: .
+          args: >
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.organization=ansible
+            -Dsonar.projectKey=ansible_metrics-service
+            -Dsonar.python.coverage.reportPaths=coverage.xml

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,13 +43,16 @@ jobs:
 
       - name: "Run pytest"
         env:
-          METRICS_SERVICE_DB_HOST: localhost
-          METRICS_SERVICE_DB_PORT: 5432
-          METRICS_SERVICE_DB_USER: metrics_service
-          METRICS_SERVICE_DB_PASSWORD: metrics_service
-          METRICS_SERVICE_TEST_DB_NAME: metrics_service
-          METRICS_SERVICE_DB_SSLMODE: disable
-          DJANGO_SETTINGS_MODULE: metrics_service.settings.test
+          METRICS_SERVICE_DATABASES__default__HOST: localhost
+          METRICS_SERVICE_DATABASES__default__PORT: 5432
+          METRICS_SERVICE_DATABASES__default__USER: metrics_service
+          METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
+          METRICS_SERVICE_DATABASES__default__NAME: metrics_service
+          METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode: disable
+          METRICS_SERVICE_DATABASES__awx__HOST: "127.0.0.1"
+          METRICS_SERVICE_DATABASES__awx__PASSWORD: mypassword
+          DJANGO_SETTINGS_MODULE: metrics_service.settings
+          METRICS_SERVICE_MODE: test
         run: |
           uv run pytest -s -v --cov=. --cov-report=xml
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -77,7 +77,7 @@ jobs:
           path: pr_number.txt
 
       - name: "Send code coverage report to Sonar Cloud (on push)"
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
         if: github.event_name != 'pull_request'
         env:
           SONAR_HOST_URL: https://sonarcloud.io

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Validate artifact PR number against workflow run
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
         run: |
           PRS_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
@@ -60,7 +61,7 @@ jobs:
           fi
 
       - name: Get Additional PR Information
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d
         id: pr_info
         with:
           route: GET /repos/{repo}/pulls/{number}
@@ -91,7 +92,7 @@ jobs:
           PR_NUMBER: ${{ env.PR_NUMBER }}
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
         env:
           SONAR_HOST_URL: https://sonarcloud.io
           SONAR_ORGANIZATION: ansible

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -1,0 +1,108 @@
+name: SonarCloud Static Scans (PR)
+
+on:
+  workflow_run:
+    workflows:
+      - Pytest tests
+    types:
+      - completed
+
+permissions: read-all
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Static Scans (PR)
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch Code Coverage Report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Fetch PR Number
+        uses: actions/download-artifact@v4
+        with:
+          name: pr_number
+          path: pr-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Extract and validate PR Number
+        run: |
+          cat pr-artifact/pr_number.txt
+          VALID_PR=$(head -n1 pr-artifact/pr_number.txt | awk '{print $2}' | grep -E '^[0-9]+$') || true
+          if [ -z "$VALID_PR" ]; then
+            echo "Invalid PR number (must be a single integer)"
+            exit 1
+          fi
+          echo "PR_NUMBER=$VALID_PR" >> $GITHUB_ENV
+
+      - name: Validate artifact PR number against workflow run
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        run: |
+          PRS_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls")
+          PR_NUMS=$(echo "$PRS_JSON" | jq -r '.[].number | tostring')
+          if ! echo "$PR_NUMS" | grep -qx "$PR_NUMBER"; then
+            echo "Artifact PR number ($PR_NUMBER) does not match PR(s) for this workflow run: $PR_NUMS"
+            exit 1
+          fi
+
+      - name: Get Additional PR Information
+        uses: octokit/request-action@v2.x
+        id: pr_info
+        with:
+          route: GET /repos/{repo}/pulls/{number}
+          repo: ${{ github.event.repository.full_name }}
+          number: ${{ env.PR_NUMBER }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Additional PR Information
+        env:
+          PR_BASE: ${{ fromJson(steps.pr_info.outputs.data).base.ref }}
+          PR_HEAD: ${{ fromJson(steps.pr_info.outputs.data).head.ref }}
+        run: |
+          delim=$(openssl rand -hex 16)
+          echo "PR_BASE<<${delim}" >> $GITHUB_ENV
+          printf '%s\n' "$PR_BASE" >> $GITHUB_ENV
+          echo "${delim}" >> $GITHUB_ENV
+          delim=$(openssl rand -hex 16)
+          echo "PR_HEAD<<${delim}" >> $GITHUB_ENV
+          printf '%s\n' "$PR_HEAD" >> $GITHUB_ENV
+          echo "${delim}" >> $GITHUB_ENV
+
+      - name: Checkout Code for PR
+        run: |
+          gh pr checkout "$PR_NUMBER"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_HOST_URL: https://sonarcloud.io
+          SONAR_ORGANIZATION: ansible
+          SONAR_PROJECT_KEY: ansible_metrics-service
+          SONAR_TOKEN: ${{ secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT }}
+        with:
+          projectBaseDir: .
+          args: >
+            -Dsonar.python.coverage.reportPaths=coverage-artifact/coverage.xml
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
+            -Dsonar.pullrequest.branch=${{ env.PR_HEAD }}
+            -Dsonar.pullrequest.base=${{ env.PR_BASE }}
+            -Dsonar.pullrequest.provider=github

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -7,7 +7,10 @@ on:
     types:
       - completed
 
-permissions: read-all
+permissions:
+  contents: read
+  pull-requests: read
+  actions: read
 
 jobs:
   sonarcloud:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI-only change but it adds a new cross-workflow PR scanning path that depends on artifacts and GitHub API validation; failures could block/skip analysis or break PR checks.
> 
> **Overview**
> Pytest CI now checks out with full git history and, on pull requests, uploads `coverage.xml` plus a generated `pr_number.txt` as workflow artifacts.
> 
> SonarCloud reporting is split: pushes run the scan directly in `pytest.yml`, while PRs trigger a new `sonar_checks.yml` workflow via `workflow_run` that downloads the artifacts, validates the PR number against the workflow run’s head SHA, checks out the PR via `gh pr checkout`, and runs a SonarCloud PR analysis configured with PR base/head metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca1042f2e9be32451266254015b89035f68f0ed8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->