### PR TITLE
Fix/service prefix url prefix

### DIFF
--- a/apps/core/middleware/service_prefix.py
+++ b/apps/core/middleware/service_prefix.py
@@ -10,6 +10,9 @@ generates canonical /api/... URLs.
 
 For the /<service-name> case, SCRIPT_NAME is set so reverse()
 generates /<service-name>/... URLs.
+
+The service name is determined by URL_PREFIX when set (e.g. URL_PREFIX="/api/metrics"
+gives service_prefix="/metrics"), falling back to a name derived from ROOT_URLCONF.
 """
 
 from django.conf import settings
@@ -23,13 +26,24 @@ class ServicePrefixMiddleware:
     Two routing modes:
     1. /api/<service-name>/... → /api/... (no SCRIPT_NAME, canonical URLs)
     2. /<service-name>/... → /... (SCRIPT_NAME set for prefixed URLs)
+
+    The prefix is taken from URL_PREFIX when set (e.g. "/api/metrics"), falling
+    back to a name derived from ROOT_URLCONF (e.g. "metrics_service" → "/metrics-service").
     """
 
     def __init__(self, get_response):
         self.get_response = get_response
-        # Get service name from ROOT_URLCONF (e.g., "metrics_service" -> "metrics-service")
-        self.service_name = settings.ROOT_URLCONF.split(".")[0].replace("_", "-")
-        self.service_prefix = f"/{self.service_name}"
+        url_prefix = getattr(settings, "URL_PREFIX", None)
+        if url_prefix:
+            # URL_PREFIX is the full API prefix, e.g. "/api/metrics"
+            self.api_prefix = url_prefix.rstrip("/")
+            # Derive the bare service prefix by stripping the leading "/api"
+            self.service_prefix = self.api_prefix[4:] if self.api_prefix.startswith("/api") else self.api_prefix
+        else:
+            # Fall back to deriving from ROOT_URLCONF (e.g. "metrics_service" → "/metrics-service")
+            service_name = settings.ROOT_URLCONF.split(".")[0].replace("_", "-")
+            self.service_prefix = f"/{service_name}"
+            self.api_prefix = f"/api{self.service_prefix}"
 
     def __call__(self, request):
         path = request.path_info
@@ -39,7 +53,7 @@ class ServicePrefixMiddleware:
         # Store the API prefix so views can build correct absolute URLs
         # Store original path for DRF breadcrumbs
         # Patch get_full_path to return the original path for templates
-        api_prefix = f"/api{self.service_prefix}"
+        api_prefix = self.api_prefix
         if path.startswith(api_prefix):
             request._original_path = path
             request._api_service_prefix = api_prefix

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -138,6 +138,62 @@ class TestServicePrefixMiddlewareUnit(TestCase):
         middleware = ServicePrefixMiddleware(mock_get_response)
         self.assertIsNotNone(middleware)
 
