### PR TITLE
docker-entrypoint.sh - split off init container logic into init.sh

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,66 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
-echo "Starting Metrics Service container..."
-
-# Wait for database to be ready
-echo "Waiting for database to be ready..."
-python -c "
-import os, time, psycopg
-host = os.environ.get('METRICS_SERVICE_DATABASES__default__HOST', 'postgres')
-port = os.environ.get('METRICS_SERVICE_DATABASES__default__PORT', '5432')
-user = os.environ.get('METRICS_SERVICE_DATABASES__default__USER', 'metrics_service')
-password = os.environ.get('METRICS_SERVICE_DATABASES__default__PASSWORD', 'metrics_service')
-db = os.environ.get('METRICS_SERVICE_DATABASES__default__NAME', 'metrics_service')
-
-max_attempts = 30
-attempt = 0
-while attempt < max_attempts:
-    try:
-        conn = psycopg.connect(
-            host=host,
-            port=port,
-            user=user,
-            password=password,
-            dbname=db,
-            connect_timeout=5
-        )
-        conn.close()
-        print('✅ Database is ready!')
-        break
-    except Exception as e:
-        attempt += 1
-        print(f'⏳ Database not ready yet (attempt {attempt}/{max_attempts}): {e}')
-        time.sleep(2)
-else:
-    print('❌ Database connection failed after all attempts')
-    exit(1)
-"
-
-# Run database migrations
-echo "Running database migrations..."
-python manage.py migrate --noinput
-
-# Initialize default settings (puts defaults in the Setting DB table)
-echo "Initializing default settings..."
-python manage.py metrics_service init-default-settings
-
-# Initialize ServiceID for Django-Ansible-Base
-echo "Initializing ServiceID..."
-python manage.py metrics_service init-service-id
-
-# Initialize system tasks (puts TASK_GROUPS in the Task DB table)
-echo "Initializing system tasks..."
-python manage.py metrics_service init-system-tasks
-
-# Collect static files (if needed)
+# FIXME: should happen during prod web container build instead
+# Collect static files (into staticfiles/)
 echo "Collecting static files..."
-python manage.py collectstatic --noinput --clear || echo "⚠️ Static files collection failed (continuing...)"
+python manage.py collectstatic --noinput --clear || echo "Static files collection failed (continuing...)" 1>&2
 
-# Create logs directory if it doesn't exist (ignore permission errors for bind mounts)
-mkdir -p /app/logs 2>/dev/null || true
-
-echo "Initialization complete! Starting application..."
-
-# Execute the command passed to the container
 exec "$@"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+python manage.py migrate --noinput
+
+# puts defaults in the Setting DB table
+echo "Initializing default settings..."
+python manage.py metrics_service init-default-settings
+
+# Initialize ServiceID for django-ansible-base
+echo "Initializing django-ansible-base ServiceID..."
+python manage.py metrics_service init-service-id
+
+# puts TASK_GROUPS in the Task DB table
+echo "Initializing system tasks..."
+python manage.py metrics_service init-system-tasks


### PR DESCRIPTION
Issue: AAP-66371

* migrate - moved to init.sh
* init-* - moved to init.sh
* collectstatic - kept in entrypoint, should be web container build?
* mkdir /app/logs - already in Dockerfile

Q: would it make sense to move collectstatic all the way to the Dockerfile instead of keeping it in entrypoint? Do we actually need to keep the entrypoint if it does nothing? I don't really see anything we would need each container to do that's common to all of them, post-split.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Split container startup from system setup so runtime launches faster and more predictably.
  * Moved database migrations, default settings, service identity creation, and system task initialization into a dedicated initialization process that logs progress.
  * Simplified container startup to only perform static asset collection and proceed even if asset collection fails, then hand off to the main command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->