### PR TITLE
fix(ci): make SonarCloud PR workflow validation reliable

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -77,3 +77,16 @@ jobs:
         with:
           name: pr_number
           path: pr_number.txt
+
+      - name: "Send code coverage report to SonarCloud (on push)"
+        if: github.event_name == 'push'
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
+        env:
+          SONAR_HOST_URL: https://sonarcloud.io
+          SONAR_ORGANIZATION: ansible
+          SONAR_PROJECT_KEY: ansible_metrics-service
+          SONAR_TOKEN: ${{ secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT }}
+        with:
+          projectBaseDir: .
+          args: >
+            -Dsonar.python.coverage.reportPaths=coverage.xml

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -55,9 +55,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
+          GITHUB_REPO: ${{ github.repository }}
+          WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           HTTP_CODE=$(curl -s -w "%{http_code}" -o pr_response.json -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER")
+            "https://api.github.com/repos/$GITHUB_REPO/pulls/$PR_NUMBER")
 
           if [ "$HTTP_CODE" != "200" ]; then
             echo "Error: GitHub API returned HTTP $HTTP_CODE when checking PR state"
@@ -81,7 +83,6 @@ jobs:
 
           PR_HEAD_BRANCH=$(jq -r '.head.ref' pr_response.json)
           PR_BASE_BRANCH=$(jq -r '.base.ref' pr_response.json)
