### PR TITLE
Update Dockerfile labels for metrics service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,10 @@ EXPOSE 8000
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["python", "manage.py", "metrics_service", "run", "--host", "0.0.0.0", "--port", "8000"]
 
-LABEL com.redhat.component="metrics-utility" \
-    name="metrics-utility" \
+LABEL com.redhat.component="metrics-service" \
+    name="metrics-service" \
     version="1.0.0" \
-    summary="Metrics Utility" \
+    summary="Metrics Service" \
     description="Backend utility for Ansible Automation Platform" \
-    cpe="cpe:/a:redhat:metrics_utility:1.0::rhel9" \
+    cpe="cpe:/a:redhat:metrics-service:1.0::rhel9" \
     org.opencontainers.image.created="${BUILD_DATE:-$(date -u +'%Y-%m-%dT%H:%M:%SZ')}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only Docker label changes; risk is limited to downstream tooling that depends on the previous label values.
> 
> **Overview**
> Updates the `Dockerfile` LABEL metadata to rename the component/image from **metrics utility** to **metrics service**, including `com.redhat.component`, `name`, `summary`, and the `cpe` string.
> 
> No runtime behavior changes; the container entrypoint/command and build steps are unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b82906f5e1a62e89a8a2e17bd61b740279601e87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->