### PR TITLE
Add auto-retry functionality for failed tasks in execute_db_task

### DIFF
--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -92,6 +92,13 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
 
         log_task_execution(task.name, "completed", f"Task execution finished with status: {status}")
 
+        # Auto-retry if the task failed and has attempts remaining
+        if status == "failed":
+            task.refresh_from_db()
+            if task.can_retry():
+                logger.info(f"Auto-retrying task {task.name} (attempt {task.attempts}/{task.max_attempts})")
+                task.retry()
+
         return result
 
     except Exception as e:


### PR DESCRIPTION
- Implemented logic to automatically retry tasks that fail, provided they have remaining attempts. This enhancement improves task resilience and reliability by allowing for automatic recovery from transient failures during execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automatic retry submission for failed tasks, which can increase execution frequency and amplify side effects if task functions aren’t idempotent. Bounded by `max_attempts`, but changes task lifecycle and dispatcher load behavior.
> 
> **Overview**
> `execute_db_task` now automatically retries a task when execution finishes in `failed` status and `task.can_retry()` indicates remaining attempts.
> 
> On failure it refreshes the task from the DB, logs an "Auto-retrying" message, and calls `task.retry()` to reset state and (when applicable) re-submit the task to the dispatcher.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6d2888d2217264739f12e02c18cac351fa60c1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->