-          WORKFLOW_BRANCH="${{ github.event.workflow_run.head_branch }}"
 
           echo "PR head branch: $PR_HEAD_BRANCH"
           echo "Workflow run branch: $WORKFLOW_BRANCH"

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -57,6 +57,8 @@ jobs:
           PR_NUMBER: ${{ env.PR_NUMBER }}
           GITHUB_REPO: ${{ github.repository }}
           WORKFLOW_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
         run: |
           HTTP_CODE=$(curl -s -w "%{http_code}" -o pr_response.json -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/$GITHUB_REPO/pulls/$PR_NUMBER")
@@ -82,17 +84,26 @@ jobs:
           fi
 
           PR_HEAD_BRANCH=$(jq -r '.head.ref' pr_response.json)
+          PR_HEAD_SHA=$(jq -r '.head.sha' pr_response.json)
+          PR_HEAD_REPO=$(jq -r '.head.repo.full_name' pr_response.json)
           PR_BASE_BRANCH=$(jq -r '.base.ref' pr_response.json)
 
           echo "PR head branch: $PR_HEAD_BRANCH"
+          echo "PR head SHA: $PR_HEAD_SHA"
+          echo "PR head repo: $PR_HEAD_REPO"
           echo "Workflow run branch: $WORKFLOW_BRANCH"
+          echo "Workflow run SHA: $WORKFLOW_HEAD_SHA"
+          echo "Workflow run repo: $WORKFLOW_HEAD_REPO"
 
-          if [ "$PR_HEAD_BRANCH" != "$WORKFLOW_BRANCH" ]; then
-            echo "Error: Workflow branch ($WORKFLOW_BRANCH) does not match PR #$PR_NUMBER head branch ($PR_HEAD_BRANCH)"
-            exit 1
+          if [ "$PR_HEAD_BRANCH" != "$WORKFLOW_BRANCH" ] || \
+             [ "$PR_HEAD_SHA" != "$WORKFLOW_HEAD_SHA" ] || \
+             [ "$PR_HEAD_REPO" != "$WORKFLOW_HEAD_REPO" ]; then
+            echo "Error: Workflow run no longer matches PR #$PR_NUMBER head (branch/SHA/repo mismatch)"
+            echo "should_scan=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
-          echo "Validation successful: PR $PR_NUMBER branch matches workflow run branch ($WORKFLOW_BRANCH)"
+          echo "Validation successful: PR $PR_NUMBER matches workflow run (branch, SHA, repo)"
           echo "should_scan=true" >> $GITHUB_OUTPUT
 
           delim=$(openssl rand -hex 16)

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -50,97 +50,61 @@ jobs:
           fi
           echo "PR_NUMBER=$VALID_PR" >> $GITHUB_ENV
 
-      - name: Check if PR is open
-        id: pr_state_check
+      - name: Check if PR is open and validate
+        id: pr_check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
         run: |
-          # Use -f flag to fail on HTTP errors, and check for valid response
           HTTP_CODE=$(curl -s -w "%{http_code}" -o pr_response.json -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER")
-          
+
           if [ "$HTTP_CODE" != "200" ]; then
             echo "Error: GitHub API returned HTTP $HTTP_CODE when checking PR state"
             cat pr_response.json
             exit 1
           fi
-          
+
           PR_STATE=$(jq -r '.state // "not_found"' pr_response.json)
           echo "PR $PR_NUMBER state: $PR_STATE"
-          echo "state=$PR_STATE" >> $GITHUB_OUTPUT
-          
+
           if [ "$PR_STATE" = "not_found" ]; then
             echo "Cannot determine PR state from API response"
             exit 1
           fi
-          
+
           if [ "$PR_STATE" != "open" ]; then
             echo "PR is not open (state: $PR_STATE) - skipping SonarCloud scan"
+            echo "should_scan=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-      - name: Validate artifact PR number against workflow run
-        if: steps.pr_state_check.outputs.state == 'open'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ env.PR_NUMBER }}
-        run: |
-          # Check API response for errors
-          HTTP_CODE=$(curl -s -w "%{http_code}" -o prs_response.json -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls")
-          
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "Error: GitHub API returned HTTP $HTTP_CODE when fetching PRs for commit"
-            cat prs_response.json
-            exit 1
-          fi
-          
-          PR_NUMS=$(jq -r '.[].number | tostring' prs_response.json)
-          
-          # For an open PR, the commit MUST be associated with at least one PR
-          # Empty response indicates an API issue or security concern
-          if [ -z "$PR_NUMS" ]; then
-            echo "Error: No PRs associated with commit ${{ github.event.workflow_run.head_sha }}"
-            exit 1
-          fi
-          
-          # Verify the PR number from artifact matches one of the PRs for this commit
-          if ! echo "$PR_NUMS" | grep -qx "$PR_NUMBER"; then
-            echo "Error: Artifact PR number ($PR_NUMBER) does not match PR(s) for this workflow $PR_NUMS"
-            exit 1
-          fi
-          
-          echo "Validation successful: PR $PR_NUMBER is associated with commit ${{ github.event.workflow_run.head_sha }}"
+          PR_HEAD_BRANCH=$(jq -r '.head.ref' pr_response.json)
+          PR_BASE_BRANCH=$(jq -r '.base.ref' pr_response.json)
+          WORKFLOW_BRANCH="${{ github.event.workflow_run.head_branch }}"
 
-      - name: Get Additional PR Information
-        if: steps.pr_state_check.outputs.state == 'open'
-        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d
-        id: pr_info
-        with:
-          route: GET /repos/{repo}/pulls/{number}
-          repo: ${{ github.event.repository.full_name }}
-          number: ${{ env.PR_NUMBER }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "PR head branch: $PR_HEAD_BRANCH"
+          echo "Workflow run branch: $WORKFLOW_BRANCH"
 
-      - name: Set Additional PR Information
-        if: steps.pr_state_check.outputs.state == 'open'
-        env:
-          PR_BASE: ${{ fromJson(steps.pr_info.outputs.data).base.ref }}
-          PR_HEAD: ${{ fromJson(steps.pr_info.outputs.data).head.ref }}
-        run: |
+          if [ "$PR_HEAD_BRANCH" != "$WORKFLOW_BRANCH" ]; then
+            echo "Error: Workflow branch ($WORKFLOW_BRANCH) does not match PR #$PR_NUMBER head branch ($PR_HEAD_BRANCH)"
+            exit 1
+          fi
+
+          echo "Validation successful: PR $PR_NUMBER branch matches workflow run branch ($WORKFLOW_BRANCH)"
+          echo "should_scan=true" >> $GITHUB_OUTPUT
+
           delim=$(openssl rand -hex 16)
           echo "PR_BASE<<${delim}" >> $GITHUB_ENV
-          printf '%s\n' "$PR_BASE" >> $GITHUB_ENV
+          printf '%s\n' "$PR_BASE_BRANCH" >> $GITHUB_ENV
           echo "${delim}" >> $GITHUB_ENV
           delim=$(openssl rand -hex 16)
           echo "PR_HEAD<<${delim}" >> $GITHUB_ENV
-          printf '%s\n' "$PR_HEAD" >> $GITHUB_ENV
+          printf '%s\n' "$PR_HEAD_BRANCH" >> $GITHUB_ENV
           echo "${delim}" >> $GITHUB_ENV
 
       - name: Checkout Code for PR
-        if: steps.pr_state_check.outputs.state == 'open'
+        if: steps.pr_check.outputs.should_scan == 'true'
         run: |
           gh pr checkout "$PR_NUMBER"
         env:
@@ -148,8 +112,8 @@ jobs:
           PR_NUMBER: ${{ env.PR_NUMBER }}
 
       - name: SonarCloud Scan
-        if: steps.pr_state_check.outputs.state == 'open'
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
+        if: steps.pr_check.outputs.should_scan == 'true'
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602
         env:
           SONAR_HOST_URL: https://sonarcloud.io
           SONAR_ORGANIZATION: ansible


### PR DESCRIPTION
## Description
Replace the unreliable commits/{sha}/pulls API check with branch-name validation so the workflow no longer fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no production code impact; main risk is misconfigured gating that could skip scans or run them unexpectedly.
> 
> **Overview**
> Adds a push-triggered SonarCloud scan to `pytest.yml` so coverage from `devel` pushes is published without the PR workflow.
> 
> Hardens the PR SonarCloud workflow (`sonar_checks.yml`) by replacing the `commits/{sha}/pulls` validation with a single PR lookup and an explicit **branch/SHA/repo match** against the triggering `workflow_run`, and gates checkout/scan via a `should_scan` output. Also aligns the SonarCloud scan action version to a pinned commit SHA.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b3f61417697b47501c83c127391155efff128c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->