### PR TITLE
Segment key from file

### DIFF
--- a/apps/settings/production.py
+++ b/apps/settings/production.py
@@ -75,31 +75,33 @@ validators.append(
     ),
 )
 
+# Optional until gateway APIs are implemented; uncomment validator when re-adding.
 RESOURCE_SERVER__SECRET_KEY = ""
-validators.append(
-    Validator(
-        "RESOURCE_SERVER__SECRET_KEY",
-        must_exist=True,
-        ne="",
-        messages={"operations": "RESOURCE_SERVER__SECRET_KEY must be set."},
-    ),
-)
+# validators.append(
+#     Validator(
+#         "RESOURCE_SERVER__SECRET_KEY",
+#         must_exist=True,
+#         ne="",
+#         messages={"operations": "RESOURCE_SERVER__SECRET_KEY must be set."},
+#     ),
+# )
 
 # =============================================================================
 # Authentication
 # =============================================================================
 
+# Optional until gateway APIs are implemented; uncomment validator when re-adding.
 ANSIBLE_BASE_JWT_KEY = ""
-validators.append(
-    Validator(
-        "ANSIBLE_BASE_JWT_KEY",
-        must_exist=True,
-        ne="",
-        messages={
-            "operations": ("ANSIBLE_BASE_JWT_KEY must be set. "),
-        },
-    ),
-)
+# validators.append(
+#     Validator(
+#         "ANSIBLE_BASE_JWT_KEY",
+#         must_exist=True,
+#         ne="",
+#         messages={
+#             "operations": ("ANSIBLE_BASE_JWT_KEY must be set. "),
+#         },
+#     ),
+# )
 
 REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES = [
     "apps.core.authentication.ServiceJWTAuthentication",
@@ -200,15 +202,16 @@ validators.append(
 # External Services
 # =============================================================================
 
+# Optional until gateway APIs are implemented; uncomment validator when re-adding.
 SEGMENT_WRITE_KEY = ""
-validators.append(
-    Validator(
-        "SEGMENT_WRITE_KEY",
-        must_exist=True,
-        ne="",
-        messages={"operations": "SEGMENT_WRITE_KEY must be set."},
-    ),
-)
+# validators.append(
+#     Validator(
+#         "SEGMENT_WRITE_KEY",
+#         must_exist=True,
+#         ne="",
+#         messages={"operations": "SEGMENT_WRITE_KEY must be set."},
+#     ),
+# )
 
 # =============================================================================
 # URL Configuration
@@ -221,15 +224,16 @@ LOGOUT_URL = "/api/gateway/v1/logout/"
 # =============================================================================
 # Allowed Hosts
 # =============================================================================
+# Optional until gateway APIs are implemented; uncomment validator when re-adding.
 # Set via METRICS_SERVICE_ALLOWED_HOSTS (comma-separated or JSON array).
 # Example: METRICS_SERVICE_ALLOWED_HOSTS=metrics.example.com,api.example.com
 # Or:      METRICS_SERVICE_ALLOWED_HOSTS='["metrics.example.com","api.example.com"]'
 ALLOWED_HOSTS = []
-validators.append(
-    Validator(
-        "ALLOWED_HOSTS",
-        must_exist=True,
-        condition=lambda v: isinstance(v, list) and len(v) > 0,
-        messages={"condition": "ALLOWED_HOSTS must be set via METRICS_SERVICE_ALLOWED_HOSTS in production."},
-    ),
-)
+# validators.append(
+#     Validator(
+#         "ALLOWED_HOSTS",
+#         must_exist=True,
+#         condition=lambda v: isinstance(v, list) and len(v) > 0,
+#         messages={"condition": "ALLOWED_HOSTS must be set via METRICS_SERVICE_ALLOWED_HOSTS in production."},
+#     ),
+# )

--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -327,6 +327,20 @@ load_standard_settings_files(DYNACONF)
 # Load envvars at the end to allow them to override everything loaded so far.
 load_envvars(DYNACONF)
 
+# SEGMENT_WRITE_KEY from file (e.g. build-time secret or runtime-mounted secret)
+_segment_write_key_file = os.environ.get(
+    "METRICS_SERVICE_SEGMENT_WRITE_KEY_FILE",
+    "/etc/ansible-automation-platform/metrics/segment-write-key",
+)
+if Path(_segment_write_key_file).exists():
+    try:
+        with open(_segment_write_key_file) as _f:
+            _key = _f.read().strip()
+        if _key:
+            DYNACONF.set("SEGMENT_WRITE_KEY", _key)
+    except OSError:
+        pass
+
 # ALLOWED_HOSTS from environment: comma-separated list or JSON array
 if os.environ.get("METRICS_SERVICE_ALLOWED_HOSTS"):
     import json

--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -341,26 +341,41 @@ def _decode_segment_key(raw: str) -> str:
         return raw
 
 
-_segment_write_key_path = os.environ.get(
-    "METRICS_SERVICE_SEGMENT_WRITE_KEY_FILE",
-    "/etc/ansible-automation-platform/metrics/segment-write-key",
-)
-_segment_path = Path(_segment_write_key_path)
-if _segment_path.exists():
+def _load_segment_write_key_from_file(
+    path: Path | None = None,
+    env: str | None = None,
+    dynaconf_instance=None,
+) -> None:
+    """Load SEGMENT_WRITE_KEY from file or directory and set on Dynaconf. Used at module load and in tests."""
+    if path is None:
+        _segment_write_key_path = os.environ.get(
+            "METRICS_SERVICE_SEGMENT_WRITE_KEY_FILE",
+            "/etc/ansible-automation-platform/metrics/segment-write-key",
+        )
+        path = Path(_segment_write_key_path)
+    if env is None:
+        env = environment
+    if dynaconf_instance is None:
+        dynaconf_instance = DYNACONF
+    if not path.exists():
+        return
     try:
-        if _segment_path.is_dir():
-            _key_name = "SEGMENT_WRITE_KEY_PROD" if environment == "production" else "SEGMENT_WRITE_KEY_DEV"
-            _key_file = _segment_path / _key_name
+        if path.is_dir():
+            _key_name = "SEGMENT_WRITE_KEY_PROD" if env == "production" else "SEGMENT_WRITE_KEY_DEV"
+            _key_file = path / _key_name
             if _key_file.is_file():
                 _key = _decode_segment_key(_key_file.read_text().strip())
                 if _key:
-                    DYNACONF.set("SEGMENT_WRITE_KEY", _key)
+                    dynaconf_instance.set("SEGMENT_WRITE_KEY", _key)
         else:
-            _key = _decode_segment_key(_segment_path.read_text().strip())
+            _key = _decode_segment_key(path.read_text().strip())
             if _key:
-                DYNACONF.set("SEGMENT_WRITE_KEY", _key)
+                dynaconf_instance.set("SEGMENT_WRITE_KEY", _key)
     except OSError:
         pass
+
+
+_load_segment_write_key_from_file()
 
 # ALLOWED_HOSTS from environment: comma-separated list or JSON array
 if os.environ.get("METRICS_SERVICE_ALLOWED_HOSTS"):

--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -50,6 +50,7 @@ uv run dynaconf inspect -k VARIABLE
 """
 
 import base64
+import logging
 import os
 import sys
 from importlib import import_module
@@ -338,11 +339,13 @@ def _decode_segment_key(raw: str) -> str:
     try:
         return base64.b64decode(raw).decode("utf-8")
     except ValueError:
+        # Covers binascii.Error (malformed base64) and UnicodeDecodeError (non-UTF-8)
         return raw
 
 
 def _read_segment_key_from_path(path: Path, env: str) -> str | None:
     """Read SEGMENT_WRITE_KEY from a file or directory. Returns decoded key or None."""
+    logger = logging.getLogger(__name__)
     try:
         if path.is_dir():
             key_name = "SEGMENT_WRITE_KEY_PROD" if env == "production" else "SEGMENT_WRITE_KEY_DEV"
@@ -353,7 +356,14 @@ def _read_segment_key_from_path(path: Path, env: str) -> str | None:
             return None
         key = _decode_segment_key(path.read_text().strip())
         return key if key else None
-    except OSError:
+    except OSError as e:
+        filename = getattr(e, "filename", path)
+        logger.error(
+            "Failed to read segment write key from %s: %s",
+            filename,
+            e,
+            exc_info=True,
+        )
         return None
 
 
@@ -373,6 +383,11 @@ def _load_segment_write_key_from_file(
         env = environment
     if dynaconf_instance is None:
         dynaconf_instance = DYNACONF
+    # Respect env/settings precedence: do not overwrite if already set
+    if os.environ.get("METRICS_SERVICE_SEGMENT_WRITE_KEY", "").strip():
+        return
+    if dynaconf_instance.get("SEGMENT_WRITE_KEY"):
+        return
     if not path.exists():
         return
     key = _read_segment_key_from_path(path, env)

--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -341,6 +341,22 @@ def _decode_segment_key(raw: str) -> str:
         return raw
 
 
+def _read_segment_key_from_path(path: Path, env: str) -> str | None:
+    """Read SEGMENT_WRITE_KEY from a file or directory. Returns decoded key or None."""
+    try:
+        if path.is_dir():
+            key_name = "SEGMENT_WRITE_KEY_PROD" if env == "production" else "SEGMENT_WRITE_KEY_DEV"
+            key_file = path / key_name
+            if key_file.is_file():
+                key = _decode_segment_key(key_file.read_text().strip())
+                return key if key else None
+            return None
+        key = _decode_segment_key(path.read_text().strip())
+        return key if key else None
+    except OSError:
+        return None
+
+
 def _load_segment_write_key_from_file(
     path: Path | None = None,
     env: str | None = None,
@@ -359,20 +375,9 @@ def _load_segment_write_key_from_file(
         dynaconf_instance = DYNACONF
     if not path.exists():
         return
-    try:
-        if path.is_dir():
-            _key_name = "SEGMENT_WRITE_KEY_PROD" if env == "production" else "SEGMENT_WRITE_KEY_DEV"
-            _key_file = path / _key_name
-            if _key_file.is_file():
-                _key = _decode_segment_key(_key_file.read_text().strip())
-                if _key:
-                    dynaconf_instance.set("SEGMENT_WRITE_KEY", _key)
-        else:
-            _key = _decode_segment_key(path.read_text().strip())
-            if _key:
-                dynaconf_instance.set("SEGMENT_WRITE_KEY", _key)
-    except OSError:
-        pass
+    key = _read_segment_key_from_path(path, env)
+    if key:
+        dynaconf_instance.set("SEGMENT_WRITE_KEY", key)
 
 
 _load_segment_write_key_from_file()

--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -330,11 +330,11 @@ load_standard_settings_files(DYNACONF)
 load_envvars(DYNACONF)
 
 
-# SEGMENT_WRITE_KEY from file or directory (e.g. K8s secret mount with DEV/PROD keys)
-# - Single file: path to a file containing the write key (legacy).
-# - Directory: path to a dir with SEGMENT_WRITE_KEY_DEV and SEGMENT_WRITE_KEY_PROD files
-#   (K8s secret metrics-service-segment-write-keys); key chosen by METRICS_SERVICE_MODE.
-# Keys in these files are expected to be base64-encoded.
+# SEGMENT_WRITE_KEY from a single file (e.g. installed at build from pipeline secret).
+# Default path: /etc/ansible-automation-platform/metrics/segment-write-key.
+# Pipeline passes build secret metrics-service-segment-write-keys (SEGMENT_WRITE_KEY_DEV for
+# PR/devel, SEGMENT_WRITE_KEY_PROD for GA); one key is installed into that path. File content
+# is expected to be base64-encoded.
 def _decode_segment_key(raw: str) -> str:
     try:
         return base64.b64decode(raw).decode("utf-8")
@@ -343,18 +343,14 @@ def _decode_segment_key(raw: str) -> str:
         return raw
 
 
-def _read_segment_key_from_path(path: Path, env: str) -> str | None:
-    """Read SEGMENT_WRITE_KEY from a file or directory. Returns decoded key or None."""
+def _read_segment_key_from_path(path: Path) -> str | None:
+    """Read SEGMENT_WRITE_KEY from a single file (base64-encoded). Returns decoded key or None."""
     logger = logging.getLogger(__name__)
     try:
-        if path.is_dir():
-            key_name = "SEGMENT_WRITE_KEY_PROD" if env == "production" else "SEGMENT_WRITE_KEY_DEV"
-            key_file = path / key_name
-            if key_file.is_file():
-                key = _decode_segment_key(key_file.read_text().strip())
-                return key if key else None
+        if not path.is_file():
             return None
-        key = _decode_segment_key(path.read_text().strip())
+        raw = path.read_text().strip()
+        key = _decode_segment_key(raw)
         return key if key else None
     except OSError as e:
         filename = getattr(e, "filename", path)
@@ -369,18 +365,15 @@ def _read_segment_key_from_path(path: Path, env: str) -> str | None:
 
 def _load_segment_write_key_from_file(
     path: Path | None = None,
-    env: str | None = None,
     dynaconf_instance=None,
 ) -> None:
-    """Load SEGMENT_WRITE_KEY from file or directory and set on Dynaconf. Used at module load and in tests."""
+    """Load SEGMENT_WRITE_KEY from file and set on Dynaconf. Used at module load and in tests."""
     if path is None:
         _segment_write_key_path = os.environ.get(
             "METRICS_SERVICE_SEGMENT_WRITE_KEY_FILE",
             "/etc/ansible-automation-platform/metrics/segment-write-key",
         )
         path = Path(_segment_write_key_path)
-    if env is None:
-        env = environment
     if dynaconf_instance is None:
         dynaconf_instance = DYNACONF
     # Respect env/settings precedence: do not overwrite if already set
@@ -390,7 +383,7 @@ def _load_segment_write_key_from_file(
         return
     if not path.exists():
         return
-    key = _read_segment_key_from_path(path, env)
+    key = _read_segment_key_from_path(path)
     if key:
         dynaconf_instance.set("SEGMENT_WRITE_KEY", key)
 

--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -49,6 +49,7 @@ uv run dynaconf inspect -k VARIABLE
 ## Default variables
 """
 
+import base64
 import os
 import sys
 from importlib import import_module
@@ -327,17 +328,37 @@ load_standard_settings_files(DYNACONF)
 # Load envvars at the end to allow them to override everything loaded so far.
 load_envvars(DYNACONF)
 
-# SEGMENT_WRITE_KEY from file (e.g. build-time secret or runtime-mounted secret)
-_segment_write_key_file = os.environ.get(
+
+# SEGMENT_WRITE_KEY from file or directory (e.g. K8s secret mount with DEV/PROD keys)
+# - Single file: path to a file containing the write key (legacy).
+# - Directory: path to a dir with SEGMENT_WRITE_KEY_DEV and SEGMENT_WRITE_KEY_PROD files
+#   (K8s secret metrics-service-segment-write-keys); key chosen by METRICS_SERVICE_MODE.
+# Keys in these files are expected to be base64-encoded.
+def _decode_segment_key(raw: str) -> str:
+    try:
+        return base64.b64decode(raw).decode("utf-8")
+    except ValueError:
+        return raw
+
+
+_segment_write_key_path = os.environ.get(
     "METRICS_SERVICE_SEGMENT_WRITE_KEY_FILE",
     "/etc/ansible-automation-platform/metrics/segment-write-key",
 )
-if Path(_segment_write_key_file).exists():
+_segment_path = Path(_segment_write_key_path)
+if _segment_path.exists():
     try:
-        with open(_segment_write_key_file) as _f:
-            _key = _f.read().strip()
-        if _key:
-            DYNACONF.set("SEGMENT_WRITE_KEY", _key)
+        if _segment_path.is_dir():
+            _key_name = "SEGMENT_WRITE_KEY_PROD" if environment == "production" else "SEGMENT_WRITE_KEY_DEV"
+            _key_file = _segment_path / _key_name
+            if _key_file.is_file():
+                _key = _decode_segment_key(_key_file.read_text().strip())
+                if _key:
+                    DYNACONF.set("SEGMENT_WRITE_KEY", _key)
+        else:
+            _key = _decode_segment_key(_segment_path.read_text().strip())
+            if _key:
+                DYNACONF.set("SEGMENT_WRITE_KEY", _key)
     except OSError:
         pass
 

--- a/tests/unit/test_dynaconf_settings.py
+++ b/tests/unit/test_dynaconf_settings.py
@@ -87,6 +87,28 @@ class TestDynaconfValidators:
         db_validators = [v for v in validators if any("DATABASES" in str(name) for name in v.names)]
         assert len(db_validators) > 0
 
+    def test_optional_production_settings_have_no_validators(self):
+        """Test that optional production settings are not required by validators.
+
+        RESOURCE_SERVER__SECRET_KEY, ANSIBLE_BASE_JWT_KEY, SEGMENT_WRITE_KEY, and
+        ALLOWED_HOSTS are optional in production so deployments can start without
+        gateway auth, Segment, or explicit allowed hosts when not needed.
+        """
+        from apps.settings.production import validators
+
+        optional_settings = {
+            "RESOURCE_SERVER__SECRET_KEY",
+            "ANSIBLE_BASE_JWT_KEY",
+            "SEGMENT_WRITE_KEY",
+            "ALLOWED_HOSTS",
+        }
+        for v in validators:
+            for name in v.names:
+                assert name not in optional_settings, (
+                    f"Setting {name!r} should be optional (no validator); "
+                    "remove its validator from apps/settings/production.py"
+                )
+
     def test_settings_pass_validation(self):
         """Test that current settings pass validation (since we're running)."""
         from django.conf import settings

--- a/tests/unit/test_settings_segment_key.py
+++ b/tests/unit/test_settings_segment_key.py
@@ -1,7 +1,7 @@
 """
 Unit tests for segment write key loading in metrics_service.settings.
 
-Covers _decode_segment_key and _load_segment_write_key_from_file (file/dir loading).
+Covers _decode_segment_key and _load_segment_write_key_from_file (single file, base64).
 """
 
 import base64
@@ -38,7 +38,7 @@ class TestDecodeSegmentKey:
 
 @pytest.mark.unit
 class TestLoadSegmentWriteKeyFromFile:
-    """Tests for _load_segment_write_key_from_file (file/dir loading and OSError)."""
+    """Tests for _load_segment_write_key_from_file (single file, base64, and OSError)."""
 
     def test_path_does_not_exist_does_nothing(self):
         """When path does not exist, SEGMENT_WRITE_KEY is not set."""
@@ -58,6 +58,7 @@ class TestLoadSegmentWriteKeyFromFile:
         key_file = tmp_path / "segment-write-key"
         key_file.write_text(base64.b64encode(b"key-from-file").decode("ascii") + "\n")
         dynaconf_mock = mock.MagicMock()
+        dynaconf_mock.get.return_value = None
         _load_segment_write_key_from_file(path=key_file, dynaconf_instance=dynaconf_mock)
         dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "key-from-file")
 
@@ -68,35 +69,16 @@ class TestLoadSegmentWriteKeyFromFile:
         key_file = tmp_path / "segment-write-key"
         key_file.write_text("plain-write-key")
         dynaconf_mock = mock.MagicMock()
+        dynaconf_mock.get.return_value = None
         _load_segment_write_key_from_file(path=key_file, dynaconf_instance=dynaconf_mock)
         dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "plain-write-key")
 
-    def test_path_is_dir_uses_dev_key_file(self, tmp_path):
-        """When path is a directory and env is development, SEGMENT_WRITE_KEY_DEV is used."""
-        from metrics_service.settings import _load_segment_write_key_from_file
-
-        dev_file = tmp_path / "SEGMENT_WRITE_KEY_DEV"
-        dev_file.write_text(base64.b64encode(b"dev-key").decode("ascii"))
-        dynaconf_mock = mock.MagicMock()
-        _load_segment_write_key_from_file(path=tmp_path, env="development", dynaconf_instance=dynaconf_mock)
-        dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "dev-key")
-
-    def test_path_is_dir_uses_prod_key_file(self, tmp_path):
-        """When path is a directory and env is production, SEGMENT_WRITE_KEY_PROD is used."""
-        from metrics_service.settings import _load_segment_write_key_from_file
-
-        prod_file = tmp_path / "SEGMENT_WRITE_KEY_PROD"
-        prod_file.write_text(base64.b64encode(b"prod-key").decode("ascii"))
-        dynaconf_mock = mock.MagicMock()
-        _load_segment_write_key_from_file(path=tmp_path, env="production", dynaconf_instance=dynaconf_mock)
-        dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "prod-key")
-
-    def test_path_is_dir_missing_key_file_does_not_set(self, tmp_path):
-        """When path is a directory but key file is missing, SEGMENT_WRITE_KEY is not set."""
+    def test_path_is_dir_does_not_set(self, tmp_path):
+        """When path is a directory (no single key file), SEGMENT_WRITE_KEY is not set."""
         from metrics_service.settings import _load_segment_write_key_from_file
 
         dynaconf_mock = mock.MagicMock()
