### PR TITLE
Refactor task submission in UnifiedTaskScheduler to use registered ca…

### DIFF
--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -215,8 +215,8 @@ class UnifiedTaskScheduler:
 
             queue = get_queue_for_function(function_name)
 
-            # Submit to dispatcherd using string reference for consistency
-            submit_task(f"apps.tasks.tasks.{function_name}", kwargs=task_args, queue=queue)
+            # Submit the registered callable directly — submit_task does not resolve strings
+            submit_task(TASK_FUNCTIONS[function_name], kwargs=task_args, queue=queue)
 
             logger.info(f"Submitted scheduled task {task_id} ({function_name}) to queue {queue}")
 

--- a/tests/unit/tasks/test_unified_scheduler.py
+++ b/tests/unit/tasks/test_unified_scheduler.py
@@ -347,14 +347,14 @@ class TestUnifiedTaskScheduler:
         mock_hello_world = Mock()
         scheduler = UnifiedTaskScheduler()
 
-        with patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {"hello_world": mock_hello_world}):
-            with patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured") as mock_ensure:
-                scheduler._execute_scheduled_task("test_task", "hello_world", {"message": "test"})
+        with (
+            patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {"hello_world": mock_hello_world}),
+            patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured") as mock_ensure,
+        ):
+            scheduler._execute_scheduled_task("test_task", "hello_world", {"message": "test"})
 
-                mock_ensure.assert_called_once()
-                mock_submit.assert_called_once_with(
-                    mock_hello_world, kwargs={"message": "test"}, queue="metrics_tasks"
-                )
+            mock_ensure.assert_called_once()
+            mock_submit.assert_called_once_with(mock_hello_world, kwargs={"message": "test"}, queue="metrics_tasks")
 
     @patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {})
     def test_execute_scheduled_task_unknown_function(self):

--- a/tests/unit/tasks/test_unified_scheduler.py
+++ b/tests/unit/tasks/test_unified_scheduler.py
@@ -341,19 +341,20 @@ class TestUnifiedTaskScheduler:
         with pytest.raises(ValueError, match="Unknown task function: unknown_function"):
             scheduler._add_scheduled_task("test_task", config)
 
-    @patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {"hello_world": Mock()})
     @patch("dispatcherd.publish.submit_task")
     def test_execute_scheduled_task_success(self, mock_submit):
         """Test successful scheduled task execution."""
+        mock_hello_world = Mock()
         scheduler = UnifiedTaskScheduler()
 
-        with patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured") as mock_ensure:
-            scheduler._execute_scheduled_task("test_task", "hello_world", {"message": "test"})
+        with patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {"hello_world": mock_hello_world}):
+            with patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured") as mock_ensure:
+                scheduler._execute_scheduled_task("test_task", "hello_world", {"message": "test"})
 
-            mock_ensure.assert_called_once()
-            mock_submit.assert_called_once_with(
-                "apps.tasks.tasks.hello_world", kwargs={"message": "test"}, queue="metrics_tasks"
-            )
+                mock_ensure.assert_called_once()
+                mock_submit.assert_called_once_with(
+                    mock_hello_world, kwargs={"message": "test"}, queue="metrics_tasks"
+                )
 
     @patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {})
     def test_execute_scheduled_task_unknown_function(self):


### PR DESCRIPTION
…llables instead of string references for improved consistency and performance.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how scheduled tasks are submitted to `dispatcherd` (callable vs string reference), which could break scheduling/dispatch at runtime if task registration or `submit_task` expectations differ. Scope is small but affects production task execution paths.
> 
> **Overview**
> Scheduled task execution in `UnifiedTaskScheduler._execute_scheduled_task` now submits the registered function callable from `TASK_FUNCTIONS` instead of a string module path, aligning with `dispatcherd.publish.submit_task` behavior.
> 
> Unit tests were updated to patch `TASK_FUNCTIONS` within the test and assert `submit_task` is called with the mocked callable rather than a string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a7cdea0e9c3804632154eea57999758e28ae788. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->