### PR TITLE
Refactor Dockerfile to simplify pip installation process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    # Force pip to build from source (no binary wheels)
-    PIP_NO_BINARY=:all:
+    PIP_DISABLE_PIP_VERSION_CHECK=1 
+
 
 # Install system dependencies required for building Python packages from source
 # These include compilers and development headers for:
@@ -60,7 +59,7 @@ USER 1001
 RUN if [ -f /cachi2/cachi2.env ]; then \
         source /cachi2/cachi2.env; \
     fi && \
-    pip install --no-cache-dir --no-binary :all: -r requirements-build.txt
+    pip install --no-cache-dir -r requirements-build.txt
 
 # Copy and set up entrypoint script
 USER root


### PR DESCRIPTION
- Removed the enforcement of building all Python dependencies from source by eliminating the `PIP_NO_BINARY` setting.
- Updated the pip installation command to allow binary wheels, streamlining the build process while maintaining the no-cache option.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency build/install behavior, which can affect runtime compatibility and SBOM/compliance expectations even though the code itself is unchanged.
> 
> **Overview**
> Simplifies the container build by no longer forcing pip to compile all Python dependencies from source.
> 
> Removes `PIP_NO_BINARY=:all:` from the Dockerfile environment and drops `--no-binary :all:` from the `pip install -r requirements-build.txt` step, allowing binary wheels while keeping `--no-cache-dir`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46d5bb5cb7beef02453fce9cdc47e82b4ca9d0e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->