### PR TITLE
Refactor SEGMENT_WRITE_KEY handling in settings.py

### DIFF
--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -49,7 +49,6 @@ uv run dynaconf inspect -k VARIABLE
 ## Default variables
 """
 
-import base64
 import logging
 import os
 import sys
@@ -333,24 +332,15 @@ load_envvars(DYNACONF)
 # SEGMENT_WRITE_KEY from a single file (e.g. installed at build from pipeline secret).
 # Default path: /etc/ansible-automation-platform/metrics/segment-write-key.
 # Pipeline passes build secret metrics-service-segment-write-keys (SEGMENT_WRITE_KEY_DEV for
-# PR/devel, SEGMENT_WRITE_KEY_PROD for GA); one key is installed into that path. File content
-# is expected to be base64-encoded.
-def _decode_segment_key(raw: str) -> str:
-    try:
-        return base64.b64decode(raw).decode("utf-8")
-    except ValueError:
-        # Covers binascii.Error (malformed base64) and UnicodeDecodeError (non-UTF-8)
-        return raw
-
-
+# PR/devel, SEGMENT_WRITE_KEY_PROD for GA); one key is installed into that path.
+# File content is the raw plaintext key (no encoding).
 def _read_segment_key_from_path(path: Path) -> str | None:
-    """Read SEGMENT_WRITE_KEY from a single file (base64-encoded). Returns decoded key or None."""
+    """Read SEGMENT_WRITE_KEY from a single file. Returns the key or None."""
     logger = logging.getLogger(__name__)
     try:
         if not path.is_file():
             return None
-        raw = path.read_text().strip()
-        key = _decode_segment_key(raw)
+        key = path.read_text().strip()
         return key if key else None
     except OSError as e:
         filename = getattr(e, "filename", path)

--- a/tests/unit/test_settings_segment_key.py
+++ b/tests/unit/test_settings_segment_key.py
@@ -1,10 +1,9 @@
 """
 Unit tests for segment write key loading in metrics_service.settings.
 
-Covers _decode_segment_key and _load_segment_write_key_from_file (single file, base64).
+Covers _load_segment_write_key_from_file (single file, plaintext).
 """
 
-import base64
 from pathlib import Path
 from unittest import mock
 
@@ -12,33 +11,8 @@ import pytest
 
 
 @pytest.mark.unit
-class TestDecodeSegmentKey:
-    """Tests for _decode_segment_key."""
-
-    def test_decodes_valid_base64_utf8(self):
-        """Valid base64-encoded UTF-8 string is decoded."""
-        from metrics_service.settings import _decode_segment_key
-
-        raw = base64.b64encode(b"my-segment-write-key").decode("ascii")
-        assert _decode_segment_key(raw) == "my-segment-write-key"
-
-    def test_returns_raw_on_value_error(self):
-        """Invalid base64 raises ValueError; raw string is returned."""
-        from metrics_service.settings import _decode_segment_key
-
-        assert _decode_segment_key("not-valid-base64!!!") == "not-valid-base64!!!"
-
-    def test_empty_string_decodes_to_empty(self):
-        """Empty string decodes to empty string (valid base64)."""
-        from metrics_service.settings import _decode_segment_key
-
-        raw = base64.b64encode(b"").decode("ascii")
-        assert _decode_segment_key(raw) == ""
-
-
-@pytest.mark.unit
 class TestLoadSegmentWriteKeyFromFile:
-    """Tests for _load_segment_write_key_from_file (single file, base64, and OSError)."""
+    """Tests for _load_segment_write_key_from_file (single plaintext file)."""
 
     def test_path_does_not_exist_does_nothing(self):
         """When path does not exist, SEGMENT_WRITE_KEY is not set."""
@@ -51,30 +25,30 @@ class TestLoadSegmentWriteKeyFromFile:
         dynaconf_mock.set.assert_not_called()
         assert DYNACONF.get("SEGMENT_WRITE_KEY") == before
 
-    def test_path_is_file_sets_key_from_decoded_content(self, tmp_path):
-        """When path is a file, key is read and set (base64 decoded)."""
+    def test_path_is_file_sets_key_from_plaintext(self, tmp_path):
+        """When path is a file, the raw plaintext key is read and set as-is."""
         from metrics_service.settings import _load_segment_write_key_from_file
 
         key_file = tmp_path / "segment-write-key"
-        key_file.write_text(base64.b64encode(b"key-from-file").decode("ascii") + "\n")
+        key_file.write_text("my-plaintext-write-key\n")
         dynaconf_mock = mock.MagicMock()
         dynaconf_mock.get.return_value = None
         _load_segment_write_key_from_file(path=key_file, dynaconf_instance=dynaconf_mock)
-        dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "key-from-file")
+        dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "my-plaintext-write-key")
 
-    def test_path_is_file_plain_text_passed_through(self, tmp_path):
-        """When content is not valid base64, raw content is used (ValueError path)."""
+    def test_path_is_file_whitespace_stripped(self, tmp_path):
+        """Leading/trailing whitespace and newlines are stripped from the key."""
         from metrics_service.settings import _load_segment_write_key_from_file
 
         key_file = tmp_path / "segment-write-key"
-        key_file.write_text("plain-write-key")
+        key_file.write_text("  key-with-spaces  \n")
         dynaconf_mock = mock.MagicMock()
         dynaconf_mock.get.return_value = None
         _load_segment_write_key_from_file(path=key_file, dynaconf_instance=dynaconf_mock)
-        dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "plain-write-key")
+        dynaconf_mock.set.assert_called_once_with("SEGMENT_WRITE_KEY", "key-with-spaces")
 
     def test_path_is_dir_does_not_set(self, tmp_path):
-        """When path is a directory (no single key file), SEGMENT_WRITE_KEY is not set."""
+        """When path is a directory (not a file), SEGMENT_WRITE_KEY is not set."""
         from metrics_service.settings import _load_segment_write_key_from_file
 
         dynaconf_mock = mock.MagicMock()


### PR DESCRIPTION
- Removed base64 decoding for SEGMENT_WRITE_KEY, simplifying the key loading process to read plaintext directly from the file.
- Updated unit tests to reflect changes in key handling, ensuring robust testing for reading plaintext keys and stripping whitespace.
- Enhanced documentation in tests to clarify the new behavior of the key loading function.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change may break environments that currently provision a base64-encoded key file, resulting in an invalid Segment write key until secrets are updated.
> 
> **Overview**
> `SEGMENT_WRITE_KEY` loading from `/etc/.../segment-write-key` is simplified to read and strip a plaintext key directly, removing the base64 decode path and related helper/import in `metrics_service/settings.py`.
> 
> Unit tests are updated to drop base64 decoding coverage and instead validate plaintext behavior (whitespace stripping, empty content, non-file paths, and suppressed `OSError`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98a318ef601c37a24facfc7350240d11eeebbe02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->