### PR TITLE
collect_hourly_metrics: optional since, until params

### DIFF
--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -74,14 +74,15 @@ def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
     Args:
         **kwargs: Task data containing:
             - collector_type (str): Type of collector (required)
-            - hour_timestamp (str): ISO timestamp for the hour to collect (optional, defaults to previous hour)
+            - since (str): ISO timestamp for collection start (optional, requires until)
+            - until (str): ISO timestamp for collection end (optional, requires since)
             - database (str): Database name (default: 'awx')
 
     Returns:
         dict: Task result with collection status and record ID
 
     Raises:
-        ValueError: If collector_type is missing or invalid
+        ValueError: If collector_type is missing or invalid, or if since/until validation fails
     """
     collector_type = kwargs.pop("collector_type", None)
     if not collector_type:
@@ -90,18 +91,35 @@ def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
     # Extract optional execution_id for linking to TaskExecution
     execution_id = kwargs.get("execution_id")  # Available when called via execute_db_task
 
-    # Determine hour to collect (default to previous full hour)
-    hour_timestamp_str = kwargs.get("hour_timestamp")
-    if hour_timestamp_str:
-        hour_timestamp = parse_datetime_string(hour_timestamp_str)
-        if hour_timestamp is None:
-            raise ValueError(f"Invalid hour_timestamp format: {hour_timestamp_str}")
-    else:
-        now = timezone.now()
-        hour_timestamp = now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)
+    # Determine time window to collect
+    since_str = kwargs.get("since")
+    until_str = kwargs.get("until")
 
-    start_datetime = hour_timestamp
-    end_datetime = start_datetime + timedelta(hours=1)
+    # Validate since/until - both must be provided or neither
+    if (since_str is None) != (until_str is None):
+        raise ValueError("Both 'since' and 'until' must be provided together, or neither")
+
+    if since_str and until_str:
+        # Parse custom time range
+        since = parse_datetime_string(since_str)
+        until = parse_datetime_string(until_str)
+
+        if since is None:
+            raise ValueError(f"Invalid 'since' timestamp format: {since_str}")
+        if until is None:
+            raise ValueError(f"Invalid 'until' timestamp format: {until_str}")
+
+        # Validate since < until
+        if since >= until:
+            raise ValueError(f"'since' ({since}) must be before 'until' ({until})")
+
+        start_datetime = since
+        end_datetime = until
+    else:
+        # Default to previous full hour
+        now = timezone.now()
+        start_datetime = now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)
+        end_datetime = start_datetime + timedelta(hours=1)
 
     # Get database connection
     db_connection = get_db_connection()

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -153,9 +153,13 @@ TASK_METADATA = {
                 "required": True,
                 "description": "Type of collector to run (e.g., job_host_summary_service, unified_jobs, credentials_service)",
             },
-            "hour_timestamp": {
+            "since": {
                 "type": "string",
-                "description": "ISO timestamp for the hour to collect (defaults to current hour)",
+                "description": "ISO timestamp for collection start (requires until, defaults to previous hour)",
+            },
+            "until": {
+                "type": "string",
+                "description": "ISO timestamp for collection end (requires since, defaults to current hour)",
             },
         },
         "examples": [
@@ -164,8 +168,12 @@ TASK_METADATA = {
             {"name": "Credentials", "data": {"collector_type": "credentials_service"}},
             {"name": "Job events", "data": {"collector_type": "main_jobevent_service"}},
             {
-                "name": "Specific hour",
-                "data": {"collector_type": "job_host_summary_service", "hour_timestamp": "2024-01-01T00:00:00Z"},
+                "name": "Custom time range",
+                "data": {
+                    "collector_type": "job_host_summary_service",
+                    "since": "2024-01-01T00:00:00Z",
+                    "until": "2024-01-01T01:00:00Z",
+                },
             },
         ],
     },

--- a/tests/unit/tasks/test_tasks_collector_advanced.py
+++ b/tests/unit/tasks/test_tasks_collector_advanced.py
@@ -21,6 +21,141 @@ from apps.tasks.collectors.send_anonymized_to_segment import send_anonymized_to_
 class TestHourlyCollectionTasks(TestCase):
     """Test hourly collection tasks."""
 
+    @patch("apps.tasks.collectors.collect_hourly_metrics.generic_collect_metrics")
+    @patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection")
+    def test_collect_hourly_metrics_with_since_until(self, mock_db_conn, mock_collect):
+        """Test collect_hourly_metrics with custom since/until timestamps."""
+        from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+        mock_collect.return_value = {"status": "success", "record_id": 123}
+
+        result = collect_hourly_metrics(
+            collector_type="job_host_summary_service",
+            since="2024-01-15T10:00:00Z",
+            until="2024-01-15T11:00:00Z",
+        )
+
+        assert result["status"] == "success"
+        # Verify generic_collect_metrics was called with the correct time window
+        call_args = mock_collect.call_args
+        assert call_args.kwargs["collector_kwargs"]["since"].hour == 10
+        assert call_args.kwargs["collector_kwargs"]["until"].hour == 11
+
+    @patch("apps.tasks.collectors.collect_hourly_metrics.generic_collect_metrics")
+    @patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection")
+    def test_collect_hourly_metrics_default_time_window(self, mock_db_conn, mock_collect):
+        """Test collect_hourly_metrics defaults to previous hour when no timestamps provided."""
+        from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+        mock_collect.return_value = {"status": "success", "record_id": 123}
+
+        with patch("apps.tasks.collectors.collect_hourly_metrics.timezone") as mock_tz:
+            # Mock current time as 2024-01-15 15:30:45
+            mock_now = timezone.datetime(2024, 1, 15, 15, 30, 45, tzinfo=UTC)
+            mock_tz.now.return_value = mock_now
+
+            result = collect_hourly_metrics(collector_type="unified_jobs")
+
+            assert result["status"] == "success"
+            # Should default to 14:00 - 15:00 (previous hour)
+            call_args = mock_collect.call_args
+            assert call_args.kwargs["collector_kwargs"]["since"].hour == 14
+            assert call_args.kwargs["collector_kwargs"]["until"].hour == 15
+
+    def test_collect_hourly_metrics_requires_both_since_and_until(self):
+        """Test that since and until must both be provided or neither."""
+        from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+        # Test only since provided
+        result = collect_hourly_metrics(
+            collector_type="unified_jobs",
+            since="2024-01-15T10:00:00Z",
+        )
+        assert result["status"] == "error"
+        assert "Both 'since' and 'until' must be provided together" in result["error"]
+
+        # Test only until provided
+        result = collect_hourly_metrics(
+            collector_type="unified_jobs",
+            until="2024-01-15T11:00:00Z",
+        )
+        assert result["status"] == "error"
+        assert "Both 'since' and 'until' must be provided together" in result["error"]
+
+    def test_collect_hourly_metrics_validates_since_before_until(self):
+        """Test that since must be before until."""
+        from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+        # Test until before since
+        result = collect_hourly_metrics(
+            collector_type="unified_jobs",
+            since="2024-01-15T11:00:00Z",
+            until="2024-01-15T10:00:00Z",
+        )
+        assert result["status"] == "error"
+        assert "'since'" in result["error"] and "must be before 'until'" in result["error"]
+
+        # Test equal times
+        result = collect_hourly_metrics(
+            collector_type="unified_jobs",
+            since="2024-01-15T10:00:00Z",
+            until="2024-01-15T10:00:00Z",
+        )
+        assert result["status"] == "error"
+        assert "'since'" in result["error"] and "must be before 'until'" in result["error"]
+
+    def test_collect_hourly_metrics_invalid_since_format(self):
+        """Test error handling for invalid since timestamp format."""
+        from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+        result = collect_hourly_metrics(
+            collector_type="unified_jobs",
+            since="not-a-date",
+            until="2024-01-15T11:00:00Z",
+        )
+        assert result["status"] == "error"
+        assert "Invalid 'since' timestamp format" in result["error"]
+
+    def test_collect_hourly_metrics_invalid_until_format(self):
+        """Test error handling for invalid until timestamp format."""
+        from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+        result = collect_hourly_metrics(
+            collector_type="unified_jobs",
+            since="2024-01-15T10:00:00Z",
+            until="not-a-date",
+        )
+        assert result["status"] == "error"
+        assert "Invalid 'until' timestamp format" in result["error"]
+
+    def test_collect_hourly_metrics_requires_collector_type(self):
+        """Test that collector_type is required."""
+        from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+        result = collect_hourly_metrics()
+        assert result["status"] == "error"
+        assert "collector_type parameter is required" in result["error"]
+
+    @patch("apps.tasks.collectors.collect_hourly_metrics.generic_collect_metrics")
+    @patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection")
+    def test_collect_hourly_metrics_with_execution_id(self, mock_db_conn, mock_collect):
+        """Test collect_hourly_metrics passes execution_id to generic_collect_metrics."""
+        from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+        mock_collect.return_value = {"status": "success", "record_id": 123}
+
+        result = collect_hourly_metrics(
+            collector_type="credentials_service",
+            since="2024-01-15T10:00:00Z",
+            until="2024-01-15T11:00:00Z",
+            execution_id=456,
+        )
+
+        assert result["status"] == "success"
+        # Verify execution_id was passed to generic_collect_metrics
+        call_args = mock_collect.call_args
+        assert call_args.kwargs["task_execution_id"] == 456
+
 
 @pytest.mark.unit
 @pytest.mark.django_db


### PR DESCRIPTION
Follows #109 

Changes the hourly task to accept since & until timestamps (optional, but required both together)


.... might need to figure out how to replace `hour_timestamp` in db in a way where the scheduler doesn't need to know too much, the collector collects the right thing even on late retry, and the daily task can still find all the data