### PR TITLE
updated validation

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -89,7 +89,4 @@ jobs:
         with:
           projectBaseDir: .
           args: >
-            -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.organization=ansible
-            -Dsonar.projectKey=ansible_metrics-service
             -Dsonar.python.coverage.reportPaths=coverage.xml

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -56,13 +56,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
         run: |
-          PR_STATE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" | jq -r '.state // "not_found"')
+          # Use -f flag to fail on HTTP errors, and check for valid response
+          HTTP_CODE=$(curl -s -w "%{http_code}" -o pr_response.json -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER")
+          
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "Error: GitHub API returned HTTP $HTTP_CODE when checking PR state"
+            cat pr_response.json
+            exit 1
+          fi
+          
+          PR_STATE=$(jq -r '.state // "not_found"' pr_response.json)
           echo "PR $PR_NUMBER state: $PR_STATE"
           echo "state=$PR_STATE" >> $GITHUB_OUTPUT
           
+          if [ "$PR_STATE" = "not_found" ]; then
+            echo "Cannot determine PR state from API response"
+            exit 1
+          fi
+          
           if [ "$PR_STATE" != "open" ]; then
-            echo "PR is not open - skipping SonarCloud scan"
+            echo "PR is not open (state: $PR_STATE) - skipping SonarCloud scan"
             exit 0
           fi
 
@@ -72,19 +86,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
         run: |
-          PRS_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+          # Check API response for errors
+          HTTP_CODE=$(curl -s -w "%{http_code}" -o prs_response.json -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls")
-          PR_NUMS=$(echo "$PRS_JSON" | jq -r '.[].number | tostring')
           
-          # If the commit is not associated with any PRs, skip validation
-          # (This can happen if the PR was recently merged)
-          if [ -z "$PR_NUMS" ]; then
-            echo "Warning: No PRs associated with commit ${{ github.event.workflow_run.head_sha }}"
-            echo "This can happen if the PR was recently merged. Proceeding with analysis."
-          elif ! echo "$PR_NUMS" | grep -qx "$PR_NUMBER"; then
-            echo "Artifact PR number ($PR_NUMBER) does not match PR(s) for this workflow run: $PR_NUMS"
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "Error: GitHub API returned HTTP $HTTP_CODE when fetching PRs for commit"
+            cat prs_response.json
             exit 1
           fi
+          
+          PR_NUMS=$(jq -r '.[].number | tostring' prs_response.json)
+          
+          # For an open PR, the commit MUST be associated with at least one PR
+          # Empty response indicates an API issue or security concern
+          if [ -z "$PR_NUMS" ]; then
+            echo "Error: No PRs associated with commit ${{ github.event.workflow_run.head_sha }}"
+            exit 1
+          fi
+          
+          # Verify the PR number from artifact matches one of the PRs for this commit
+          if ! echo "$PR_NUMS" | grep -qx "$PR_NUMBER"; then
+            echo "Error: Artifact PR number ($PR_NUMBER) does not match PR(s) for this workflow $PR_NUMS"
+            exit 1
+          fi
+          
+          echo "Validation successful: PR $PR_NUMBER is associated with commit ${{ github.event.workflow_run.head_sha }}"
 
       - name: Get Additional PR Information
         if: steps.pr_state_check.outputs.state == 'open'

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -50,7 +50,24 @@ jobs:
           fi
           echo "PR_NUMBER=$VALID_PR" >> $GITHUB_ENV
 
+      - name: Check if PR is open
+        id: pr_state_check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        run: |
+          PR_STATE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER" | jq -r '.state // "not_found"')
+          echo "PR $PR_NUMBER state: $PR_STATE"
+          echo "state=$PR_STATE" >> $GITHUB_OUTPUT
+          
+          if [ "$PR_STATE" != "open" ]; then
+            echo "PR is not open - skipping SonarCloud scan"
+            exit 0
+          fi
+
       - name: Validate artifact PR number against workflow run
+        if: steps.pr_state_check.outputs.state == 'open'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
@@ -58,12 +75,19 @@ jobs:
           PRS_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls")
           PR_NUMS=$(echo "$PRS_JSON" | jq -r '.[].number | tostring')
-          if ! echo "$PR_NUMS" | grep -qx "$PR_NUMBER"; then
+          
+          # If the commit is not associated with any PRs, skip validation
+          # (This can happen if the PR was recently merged)
+          if [ -z "$PR_NUMS" ]; then
+            echo "Warning: No PRs associated with commit ${{ github.event.workflow_run.head_sha }}"
+            echo "This can happen if the PR was recently merged. Proceeding with analysis."
+          elif ! echo "$PR_NUMS" | grep -qx "$PR_NUMBER"; then
             echo "Artifact PR number ($PR_NUMBER) does not match PR(s) for this workflow run: $PR_NUMS"
             exit 1
           fi
 
       - name: Get Additional PR Information
+        if: steps.pr_state_check.outputs.state == 'open'
         uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d
         id: pr_info
         with:
@@ -74,6 +98,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Additional PR Information
+        if: steps.pr_state_check.outputs.state == 'open'
         env:
           PR_BASE: ${{ fromJson(steps.pr_info.outputs.data).base.ref }}
           PR_HEAD: ${{ fromJson(steps.pr_info.outputs.data).head.ref }}
@@ -88,6 +113,7 @@ jobs:
           echo "${delim}" >> $GITHUB_ENV
 
       - name: Checkout Code for PR
+        if: steps.pr_state_check.outputs.state == 'open'
         run: |
           gh pr checkout "$PR_NUMBER"
         env:
@@ -95,6 +121,7 @@ jobs:
           PR_NUMBER: ${{ env.PR_NUMBER }}
 
       - name: SonarCloud Scan
+        if: steps.pr_state_check.outputs.state == 'open'
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
         env:
           SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
Fix for GH API returning empty list of PRs associated with commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that tighten validation and add early exits; main risk is false negatives/failed CI if GitHub API responses differ from expectations.
> 
> **Overview**
> Improves the `sonar_checks.yml` workflow to **guard SonarCloud PR scans behind explicit PR-state validation**: it now queries the GitHub API to ensure the artifact PR is still `open`, adds HTTP status checking for API calls, and fails fast if the commit-to-PR association list is unexpectedly empty or doesn’t contain the artifact PR number.
> 
> Simplifies `pytest.yml` Sonar invocation by removing redundant `sonar.host.url`, `sonar.organization`, and `sonar.projectKey` args (relying on env vars instead).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fb83b73e8ac85491c19680a5a0110d1cdb74ddd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->