+    def test_middleware_uses_url_prefix_when_set(self):
+        """When URL_PREFIX is set, api_prefix and service_prefix are derived from it."""
+        from apps.core.middleware import ServicePrefixMiddleware
+
+        with self.settings(URL_PREFIX="/api/metrics"):
+
+            def mock_get_response(request):
+                from django.http import HttpResponse
+
+                return HttpResponse("OK")
+
+            middleware = ServicePrefixMiddleware(mock_get_response)
+            self.assertEqual(middleware.api_prefix, "/api/metrics")
+            self.assertEqual(middleware.service_prefix, "/metrics")
+
+    def test_middleware_falls_back_to_root_urlconf_when_url_prefix_unset(self):
+        """When URL_PREFIX is None, prefix is derived from ROOT_URLCONF."""
+        from apps.core.middleware import ServicePrefixMiddleware
+
+        with self.settings(URL_PREFIX=None):
+
+            def mock_get_response(request):
+                from django.http import HttpResponse
+
+                return HttpResponse("OK")
+
+            middleware = ServicePrefixMiddleware(mock_get_response)
+            expected_service_name = settings.ROOT_URLCONF.split(".")[0].replace("_", "-")
+            self.assertEqual(middleware.service_prefix, f"/{expected_service_name}")
+            self.assertEqual(middleware.api_prefix, f"/api/{expected_service_name}")
+
+    def test_middleware_routes_url_prefix_path(self):
+        """Requests at URL_PREFIX path are routed correctly."""
+        with self.settings(URL_PREFIX="/api/metrics"):
+            response = self.client.get("/api/metrics/v1/")
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertIn("v1", data)
+            for url in data.values():
+                self.assertIn("/api/metrics/v1/", url)
+
+    def test_middleware_strips_trailing_slash_from_url_prefix(self):
+        """URL_PREFIX with a trailing slash is handled correctly."""
+        from apps.core.middleware import ServicePrefixMiddleware
+
+        with self.settings(URL_PREFIX="/api/metrics/"):
+
+            def mock_get_response(request):
+                from django.http import HttpResponse
+
+                return HttpResponse("OK")
+
+            middleware = ServicePrefixMiddleware(mock_get_response)
+            self.assertEqual(middleware.api_prefix, "/api/metrics")
+            self.assertEqual(middleware.service_prefix, "/metrics")
+
 
 class TestAPIRootViewMiddlewareUnit(TestCase):
     """Unit tests for APIRootViewMiddleware."""

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -172,12 +172,12 @@ class TestServicePrefixMiddlewareUnit(TestCase):
     def test_middleware_routes_url_prefix_path(self):
         """Requests at URL_PREFIX path are routed correctly."""
         with self.settings(URL_PREFIX="/api/metrics"):
-            response = self.client.get("/api/metrics/v1/")
+            response = self.client.get("/api/metrics/")
             self.assertEqual(response.status_code, 200)
             data = response.json()
             self.assertIn("v1", data)
             for url in data.values():
-                self.assertIn("/api/metrics/v1/", url)
+                self.assertIn("/api/metrics/", url)
 
     def test_middleware_strips_trailing_slash_from_url_prefix(self):
         """URL_PREFIX with a trailing slash is handled correctly."""

--- a/apps/settings/production.py
+++ b/apps/settings/production.py
@@ -214,6 +214,14 @@ SEGMENT_WRITE_KEY = ""
 # )
 
 # =============================================================================
+# Static Files
+# =============================================================================
+
+# Override BASE_DIR-relative default so static files land in a known writable
+# location regardless of where the package is installed (e.g. site-packages).
+STATIC_ROOT = "/var/lib/ansible-automation-platform/metrics/staticfiles"
+
+# =============================================================================
 # URL Configuration
 # =============================================================================
 

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -192,9 +192,7 @@ class UnifiedTaskScheduler:
                 return
 
             if task.status in ("cancelled", "completed"):
-                logger.warning(
-                    f"System task '{task_id}' has status '{task.status}' and will not be executed"
-                )
+                logger.warning(f"System task '{task_id}' has status '{task.status}' and will not be executed")
                 return
 
             # Re-check the feature flag stored in task_data so that disabling the flag

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -177,7 +177,8 @@ class UnifiedTaskScheduler:
         Args:
             task_id: Unique identifier for the task (matches Task.name for system tasks)
             function_name: Name of the function to execute
