### PR TITLE
Update Dockerfile labels for metrics service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,10 +78,10 @@ EXPOSE 8000
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["python", "manage.py", "metrics_service", "run", "--host", "0.0.0.0", "--port", "8000"]
 
-LABEL com.redhat.component="metrics-service" \
-    name="metrics-service" \
+LABEL com.redhat.component="ansible-automation-platform-tech-preview-metrics-service-rhel9" \
+    name="ansible-automation-platform-tech-preview/metrics-service-rhel9" \
     version="1.0.0" \
     summary="Metrics Service" \
     description="Backend utility for Ansible Automation Platform" \
-    cpe="cpe:/a:redhat:metrics-service:1.0::rhel9" \
+    cpe="cpe:/a:redhat:metrics_utility:1.0::rhel9" \
     org.opencontainers.image.created="${BUILD_DATE:-$(date -u +'%Y-%m-%dT%H:%M:%SZ')}"


### PR DESCRIPTION
Future change based on label review on konflux

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label-only metadata changes; no functional impact on build steps, runtime command, or exposed ports.
> 
> **Overview**
> Updates the Docker image metadata labels in `Dockerfile` to align with the Ansible Automation Platform tech-preview naming.
> 
> Renames the `com.redhat.component` and `name` labels and adjusts the `cpe` value from `metrics-service` to `metrics_utility`; runtime/build behavior is unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5944c1cda29144298ddb09ae8dbbaa9fa89c0b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->