### PR TITLE
AAP-69203 - Middleware change for service prefix

### DIFF
--- a/apps/core/middleware/service_prefix.py
+++ b/apps/core/middleware/service_prefix.py
@@ -10,6 +10,9 @@ generates canonical /api/... URLs.
 
 For the /<service-name> case, SCRIPT_NAME is set so reverse()
 generates /<service-name>/... URLs.
+
+The service name is determined by URL_PREFIX when set (e.g. URL_PREFIX="/api/metrics"
+gives service_prefix="/metrics"), falling back to a name derived from ROOT_URLCONF.
 """
 
 from django.conf import settings
@@ -23,13 +26,24 @@ class ServicePrefixMiddleware:
     Two routing modes:
     1. /api/<service-name>/... → /api/... (no SCRIPT_NAME, canonical URLs)
     2. /<service-name>/... → /... (SCRIPT_NAME set for prefixed URLs)
+
+    The prefix is taken from URL_PREFIX when set (e.g. "/api/metrics"), falling
+    back to a name derived from ROOT_URLCONF (e.g. "metrics_service" → "/metrics-service").
     """
 
     def __init__(self, get_response):
         self.get_response = get_response
-        # Get service name from ROOT_URLCONF (e.g., "metrics_service" -> "metrics-service")
-        self.service_name = settings.ROOT_URLCONF.split(".")[0].replace("_", "-")
-        self.service_prefix = f"/{self.service_name}"
+        url_prefix = getattr(settings, "URL_PREFIX", None)
+        if url_prefix:
+            # URL_PREFIX is the full API prefix, e.g. "/api/metrics"
+            self.api_prefix = url_prefix.rstrip("/")
+            # Derive the bare service prefix by stripping the leading "/api"
+            self.service_prefix = self.api_prefix[4:] if self.api_prefix.startswith("/api") else self.api_prefix
+        else:
+            # Fall back to deriving from ROOT_URLCONF (e.g. "metrics_service" → "/metrics-service")
+            service_name = settings.ROOT_URLCONF.split(".")[0].replace("_", "-")
+            self.service_prefix = f"/{service_name}"
+            self.api_prefix = f"/api{self.service_prefix}"
 
     def __call__(self, request):
         path = request.path_info
@@ -39,7 +53,7 @@ class ServicePrefixMiddleware:
         # Store the API prefix so views can build correct absolute URLs
         # Store original path for DRF breadcrumbs
         # Patch get_full_path to return the original path for templates
-        api_prefix = f"/api{self.service_prefix}"
+        api_prefix = self.api_prefix
         if path.startswith(api_prefix):
             request._original_path = path
             request._api_service_prefix = api_prefix

--- a/apps/core/middleware/service_prefix.py
+++ b/apps/core/middleware/service_prefix.py
@@ -37,8 +37,8 @@ class ServicePrefixMiddleware:
         if url_prefix:
             # URL_PREFIX is the full API prefix, e.g. "/api/metrics"
             self.api_prefix = url_prefix.rstrip("/")
-            # Derive the bare service prefix by stripping the leading "/api"
-            self.service_prefix = self.api_prefix[4:] if self.api_prefix.startswith("/api") else self.api_prefix
+            # Derive the bare service prefix by stripping the leading "/api" segment
+            self.service_prefix = self.api_prefix[4:] if self.api_prefix.startswith("/api/") else self.api_prefix
         else:
             # Fall back to deriving from ROOT_URLCONF (e.g. "metrics_service" → "/metrics-service")
             service_name = settings.ROOT_URLCONF.split(".")[0].replace("_", "-")

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -170,14 +170,38 @@ class TestServicePrefixMiddlewareUnit(TestCase):
             self.assertEqual(middleware.api_prefix, f"/api/{expected_service_name}")
 
     def test_middleware_routes_url_prefix_path(self):
-        """Requests at URL_PREFIX path are routed correctly."""
+        """With URL_PREFIX set, requests at the API prefix are rewritten to /api/...
+
+        Directly instantiates ServicePrefixMiddleware inside the settings context so
+        the cached api_prefix reflects the override — using self.client would not
+        work because ClientHandler loads middleware before override_settings takes
+        effect.
+        """
+        from django.test import RequestFactory
+
+        from apps.core.middleware import ServicePrefixMiddleware
+
         with self.settings(URL_PREFIX="/api/metrics"):
-            response = self.client.get("/api/metrics/v1/")
-            self.assertEqual(response.status_code, 200)
-            data = response.json()
-            self.assertTrue(len(data) > 0, "API root should return at least one resource")
-            for url in data.values():
-                self.assertIn("/api/metrics/v1/", url)
+            factory = RequestFactory()
+            request = factory.get("/api/metrics/v1/")
+
+            rewritten_paths = []
+
+            def capture_get_response(req):
+                from django.http import HttpResponse
+
+                rewritten_paths.append(req.path_info)
+                return HttpResponse("OK")
+
+            middleware = ServicePrefixMiddleware(capture_get_response)
+            middleware(request)
+
+            # Path must be rewritten to the canonical /api/ form
+            self.assertEqual(rewritten_paths[0], "/api/v1/")
+            # The original prefixed path is stored for DRF breadcrumbs / templates
+            self.assertEqual(request._api_service_prefix, "/api/metrics")
+            # get_full_path() must restore the prefixed form so response URLs are correct
+            self.assertIn("/api/metrics/", request.get_full_path())
 
     def test_middleware_strips_trailing_slash_from_url_prefix(self):
         """URL_PREFIX with a trailing slash is handled correctly."""

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -138,6 +138,62 @@ class TestServicePrefixMiddlewareUnit(TestCase):
         middleware = ServicePrefixMiddleware(mock_get_response)
         self.assertIsNotNone(middleware)
 