-            args: Arguments originally registered with the scheduler (used for feature flag check only)
+            args: Arguments originally registered with the scheduler (unused; feature flag is
+                  re-read from task.task_data at runtime to reflect the current DB state)
         """
         try:
             from .models import Task
@@ -189,6 +190,22 @@ class UnifiedTaskScheduler:
                     f"System task '{task_id}' not found in database - run 'manage.py metrics_service init-system-tasks'"
                 )
                 return
+
+            if task.status in ("cancelled", "completed"):
+                logger.warning(
+                    f"System task '{task_id}' has status '{task.status}' and will not be executed"
+                )
+                return
+
+            # Re-check the feature flag stored in task_data so that disabling the flag
+            # at runtime stops execution without requiring a scheduler restart.
+            feature_flag = task.task_data.get("_feature_flag") if task.task_data else None
+            if feature_flag:
+                from .task_groups import get_feature_enabled_from_db
+
+                if not get_feature_enabled_from_db(feature_flag):
+                    logger.info(f"Skipping task '{task_id}': feature flag '{feature_flag}' is disabled")
+                    return
 
             self._execute_database_task(task.id)
 

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -176,9 +176,12 @@ class UnifiedTaskScheduler:
 
         Args:
             task_id: Unique identifier for the task (matches Task.name for system tasks)
-            function_name: Name of the function to execute
-            args: Arguments originally registered with the scheduler (unused; feature flag is
-                  re-read from task.task_data at runtime to reflect the current DB state)
+            function_name: Unused. The function to execute is determined by the DB task record
+                  inside _execute_database_task; this parameter exists only because APScheduler
+                  was originally registered with it and removing it would require re-registering
+                  all scheduled jobs.
+            args: Unused. The feature flag and other task data are re-read from task.task_data
+                  at runtime to reflect the current DB state.
         """
         try:
             from .models import Task

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -169,56 +169,28 @@ class UnifiedTaskScheduler:
 
     def _execute_scheduled_task(self, task_id: str, function_name: str, args: dict[str, Any]):
         """
-        Execute a scheduled task by submitting it to dispatcherd.
+        Execute a scheduled task by looking it up from the DB and routing through execute_db_task.
 
-        Checks feature flags at runtime before execution to ensure tasks
-        are only run when their associated feature is enabled.
+        This ensures task_data always comes from the DB (maintained by init-system-tasks),
+        and all tasks go through the same lifecycle management path as DB-scheduled tasks.
 
         Args:
-            task_id: Unique identifier for the task
+            task_id: Unique identifier for the task (matches Task.name for system tasks)
             function_name: Name of the function to execute
-            args: Arguments to pass to the function (may contain _feature_flag)
+            args: Arguments originally registered with the scheduler (used for feature flag check only)
         """
         try:
-            # FIXME: probably doesn't make sense here at all? why only scheduled?
-            # ..feature_flag TaskGroup, but ignored because wrong type
+            from .models import Task
 
-            # Check feature flag from args
-            feature_flag_to_check = args.get("_feature_flag")
+            task = Task.objects.filter(name=task_id, is_system_task=True).first()
 
-            if feature_flag_to_check:
-                from .task_groups import get_feature_enabled_from_db
+            if not task:
+                logger.error(
+                    f"System task '{task_id}' not found in database - run 'manage.py metrics_service init-system-tasks'"
+                )
+                return
 
-                is_enabled = get_feature_enabled_from_db(feature_flag_to_check, False)
-                if not is_enabled:
-                    logger.info(
-                        f"Skipping task {task_id} ({function_name}): feature flag {feature_flag_to_check} is disabled"
-                    )
-                    return
-
-            # Remove _feature_flag from args before passing to task function
-            task_args = {k: v for k, v in args.items() if k != "_feature_flag"}
-
-            # Ensure dispatcherd is configured before attempting to submit tasks
-            from .dispatcherd_config import ensure_dispatcherd_configured
-
-            ensure_dispatcherd_configured()
-
-            from dispatcherd.publish import submit_task
-
-            # Validate the task function exists
-            if function_name not in TASK_FUNCTIONS:
-                raise ValueError(f"Unknown task function: {function_name}")
-
-            # Determine queue based on function name
-            from .dispatcherd_config import get_queue_for_function
-
-            queue = get_queue_for_function(function_name)
-
-            # Submit to dispatcherd using string reference for consistency
-            submit_task(f"apps.tasks.tasks.{function_name}", kwargs=task_args, queue=queue)
-
-            logger.info(f"Submitted scheduled task {task_id} ({function_name}) to queue {queue}")
+            self._execute_database_task(task.id)
 
         except Exception as e:
             logger.error(f"Failed to execute scheduled task {task_id}: {str(e)}")

