### PR TITLE
Normalize PostgreSQL session parameters in DATABASES options for impr…

### DIFF
--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -448,6 +448,20 @@ if (env_settings := Path(apps_settings_dir / f"{environment}.py")).exists():
     if hasattr(env_module, "validators"):
         DYNACONF.validators.register(*env_module.validators)
 
+# Normalize DATABASES OPTIONS: move PostgreSQL session parameters into the psycopg2 'options' string.
+# This allows installers to set e.g. METRICS_SERVICE_DATABASES__awx__OPTIONS__datestyle=iso, mdy
+# without needing to know the psycopg2-specific OPTIONS__options=-c datestyle=... syntax.
+_PG_SESSION_PARAMS = {"datestyle", "search_path", "timezone", "application_name"}
+_databases = DYNACONF.get("DATABASES", {})
+for _db_conf in _databases.values():
+    _opts = _db_conf.get("OPTIONS", {})
+    _session_params = {k: _opts.pop(k) for k in list(_opts) if k.lower() in _PG_SESSION_PARAMS}
+    if _session_params:
+        _existing = _opts.get("options", "")
+        _new = " ".join(f"-c {k}={v.replace(' ', '')}" for k, v in _session_params.items())
+        _opts["options"] = f"{_existing} {_new}".strip()
+DYNACONF.set("DATABASES", _databases)
+
 # Update django.conf.settings with DYNACONF keys.
 export(__name__, DYNACONF, validation=False)
 


### PR DESCRIPTION
…oved configuration flexibility. This change allows users to set session parameters like datestyle and timezone without needing to use psycopg2-specific syntax, enhancing usability in settings management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches database connection configuration by rewriting `DATABASES[*].OPTIONS`, which could affect runtime DB connectivity or session behavior if options are formatted unexpectedly.
> 
> **Overview**
> Adds post-load normalization of `DATABASES` configuration to translate common PostgreSQL session parameters (e.g. `datestyle`, `timezone`, `search_path`, `application_name`) from `DATABASES[*].OPTIONS` into the psycopg2 `OPTIONS.options` `-c key=value` string.
> 
> This makes envvar-based configuration like `...__OPTIONS__datestyle=...` work without requiring users to provide psycopg2-specific `options` syntax, while preserving any preexisting `options` value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 649e3dabe49970e5e54659e8bcaafbe341a20617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->