+    def test_middleware_uses_url_prefix_when_set(self):
+        """When URL_PREFIX is set, api_prefix and service_prefix are derived from it."""
+        from apps.core.middleware import ServicePrefixMiddleware
+
+        with self.settings(URL_PREFIX="/api/metrics"):
+
+            def mock_get_response(request):
+                from django.http import HttpResponse
+
+                return HttpResponse("OK")
+
+            middleware = ServicePrefixMiddleware(mock_get_response)
+            self.assertEqual(middleware.api_prefix, "/api/metrics")
+            self.assertEqual(middleware.service_prefix, "/metrics")
+
+    def test_middleware_falls_back_to_root_urlconf_when_url_prefix_unset(self):
+        """When URL_PREFIX is None, prefix is derived from ROOT_URLCONF."""
+        from apps.core.middleware import ServicePrefixMiddleware
+
+        with self.settings(URL_PREFIX=None):
+
+            def mock_get_response(request):
+                from django.http import HttpResponse
+
+                return HttpResponse("OK")
+
+            middleware = ServicePrefixMiddleware(mock_get_response)
+            expected_service_name = settings.ROOT_URLCONF.split(".")[0].replace("_", "-")
+            self.assertEqual(middleware.service_prefix, f"/{expected_service_name}")
+            self.assertEqual(middleware.api_prefix, f"/api/{expected_service_name}")
+
+    def test_middleware_routes_url_prefix_path(self):
+        """Requests at URL_PREFIX path are routed correctly."""
+        with self.settings(URL_PREFIX="/api/metrics"):
+            response = self.client.get("/api/metrics/v1/")
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertIn("v1", data)
+            for url in data.values():
+                self.assertIn("/api/metrics/v1/", url)
+
+    def test_middleware_strips_trailing_slash_from_url_prefix(self):
+        """URL_PREFIX with a trailing slash is handled correctly."""
+        from apps.core.middleware import ServicePrefixMiddleware
+
+        with self.settings(URL_PREFIX="/api/metrics/"):
+
+            def mock_get_response(request):
+                from django.http import HttpResponse
+
+                return HttpResponse("OK")
+
+            middleware = ServicePrefixMiddleware(mock_get_response)
+            self.assertEqual(middleware.api_prefix, "/api/metrics")
+            self.assertEqual(middleware.service_prefix, "/metrics")
+
 
 class TestAPIRootViewMiddlewareUnit(TestCase):
     """Unit tests for APIRootViewMiddleware."""

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -194,6 +194,22 @@ class TestServicePrefixMiddlewareUnit(TestCase):
             self.assertEqual(middleware.api_prefix, "/api/metrics")
             self.assertEqual(middleware.service_prefix, "/metrics")
 
+    def test_middleware_url_prefix_not_under_api_segment(self):
+        """URL_PREFIX that does not start with '/api/' is used verbatim as service_prefix."""
+        from apps.core.middleware import ServicePrefixMiddleware
+
+        with self.settings(URL_PREFIX="/apis/metrics"):
+
+            def mock_get_response(request):
+                from django.http import HttpResponse
+
+                return HttpResponse("OK")
+
+            middleware = ServicePrefixMiddleware(mock_get_response)
+            self.assertEqual(middleware.api_prefix, "/apis/metrics")
+            # '/apis/metrics' does not start with '/api/' so service_prefix is unchanged
+            self.assertEqual(middleware.service_prefix, "/apis/metrics")
+
 
 class TestAPIRootViewMiddlewareUnit(TestCase):
     """Unit tests for APIRootViewMiddleware."""

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -175,7 +175,7 @@ class TestServicePrefixMiddlewareUnit(TestCase):
             response = self.client.get("/api/metrics/v1/")
             self.assertEqual(response.status_code, 200)
             data = response.json()
-            self.assertIn("v1", data)
+            self.assertTrue(len(data) > 0, "API root should return at least one resource")
             for url in data.values():
                 self.assertIn("/api/metrics/v1/", url)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes request path rewriting and URL generation for service-prefixed routes; misconfiguration of `URL_PREFIX` could break routing or browsable API links across services.
> 
> **Overview**
> **Service prefix routing is now configurable via `URL_PREFIX`.** `ServicePrefixMiddleware` derives `api_prefix`/`service_prefix` from `settings.URL_PREFIX` (normalizing trailing slashes and handling non-`/api/` prefixes), and falls back to the previous `ROOT_URLCONF`-derived prefix when unset.
> 
> **Tests are expanded** to cover the new `URL_PREFIX` behaviors, including path rewriting under the configured prefix and edge cases like trailing slashes and non-`/api/` prefixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cac1e9b468b45f8f06891d50422057d03641e287. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->