### PR TITLE
Update dispatcher configuration to reduce max workers from 4 to 1 and…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ EXPOSE 8080 8443 8000
 # docker-compose can override with entrypoint: ["/usr/local/bin/entrypoint-web.sh"] etc. for split services.
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 # App binds to 127.0.0.1:8000; Nginx proxies external 8080/8443 to it.
-CMD ["python3.12", "manage.py", "metrics_service", "run", "--host", "127.0.0.1", "--port", "8000", "--workers", "4"]
+CMD ["python3.12", "manage.py", "metrics_service", "run", "--host", "127.0.0.1", "--port", "8000", "--workers", "1"]
 
 LABEL com.redhat.component="ansible-automation-platform-tech-preview-metrics-service-rhel9" \
     name="ansible-automation-platform-tech-preview/metrics-service-rhel9" \

--- a/apps/settings/dispatcherd.yaml
+++ b/apps/settings/dispatcherd.yaml
@@ -23,7 +23,7 @@ brokers:
 
 service:
   pool_kwargs:
-    max_workers: 4
+    max_workers: 1
 
   # Task execution settings
   task_settings:

--- a/apps/tasks/dispatcherd_config.py
+++ b/apps/tasks/dispatcherd_config.py
@@ -161,7 +161,7 @@ def build_config_from_django_settings() -> dict[str, Any]:
                 },
             },
             "service": {
-                "pool_kwargs": {"max_workers": 4},
+                "pool_kwargs": {"max_workers": 1},
             },
         }
 

--- a/apps/tasks/management/commands/metrics_service.py
+++ b/apps/tasks/management/commands/metrics_service.py
@@ -79,8 +79,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "--workers",
             type=int,
-            default=4,
-            help="Number of workers for both Gunicorn and dispatcher when not overridden (default: 4)",
+            default=1,
+            help="Number of workers for both Gunicorn and dispatcher when not overridden (default: 1)",
         )
         parser.add_argument(
             "--gunicorn-workers",
@@ -744,7 +744,7 @@ class Command(BaseCommand):
 
     def _extract_config(self, options: dict[str, Any]) -> dict[str, Any]:
         """Extract configuration from command options."""
-        workers = options.get("workers", 4)
+        workers = options.get("workers", 1)
         # argparse sets gunicorn_workers/dispatcher_workers to None when not passed;
         # treat None as "use workers" so options.get(..., workers) works as intended
         gunicorn_workers = options.get("gunicorn_workers")

--- a/apps/tasks/management/commands/run_dispatcherd.py
+++ b/apps/tasks/management/commands/run_dispatcherd.py
@@ -24,8 +24,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "--workers",
             type=int,
-            default=4,
-            help="Number of worker processes (default: 4)",
+            default=1,
+            help="Number of worker processes (default: 1)",
         )
         parser.add_argument(
             "--timeout",

--- a/docker-compose.prod.single.yml
+++ b/docker-compose.prod.single.yml
@@ -1,7 +1,7 @@
 # Production-style orchestration for metrics-service.
 #
 # Uses the main Dockerfile (Gunicorn + Dispatcher + Scheduler via
-# `python manage.py metrics_service run --workers 4`). Static files
+# `python manage.py metrics_service run --workers 1`). Static files
 # are collected at build time and served by WhiteNoise in the same
 # container. For high traffic, you can put Nginx (or another reverse
 # proxy) in front and serve /static/ from Nginx or a CDN.
@@ -40,7 +40,7 @@ services:
     container_name: metrics-service-prod
     # All-in-one: entrypoint starts Nginx (8080/8443) then runs the app command (Gunicorn on 127.0.0.1:8000 + Dispatcher + Scheduler)
     entrypoint: ["/usr/local/bin/docker-entrypoint.sh"]
-    command: ["python3.12", "manage.py", "metrics_service", "run", "--host", "127.0.0.1", "--port", "8000", "--workers", "4"]
+    command: ["python3.12", "manage.py", "metrics_service", "run", "--host", "127.0.0.1", "--port", "8000", "--workers", "1"]
     ports:
       - "${METRICS_SERVICE_HTTPS_PORT:-8443}:8443"
       - "${METRICS_SERVICE_HTTP_PORT:-8080}:8080"

--- a/tests/unit/tasks/test_dispatcherd_config.py
+++ b/tests/unit/tasks/test_dispatcherd_config.py
@@ -367,7 +367,7 @@ class TestBuildConfigFromDjangoSettings:
 
         assert "service" in config
         assert "pool_kwargs" in config["service"]
-        assert config["service"]["pool_kwargs"]["max_workers"] == 4
+        assert config["service"]["pool_kwargs"]["max_workers"] == 1
 
     @patch("django.conf.settings")
     @patch("apps.tasks.dispatcherd_config.logger")

--- a/tests/unit/tasks/test_run_dispatcherd_command.py
+++ b/tests/unit/tasks/test_run_dispatcherd_command.py
@@ -53,7 +53,7 @@ class TestRunDispatcherdCommand(TestCase):
         # Verify argument configuration
         call_kwargs = calls[0][1]
         self.assertEqual(call_kwargs["type"], int)
-        self.assertEqual(call_kwargs["default"], 4)
+        self.assertEqual(call_kwargs["default"], 1)
         self.assertIn("worker", call_kwargs["help"].lower())
 
     def test_add_arguments_timeout(self):


### PR DESCRIPTION
… adjust command-line argument defaults accordingly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only reduces default concurrency for Gunicorn/dispatcherd and updates related configs/tests; the main impact is potentially lower throughput and longer task backlogs under load.
> 
> **Overview**
> Reduces the default worker/concurrency settings across the deployment and CLI entrypoints from **4 to 1** (Docker `CMD`, `dispatcherd.yaml` `max_workers`, and the `metrics_service`/`run_dispatcherd` `--workers` defaults).
> 
> Updates the single-container production compose example and unit tests to match the new defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1e6afb9aff00dd6e9e24658776a34c701184afa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->