### PR TITLE
Update settings.py turning validation off

### DIFF
--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -449,6 +449,6 @@ if (env_settings := Path(apps_settings_dir / f"{environment}.py")).exists():
         DYNACONF.validators.register(*env_module.validators)
 
 # Update django.conf.settings with DYNACONF keys.
-export(__name__, DYNACONF, validation=True)
+export(__name__, DYNACONF, validation=False)
 
 ## --- End Settings | After this line only post validation can happen --- #


### PR DESCRIPTION
turning validation off until gateway is full implemented


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disables settings validation at runtime, which can let invalid/missing configuration slip through and fail later in harder-to-debug ways.
> 
> **Overview**
> Turns off Dynaconf validation when exporting configuration into `django.conf.settings` by changing `export(..., validation=True)` to `validation=False` in `metrics_service/settings.py`, effectively bypassing validator enforcement during settings load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f550d94416979202de94adaca00088929b516fd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->