--- a/apps/tasks/tests/test_feature_flag_runtime_check.py
+++ b/apps/tasks/tests/test_feature_flag_runtime_check.py
@@ -1,127 +1,134 @@
 """
 Tests for runtime feature flag checking in task scheduler.
+
+The implementation reads _feature_flag from task.task_data (live DB) at execution time,
+then routes through _execute_database_task. All DB access is mocked here so these tests
+do not require @pytest.mark.django_db.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from apps.tasks.cron_scheduler import UnifiedTaskScheduler
 
 
+def _make_mock_task(task_id=42, task_data=None):
+    """Return a MagicMock resembling a Task DB object."""
+    mock_task = MagicMock()
+    mock_task.id = task_id
+    mock_task.task_data = task_data if task_data is not None else {}
+    return mock_task
+
+
 @pytest.mark.unit
 class TestFeatureFlagRuntimeCheck:
-    """Test runtime feature flag checking for task execution."""
+    """Test runtime feature flag checking for task execution.
 
+    _execute_scheduled_task reads _feature_flag from the live DB task record so that
+    toggling the flag takes effect immediately without restarting the scheduler or
+    re-running init-system-tasks.
+    """
+
+    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
-    @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")
-    @patch("dispatcherd.publish.submit_task")
-    def test_task_executes_when_feature_flag_enabled(self, mock_submit, mock_ensure, mock_get_feature):
-        """Test that task executes when its feature flag is enabled."""
-        mock_get_feature.return_value = True  # Feature is enabled
+    @patch("apps.tasks.models.Task")
+    def test_task_executes_when_feature_flag_enabled(self, mock_task_cls, mock_get_feature, mock_execute_db):
+        """Task is routed to _execute_database_task when its feature flag is enabled."""
+        mock_get_feature.return_value = True
+        mock_task_cls.objects.filter.return_value.first.return_value = _make_mock_task(
+            task_id=1, task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
+        )
 
         scheduler = UnifiedTaskScheduler()
-
-        # Execute a task with a feature flag (using hello_world for testing)
         scheduler._execute_scheduled_task(
             task_id="test_task",
             function_name="hello_world",
-            args={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"},
+            args={},
         )
 
-        # Verify task was submitted
-        mock_submit.assert_called_once()
+        mock_get_feature.assert_called_once_with("ANONYMIZED_DATA_COLLECTION")
+        mock_execute_db.assert_called_once_with(1)
 
+    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
-    @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")
-    @patch("dispatcherd.publish.submit_task")
-    def test_task_skips_when_feature_flag_disabled(self, mock_submit, mock_ensure, mock_get_feature):
-        """Test that task is skipped when its feature flag is disabled."""
-        mock_get_feature.return_value = False  # Feature is disabled
+    @patch("apps.tasks.models.Task")
+    def test_task_skips_when_feature_flag_disabled(self, mock_task_cls, mock_get_feature, mock_execute_db):
+        """Task is NOT dispatched when its feature flag is disabled in the DB."""
+        mock_get_feature.return_value = False
+        mock_task_cls.objects.filter.return_value.first.return_value = _make_mock_task(
+            task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
+        )
 
         scheduler = UnifiedTaskScheduler()
-
-        # Execute a task with a feature flag (using hello_world for testing)
         scheduler._execute_scheduled_task(
             task_id="test_task",
             function_name="hello_world",
-            args={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"},
+            args={},
         )
 
-        # Verify task was NOT submitted
-        mock_submit.assert_not_called()
+        mock_get_feature.assert_called_once_with("ANONYMIZED_DATA_COLLECTION")
+        mock_execute_db.assert_not_called()
 
-    @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")
-    @patch("dispatcherd.publish.submit_task")
-    def test_task_executes_when_no_feature_flag(self, mock_submit, mock_ensure):
-        """Test that task executes normally when no feature flag is specified."""
+    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
+    @patch("apps.tasks.models.Task")
+    def test_task_executes_when_no_feature_flag(self, mock_task_cls, mock_execute_db):
+        """Task executes without a feature flag check when task_data has no _feature_flag."""
+        mock_task = _make_mock_task(task_id=5, task_data={})
+        mock_task_cls.objects.filter.return_value.first.return_value = mock_task
+
         scheduler = UnifiedTaskScheduler()
-
-        # Execute a task without a feature flag
         scheduler._execute_scheduled_task(task_id="test_task", function_name="hello_world", args={})
 
-        # Verify task was submitted
-        mock_submit.assert_called_once()
+        mock_execute_db.assert_called_once_with(5)
 
     def test_get_all_enabled_tasks_includes_feature_flag(self):
-        """Test that get_all_enabled_tasks includes feature_flag from group in task configs."""
+        """get_all_enabled_tasks propagates the group's feature_flag into each task config."""
         from apps.tasks.task_groups import METRICS_COLLECTION_GROUP, get_all_enabled_tasks
 