-        _load_segment_write_key_from_file(path=tmp_path, env="development", dynaconf_instance=dynaconf_mock)
+        _load_segment_write_key_from_file(path=tmp_path, dynaconf_instance=dynaconf_mock)
         dynaconf_mock.set.assert_not_called()
 
     def test_path_is_file_empty_key_not_set(self, tmp_path):
@@ -116,7 +98,7 @@ class TestLoadSegmentWriteKeyFromFile:
         dynaconf_mock = mock.MagicMock()
         path_mock = mock.MagicMock(spec=Path)
         path_mock.exists.return_value = True
-        path_mock.is_dir.return_value = False
+        path_mock.is_file.return_value = True
         path_mock.read_text.side_effect = OSError
         _load_segment_write_key_from_file(path=path_mock, dynaconf_instance=dynaconf_mock)
         dynaconf_mock.set.assert_not_called()

--- a/tests/unit/test_settings_segment_key.py
+++ b/tests/unit/test_settings_segment_key.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for segment write key loading in metrics_service.settings.
+
+Covers _decode_segment_key and _load_segment_write_key_from_file (file/dir loading).
+"""
+
+import base64
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+@pytest.mark.unit
+class TestDecodeSegmentKey:
+    """Tests for _decode_segment_key."""
+
+    def test_decodes_valid_base64_utf8(self):
+        """Valid base64-encoded UTF-8 string is decoded."""
+        from metrics_service.settings import _decode_segment_key
+
+        raw = base64.b64encode(b"my-segment-write-key").decode("ascii")
+        assert _decode_segment_key(raw) == "my-segment-write-key"
+
+    def test_returns_raw_on_value_error(self):
+        """Invalid base64 raises ValueError; raw string is returned."""
+        from metrics_service.settings import _decode_segment_key
+
+        assert _decode_segment_key("not-valid-base64!!!") == "not-valid-base64!!!"
+
+    def test_empty_string_decodes_to_empty(self):
+        """Empty string decodes to empty string (valid base64)."""
+        from metrics_service.settings import _decode_segment_key
+
+        raw = base64.b64encode(b"").decode("ascii")
+        assert _decode_segment_key(raw) == ""
+
+
+@pytest.mark.unit
+class TestLoadSegmentWriteKeyFromFile:
+    """Tests for _load_segment_write_key_from_file (file/dir loading and OSError)."""
+
+    def test_path_does_not_exist_does_nothing(self):
+        """When path does not exist, SEGMENT_WRITE_KEY is not set."""
+        from metrics_service.settings import DYNACONF, _load_segment_write_key_from_file
+
+        before = DYNACONF.get("SEGMENT_WRITE_KEY")
+        nonexistent = Path("/nonexistent/segment-key-path")
+        dynaconf_mock = mock.MagicMock()
+        _load_segment_write_key_from_file(path=nonexistent, dynaconf_instance=dynaconf_mock)
+        dynaconf_mock.set.assert_not_called()
+        assert DYNACONF.get("SEGMENT_WRITE_KEY") == before
+
+    def test_path_is_file_sets_key_from_decoded_content(self, tmp_path):
+        """When path is a file, key is read and set (base64 decoded)."""
+        from metrics_service.settings import _load_segment_write_key_from_file
+
+        key_file = tmp_path / "segment-write-key"
+        key_file.write_text(base64.b64encode(b"key-from-file").decode("ascii") + "\n")
+        dynaconf_mock = mock.MagicMock()
+        _load_segment_write_key_from_file(path=key_file, dynaconf_instance=dynaconf_mock)
+        dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "key-from-file")
+
+    def test_path_is_file_plain_text_passed_through(self, tmp_path):
+        """When content is not valid base64, raw content is used (ValueError path)."""
+        from metrics_service.settings import _load_segment_write_key_from_file
+
+        key_file = tmp_path / "segment-write-key"
+        key_file.write_text("plain-write-key")
+        dynaconf_mock = mock.MagicMock()
+        _load_segment_write_key_from_file(path=key_file, dynaconf_instance=dynaconf_mock)
+        dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "plain-write-key")
+
+    def test_path_is_dir_uses_dev_key_file(self, tmp_path):
+        """When path is a directory and env is development, SEGMENT_WRITE_KEY_DEV is used."""
+        from metrics_service.settings import _load_segment_write_key_from_file
+
+        dev_file = tmp_path / "SEGMENT_WRITE_KEY_DEV"
+        dev_file.write_text(base64.b64encode(b"dev-key").decode("ascii"))
+        dynaconf_mock = mock.MagicMock()
+        _load_segment_write_key_from_file(path=tmp_path, env="development", dynaconf_instance=dynaconf_mock)
+        dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "dev-key")
+
+    def test_path_is_dir_uses_prod_key_file(self, tmp_path):
+        """When path is a directory and env is production, SEGMENT_WRITE_KEY_PROD is used."""
+        from metrics_service.settings import _load_segment_write_key_from_file
+
+        prod_file = tmp_path / "SEGMENT_WRITE_KEY_PROD"
+        prod_file.write_text(base64.b64encode(b"prod-key").decode("ascii"))
+        dynaconf_mock = mock.MagicMock()
+        _load_segment_write_key_from_file(path=tmp_path, env="production", dynaconf_instance=dynaconf_mock)
+        dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "prod-key")
+
+    def test_path_is_dir_missing_key_file_does_not_set(self, tmp_path):
+        """When path is a directory but key file is missing, SEGMENT_WRITE_KEY is not set."""
+        from metrics_service.settings import _load_segment_write_key_from_file
+
+        dynaconf_mock = mock.MagicMock()
+        _load_segment_write_key_from_file(path=tmp_path, env="development", dynaconf_instance=dynaconf_mock)
+        dynaconf_mock.set.assert_not_called()
+
+    def test_path_is_file_empty_key_not_set(self, tmp_path):
+        """When file content is empty after strip, key is not set."""
+        from metrics_service.settings import _load_segment_write_key_from_file
+
+        key_file = tmp_path / "segment-write-key"
+        key_file.write_text("   \n  ")
+        dynaconf_mock = mock.MagicMock()
+        _load_segment_write_key_from_file(path=key_file, dynaconf_instance=dynaconf_mock)
+        dynaconf_mock.set.assert_not_called()
+
+    def test_os_error_suppressed(self, tmp_path):
+        """OSError when reading file is suppressed and key is not set."""
+        from metrics_service.settings import _load_segment_write_key_from_file
+
+        dynaconf_mock = mock.MagicMock()
+        path_mock = mock.MagicMock(spec=Path)
+        path_mock.exists.return_value = True
+        path_mock.is_dir.return_value = False
+        path_mock.read_text.side_effect = OSError
+        _load_segment_write_key_from_file(path=path_mock, dynaconf_instance=dynaconf_mock)
+        dynaconf_mock.set.assert_not_called()


### PR DESCRIPTION
Added opening a file for segment keys as thats how its loaded by Konflux. Temp removing validators as TP wont support gateway correction. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes production configuration validation and introduces a new secret-loading path; misconfiguration could silently skip Segment initialization or allow deployments to start without previously-required gateway/host settings.
> 
> **Overview**
> Adds support for loading `SEGMENT_WRITE_KEY` from a single (optionally base64-encoded) file via `METRICS_SERVICE_SEGMENT_WRITE_KEY_FILE`, without overriding an explicitly configured env var or existing Dynaconf value.
> 
> Relaxes production startup validation by disabling validators for `RESOURCE_SERVER__SECRET_KEY`, `ANSIBLE_BASE_JWT_KEY`, `SEGMENT_WRITE_KEY`, and `ALLOWED_HOSTS`, and adds tests to ensure these remain optional plus new unit tests covering the file-loading/decoding behavior and error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 669a6e56173998deb0f43d8101eaee28f242ed76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->