### PR TITLE
Update sonar_checks.yml

### DIFF
--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -16,16 +16,17 @@ jobs:
   sonarcloud:
     name: SonarCloud Static Scans (PR)
     runs-on: ubuntu-latest
+    # Only run if the previous workflow was a success and it was triggered by a PR
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
 
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6
+      - name: Checkout Code (Default)
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Fetch Code Coverage Report
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: coverage-report
           path: coverage-artifact
@@ -33,7 +34,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Fetch PR Number
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: pr_number
           path: pr-artifact
@@ -41,6 +42,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Extract and validate PR Number
+        id: extract_pr
         run: |
           cat pr-artifact/pr_number.txt
           VALID_PR=$(head -n1 pr-artifact/pr_number.txt | awk '{print $2}' | grep -E '^[0-9]+$') || true
@@ -49,118 +51,12 @@ jobs:
             exit 1
           fi
           echo "PR_NUMBER=$VALID_PR" >> $GITHUB_ENV
+          echo "number=$VALID_PR" >> $GITHUB_OUTPUT
 
-      - name: Check if PR is open
+      - name: Check PR state (Open or Merged)
         id: pr_state_check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
         run: |
-          # Use -f flag to fail on HTTP errors, and check for valid response
-          HTTP_CODE=$(curl -s -w "%{http_code}" -o pr_response.json -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER")
-          
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "Error: GitHub API returned HTTP $HTTP_CODE when checking PR state"
-            cat pr_response.json
-            exit 1
-          fi
-          
-          PR_STATE=$(jq -r '.state // "not_found"' pr_response.json)
-          echo "PR $PR_NUMBER state: $PR_STATE"
-          echo "state=$PR_STATE" >> $GITHUB_OUTPUT
-          
-          if [ "$PR_STATE" = "not_found" ]; then
-            echo "Cannot determine PR state from API response"
-            exit 1
-          fi
-          
-          if [ "$PR_STATE" != "open" ]; then
-            echo "PR is not open (state: $PR_STATE) - skipping SonarCloud scan"
-            exit 0
-          fi
-
-      - name: Validate artifact PR number against workflow run
-        if: steps.pr_state_check.outputs.state == 'open'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ env.PR_NUMBER }}
-        run: |
-          # Check API response for errors
-          HTTP_CODE=$(curl -s -w "%{http_code}" -o prs_response.json -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls")
-          
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "Error: GitHub API returned HTTP $HTTP_CODE when fetching PRs for commit"
-            cat prs_response.json
-            exit 1
-          fi
-          
-          PR_NUMS=$(jq -r '.[].number | tostring' prs_response.json)
-          
-          # For an open PR, the commit MUST be associated with at least one PR
-          # Empty response indicates an API issue or security concern
-          if [ -z "$PR_NUMS" ]; then
-            echo "Error: No PRs associated with commit ${{ github.event.workflow_run.head_sha }}"
-            exit 1
-          fi
-          
-          # Verify the PR number from artifact matches one of the PRs for this commit
-          if ! echo "$PR_NUMS" | grep -qx "$PR_NUMBER"; then
-            echo "Error: Artifact PR number ($PR_NUMBER) does not match PR(s) for this workflow $PR_NUMS"
-            exit 1
-          fi
-          
-          echo "Validation successful: PR $PR_NUMBER is associated with commit ${{ github.event.workflow_run.head_sha }}"
-
-      - name: Get Additional PR Information
-        if: steps.pr_state_check.outputs.state == 'open'
-        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d
-        id: pr_info
-        with:
-          route: GET /repos/{repo}/pulls/{number}
-          repo: ${{ github.event.repository.full_name }}
-          number: ${{ env.PR_NUMBER }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set Additional PR Information
-        if: steps.pr_state_check.outputs.state == 'open'
-        env:
-          PR_BASE: ${{ fromJson(steps.pr_info.outputs.data).base.ref }}
-          PR_HEAD: ${{ fromJson(steps.pr_info.outputs.data).head.ref }}
-        run: |
-          delim=$(openssl rand -hex 16)
-          echo "PR_BASE<<${delim}" >> $GITHUB_ENV
-          printf '%s\n' "$PR_BASE" >> $GITHUB_ENV
-          echo "${delim}" >> $GITHUB_ENV
-          delim=$(openssl rand -hex 16)
-          echo "PR_HEAD<<${delim}" >> $GITHUB_ENV
-          printf '%s\n' "$PR_HEAD" >> $GITHUB_ENV
-          echo "${delim}" >> $GITHUB_ENV
-
-      - name: Checkout Code for PR
-        if: steps.pr_state_check.outputs.state == 'open'
-        run: |
-          gh pr checkout "$PR_NUMBER"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ env.PR_NUMBER }}
-
-      - name: SonarCloud Scan
-        if: steps.pr_state_check.outputs.state == 'open'
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
-        env:
-          SONAR_HOST_URL: https://sonarcloud.io
-          SONAR_ORGANIZATION: ansible
-          SONAR_PROJECT_KEY: ansible_metrics-service
-          SONAR_TOKEN: ${{ secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT }}
-        with:
-          projectBaseDir: .
-          args: >
-            -Dsonar.python.coverage.reportPaths=coverage-artifact/coverage.xml
-            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
-            -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
-            -Dsonar.pullrequest.branch=${{ env.PR_HEAD }}
-            -Dsonar.pullrequest.base=${{ env.PR_BASE }}
-            -Dsonar.pullrequest.provider=github
+          HTTP_CODE=$(curl -s -w "%{http_code}" -


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it substantially rewires the SonarCloud workflow (including removing prior PR/commit validation and scan steps) and the updated `sonar_checks.yml` appears incomplete, which could break CI or stop static analysis from running.
> 
> **Overview**
> **Reworks the `SonarCloud Static Scans (PR)` GitHub Actions workflow.** It pins `actions/checkout` and `actions/download-artifact` to `@v4`, adds an `id`/outputs to the PR-number extraction step, and keeps the job gated on a successful upstream `workflow_run` triggered by a PR.
> 
> It removes the previous PR-open check/commit-to-PR validation, PR metadata fetching (base/head), PR checkout, and the SonarCloud scan invocation, replacing the PR-state logic with a new `curl`-based check (the new workflow content currently ends mid-command).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf9a6fc3da89890f9dde0293982bd7c65f69f08e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->