-        # Get all enabled tasks
         all_tasks = get_all_enabled_tasks()
 
-        # Check that metrics collection tasks have the group's feature flag
         for task in METRICS_COLLECTION_GROUP.tasks:
             task_id = task["task_id"]
             if task_id in all_tasks:
-                # Task should have feature_flag from the group
                 assert "feature_flag" in all_tasks[task_id]
                 assert all_tasks[task_id]["feature_flag"] == "ANONYMIZED_DATA_COLLECTION"
 
+    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
-    @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")
-    @patch("dispatcherd.publish.submit_task")
-    def test_feature_flag_checked_at_execution_time(self, mock_submit, mock_ensure, mock_get_feature):
-        """Test that feature flag is checked at execution time, not at registration."""
+    @patch("apps.tasks.models.Task")
+    def test_feature_flag_checked_at_execution_time(self, mock_task_cls, mock_get_feature, mock_execute_db):
+        """Flag is re-read from DB on each fire so runtime changes take effect immediately."""
+        mock_task_cls.objects.filter.return_value.first.return_value = _make_mock_task(
+            task_id=10, task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
+        )
         scheduler = UnifiedTaskScheduler()
 
-        # First execution - feature enabled
+        # First fire — flag enabled
         mock_get_feature.return_value = True
-        scheduler._execute_scheduled_task(
-            task_id="test_task",
-            function_name="hello_world",
-            args={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"},
-        )
+        scheduler._execute_scheduled_task(task_id="test_task", function_name="hello_world", args={})
+        assert mock_execute_db.call_count == 1
 
-        # Verify task was submitted
-        assert mock_submit.call_count == 1
-
-        # Second execution - feature disabled (flag changed at runtime)
+        # Second fire — flag disabled at runtime, no restart needed
         mock_get_feature.return_value = False
-        scheduler._execute_scheduled_task(
-            task_id="test_task",
-            function_name="hello_world",
-            args={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"},
-        )
+        scheduler._execute_scheduled_task(task_id="test_task", function_name="hello_world", args={})
+        assert mock_execute_db.call_count == 1  # Not incremented
 
-        # Verify task was NOT submitted the second time
-        assert mock_submit.call_count == 1  # Still 1, not 2
-
+    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
-    @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")
-    @patch("dispatcherd.publish.submit_task")
-    def test_feature_flag_error_prevents_execution(self, mock_submit, mock_ensure, mock_get_feature):
-        """Test that errors checking feature flag prevent task execution."""
+    @patch("apps.tasks.models.Task")
+    def test_feature_flag_error_prevents_execution(self, mock_task_cls, mock_get_feature, mock_execute_db):
+        """Errors reading the feature flag are caught by the outer try/except; task is not dispatched."""
         mock_get_feature.side_effect = Exception("Database error")
+        mock_task_cls.objects.filter.return_value.first.return_value = _make_mock_task(
+            task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
+        )
 
         scheduler = UnifiedTaskScheduler()
-
-        # Execute task - should handle error gracefully
         scheduler._execute_scheduled_task(
             task_id="test_task",
             function_name="hello_world",
-            args={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"},
+            args={},
         )
 
-        # Verify task was NOT submitted due to error
-        mock_submit.assert_not_called()
+        mock_execute_db.assert_not_called()

--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -2,6 +2,7 @@
 Utility functions for task management and execution.
 """
 
+import functools
 import logging
 from datetime import UTC
 from typing import Any
@@ -45,6 +46,7 @@ def task_execution_wrapper(task_name: str):
     """
 
     def decorator(func):
+        @functools.wraps(func)
         def wrapper(**kwargs):
             ensure_django_setup()
             log_task_execution(task_name, "start", f"Starting {task_name} task")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ where = ["."]
 include = ["metrics_service*", "apps*"]
 exclude = ["tests*"]
 
+[tool.setuptools.package-data]
+"apps.settings" = ["*.yaml"]
+
 
 [dependency-groups]
 dev=[

--- a/scripts/entrypoint-init.sh
+++ b/scripts/entrypoint-init.sh
@@ -76,6 +76,12 @@ echo "─── Initializing System Tasks ───"
 echo "✓ System tasks initialized"
 echo ""
 
+# Collect static files into STATIC_ROOT so WhiteNoise can serve them
+echo "─── Collecting Static Files ───"
+"$PYTHON" manage.py collectstatic --noinput --clear
+echo "✓ Static files collected"
+echo ""
+
 echo "════════════════════════════════════════════════════════════════"
 echo "  Database initialization complete"
 echo "════════════════════════════════════════════════════════════════"

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -19,76 +19,73 @@ from apps.tasks.cron_scheduler import UnifiedTaskScheduler
 
 
 @pytest.mark.unit
-@pytest.mark.django_db
 class TestExecuteScheduledTaskFeatureFlags:
-    """Test feature flag checking in _execute_scheduled_task."""
+    """Test feature flag checking in _execute_scheduled_task.
 
-    @patch("dispatcherd.publish.submit_task")
-    @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")
+    The implementation reads _feature_flag from task.task_data (live DB) at runtime,
+    then routes through _execute_database_task. All DB access is mocked here.
+    """
+
+    def _make_mock_task(self, task_id=42, task_data=None):
+        """Return a MagicMock that looks like a Task with the given task_data."""
+        mock_task = MagicMock()
+        mock_task.id = task_id
+        mock_task.task_data = task_data if task_data is not None else {}
+        return mock_task
+
+    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
-    def test_skips_task_when_feature_flag_disabled(
-        self, mock_get_feature_enabled, mock_ensure_config, mock_submit_task
-    ):
-        """Test task is skipped when feature flag is disabled."""
-        # Arrange
+    @patch("apps.tasks.models.Task")
+    def test_skips_task_when_feature_flag_disabled(self, mock_task_cls, mock_get_feature_enabled, mock_execute_db):
+        """Task is skipped when its feature flag is disabled in the DB."""
         scheduler = UnifiedTaskScheduler()
         mock_get_feature_enabled.return_value = False
+        mock_task_cls.objects.filter.return_value.first.return_value = self._make_mock_task(
+            task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
+        )
 
-        task_id = "test_task"
-        function_name = "hello_world"
-        args = {"_feature_flag": "ANONYMIZED_DATA_COLLECTION", "message": "test"}
+        scheduler._execute_scheduled_task("test_task", "hello_world", {})
 
-        # Act
-        scheduler._execute_scheduled_task(task_id, function_name, args)
+        mock_get_feature_enabled.assert_called_once_with("ANONYMIZED_DATA_COLLECTION")
+        mock_execute_db.assert_not_called()
 
-        # Assert
-        mock_get_feature_enabled.assert_called_once_with("ANONYMIZED_DATA_COLLECTION", False)
-        mock_submit_task.assert_not_called()
-
-    @patch("dispatcherd.publish.submit_task")
-    @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")
+    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
-    def test_executes_task_when_feature_flag_enabled(
-        self, mock_get_feature_enabled, mock_ensure_config, mock_submit_task
-    ):
-        """Test task executes when feature flag is enabled."""
-        # Arrange
+    @patch("apps.tasks.models.Task")
+    def test_executes_task_when_feature_flag_enabled(self, mock_task_cls, mock_get_feature_enabled, mock_execute_db):
+        """Task proceeds to _execute_database_task when its feature flag is enabled."""
         scheduler = UnifiedTaskScheduler()
         mock_get_feature_enabled.return_value = True
+        mock_task = self._make_mock_task(task_id=42, task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"})
+        mock_task_cls.objects.filter.return_value.first.return_value = mock_task
 
-        task_id = "test_task"
-        function_name = "hello_world"
-        args = {"_feature_flag": "ANONYMIZED_DATA_COLLECTION", "message": "test"}
+        scheduler._execute_scheduled_task("test_task", "hello_world", {})
 
-        # Act
-        scheduler._execute_scheduled_task(task_id, function_name, args)
+        mock_get_feature_enabled.assert_called_once_with("ANONYMIZED_DATA_COLLECTION")
+        mock_execute_db.assert_called_once_with(42)
 
-        # Assert
-        mock_get_feature_enabled.assert_called_once_with("ANONYMIZED_DATA_COLLECTION", False)
-        mock_submit_task.assert_called_once()
-        # Verify _feature_flag was removed from args
-        call_kwargs = mock_submit_task.call_args.kwargs
-        assert "_feature_flag" not in call_kwargs["kwargs"]
-        assert call_kwargs["kwargs"]["message"] == "test"
-
-    @patch("dispatcherd.publish.submit_task")
-    @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")
-    def test_executes_task_when_no_feature_flag(self, mock_ensure_config, mock_submit_task):
-        """Test task executes normally when no feature flag is specified."""
-        # Arrange
+    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
+    @patch("apps.tasks.models.Task")
+    def test_executes_task_when_no_feature_flag(self, mock_task_cls, mock_execute_db):
+        """Task proceeds without a feature flag check when task_data has no _feature_flag."""
         scheduler = UnifiedTaskScheduler()
+        mock_task = self._make_mock_task(task_id=7, task_data={})
+        mock_task_cls.objects.filter.return_value.first.return_value = mock_task
 
-        task_id = "test_task"
-        function_name = "hello_world"
-        args = {"message": "test"}  # No _feature_flag
+        scheduler._execute_scheduled_task("test_task", "hello_world", {})
 
-        # Act
-        scheduler._execute_scheduled_task(task_id, function_name, args)
+        mock_execute_db.assert_called_once_with(7)
 
-        # Assert
-        mock_submit_task.assert_called_once()
-        call_kwargs = mock_submit_task.call_args.kwargs
-        assert call_kwargs["kwargs"]["message"] == "test"
+    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
+    @patch("apps.tasks.models.Task")
+    def test_logs_error_when_task_not_in_db(self, mock_task_cls, mock_execute_db):
+        """Logs an error and skips execution when the system task is missing from DB."""
+        scheduler = UnifiedTaskScheduler()
+        mock_task_cls.objects.filter.return_value.first.return_value = None
+
+        scheduler._execute_scheduled_task("missing_task", "hello_world", {})
+
+        mock_execute_db.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/unit/tasks/test_unified_scheduler.py
+++ b/tests/unit/tasks/test_unified_scheduler.py
@@ -341,37 +341,47 @@ class TestUnifiedTaskScheduler:
         with pytest.raises(ValueError, match="Unknown task function: unknown_function"):
             scheduler._add_scheduled_task("test_task", config)
 
-    @patch("dispatcherd.publish.submit_task")
-    def test_execute_scheduled_task_success(self, mock_submit):
-        """Test successful scheduled task execution."""
-        mock_hello_world = Mock()
+    def test_execute_scheduled_task_success(self):
+        """Test successful scheduled task execution routes through _execute_database_task."""
+        scheduler = UnifiedTaskScheduler()
+
+        mock_task = Mock()
+        mock_task.id = 42
+        mock_task.status = "pending"
+        mock_task.task_data = {}
+
+        with (
+            patch("apps.tasks.models.Task") as mock_task_model,
+            patch.object(scheduler, "_execute_database_task") as mock_execute_db,
+        ):
+            mock_task_model.objects.filter.return_value.first.return_value = mock_task
+
+            scheduler._execute_scheduled_task("test_task", "hello_world", {"message": "test"})
+
+            mock_task_model.objects.filter.assert_called_once_with(name="test_task", is_system_task=True)
+            mock_execute_db.assert_called_once_with(mock_task.id)
+
+    def test_execute_scheduled_task_task_not_found(self):
+        """Test executing scheduled task when task is not found in DB logs error and returns."""
         scheduler = UnifiedTaskScheduler()
 
         with (
-            patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {"hello_world": mock_hello_world}),
-            patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured") as mock_ensure,
+            patch("apps.tasks.models.Task") as mock_task_model,
+            patch.object(scheduler, "_execute_database_task") as mock_execute_db,
         ):
-            scheduler._execute_scheduled_task("test_task", "hello_world", {"message": "test"})
+            mock_task_model.objects.filter.return_value.first.return_value = None
 
-            mock_ensure.assert_called_once()
-            mock_submit.assert_called_once_with(mock_hello_world, kwargs={"message": "test"}, queue="metrics_tasks")
+            scheduler._execute_scheduled_task("missing_task", "hello_world", {})  # Should log error and return
 
-    @patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {})
-    def test_execute_scheduled_task_unknown_function(self):
-        """Test executing scheduled task with unknown function."""
-        scheduler = UnifiedTaskScheduler()
+            mock_execute_db.assert_not_called()
 
-        with patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured"):
-            scheduler._execute_scheduled_task("test_task", "unknown_function", {})  # Should log error
-
-    @patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {"hello_world": Mock()})
     def test_execute_scheduled_task_config_error(self):
-        """Test executing scheduled task with configuration error."""
+        """Test executing scheduled task when an unexpected error occurs is handled gracefully."""
         scheduler = UnifiedTaskScheduler()
 
-        with patch(
-            "apps.tasks.dispatcherd_config.ensure_dispatcherd_configured", side_effect=Exception("Config error")
-        ):
+        with patch("apps.tasks.models.Task") as mock_task_model:
+            mock_task_model.objects.filter.side_effect = Exception("DB error")
+
             scheduler._execute_scheduled_task("test_task", "hello_world", {})  # Should catch error
 
     def test_get_queue_for_function_known_functions(self):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes request URL rewriting logic and alters how scheduled system tasks are executed (now DB-driven), which could affect routing and background job execution if misconfigured or if DB task records are missing.
> 
> **Overview**
> **URL prefixing:** `ServicePrefixMiddleware` now derives `api_prefix`/`service_prefix` from `settings.URL_PREFIX` (with trailing-slash normalization) and falls back to `ROOT_URLCONF` only when unset; tests were added/updated to cover the new behavior and routing.
> 
> **Task scheduling:** `UnifiedTaskScheduler._execute_scheduled_task` no longer submits functions directly to dispatcherd or trusts in-memory args; it looks up the corresponding *system task* row in the DB, re-reads `_feature_flag` from `task.task_data` at execution time, skips cancelled/completed/missing tasks, and routes execution through `_execute_database_task`. Unit tests were rewritten to mock DB access and validate the new runtime flag behavior.
> 
> **Packaging/runtime:** Production sets a fixed `STATIC_ROOT`, init entrypoint runs `collectstatic`, `pyproject.toml` includes `apps.settings` YAMLs as package data, and task wrapper decorator preserves function metadata via `functools.wraps`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a46b3e871529f1e662af90cf52d96fd56647339. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->