### PR TITLE
AAP-69681 - Enhance database connection management in UnifiedTaskScheduler

### DIFF
--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -12,6 +12,7 @@ from typing import Any
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
+from django.db import close_old_connections
 from django.utils import timezone
 
 from .tasks import TASK_FUNCTIONS
@@ -183,6 +184,7 @@ class UnifiedTaskScheduler:
             args: Unused. The feature flag and other task data are re-read from task.task_data
                   at runtime to reflect the current DB state.
         """
+        close_old_connections()
         try:
             from .models import Task
 
@@ -241,6 +243,7 @@ class UnifiedTaskScheduler:
 
     def _periodic_database_sync(self):
         """Periodically check for new database tasks and add them to the scheduler."""
+        close_old_connections()
         try:
             from .models import Task
 

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -355,6 +355,7 @@ class UnifiedTaskScheduler:
 
     def _execute_database_task(self, task_id: int):
         """Execute a database task by submitting it to dispatcherd."""
+        close_old_connections()
         try:
             from .models import Task
 

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -92,12 +92,17 @@ class TestExecuteScheduledTaskFeatureFlags:
     @patch("apps.tasks.models.Task")
     def test_closes_old_connections_before_querying(self, mock_task_cls, mock_close):
         """close_old_connections is called before any ORM access in _execute_scheduled_task."""
-        mock_task_cls.objects.filter.return_value.first.return_value = None  # task not found
+        call_order = []
+        mock_close.side_effect = lambda: call_order.append("close")
+        mock_task_cls.objects.filter.side_effect = lambda **_: call_order.append("query") or MagicMock(
+            first=lambda: None
+        )
 
         scheduler = UnifiedTaskScheduler()
         scheduler._execute_scheduled_task("missing_task", "hello_world", {})
 
         mock_close.assert_called_once()
+        assert call_order[0] == "close"
 
 
 @pytest.mark.unit
@@ -361,6 +366,36 @@ class TestExecuteDatabaseTaskErrors:
 
         # Assert
         mock_remove.assert_called_once_with(1)
+
+    @patch("apps.tasks.cron_scheduler.close_old_connections")
+    @patch("apps.tasks.models.Task")
+    def test_closes_old_connections_before_querying(self, mock_task_model, mock_close):
+        """close_old_connections is called before any ORM access in _execute_database_task."""
+        call_order = []
+        mock_close.side_effect = lambda: call_order.append("close")
+
+        def get_side_effect(**kwargs):
+            call_order.append("query")
+            raise Exception("db gone")
+
+        mock_task_model.objects.get.side_effect = get_side_effect
+
+        scheduler = UnifiedTaskScheduler()
+        scheduler._execute_database_task(999)
+
+        mock_close.assert_called_once()
+        assert call_order[0] == "close"
+
+    @patch("apps.tasks.cron_scheduler.close_old_connections")
+    @patch("apps.tasks.models.Task")
+    def test_closes_old_connections_even_on_error(self, mock_task_model, mock_close):
+        """close_old_connections is called even when the task body raises."""
+        mock_task_model.objects.get.side_effect = Exception("db gone")
+
+        scheduler = UnifiedTaskScheduler()
+        scheduler._execute_database_task(999)
+
+        mock_close.assert_called_once()
 
 
 @pytest.mark.unit

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -98,8 +98,8 @@ class TestExecuteScheduledTaskFeatureFlags:
 
         call_order = []
         mock_close.side_effect = lambda: call_order.append("close")
-        mock_task_cls.objects.filter.side_effect = lambda **_: call_order.append("query") or MagicMock(
-            first=lambda: None
+        mock_task_cls.objects.filter.side_effect = lambda **_: (
+            call_order.append("query") or MagicMock(first=lambda: None)
         )
 
         scheduler._execute_scheduled_task("missing_task", "hello_world", {})

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -91,18 +91,20 @@ class TestExecuteScheduledTaskFeatureFlags:
     @patch("apps.tasks.cron_scheduler.close_old_connections")
     @patch("apps.tasks.models.Task")
     def test_closes_old_connections_before_querying(self, mock_task_cls, mock_close):
-        """close_old_connections is called before any ORM access in _execute_scheduled_task."""
+        """close_old_connections must be called before any ORM access in _execute_scheduled_task."""
+        # Instantiate first so _load_task_registry()'s Task.objects.filter() call in __init__
+        # does not pollute the call_order we install below.
+        scheduler = UnifiedTaskScheduler()
+
         call_order = []
         mock_close.side_effect = lambda: call_order.append("close")
         mock_task_cls.objects.filter.side_effect = lambda **_: call_order.append("query") or MagicMock(
             first=lambda: None
         )
 
-        scheduler = UnifiedTaskScheduler()
         scheduler._execute_scheduled_task("missing_task", "hello_world", {})
 
-        mock_close.assert_called_once()
-        assert call_order[0] == "close"
+        assert call_order[0] == "close", f"Expected close_old_connections first, got: {call_order}"
 
 
 @pytest.mark.unit

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -19,6 +19,7 @@ from apps.tasks.cron_scheduler import UnifiedTaskScheduler
 
 
 @pytest.mark.unit
+@pytest.mark.django_db
 class TestExecuteScheduledTaskFeatureFlags:
     """Test feature flag checking in _execute_scheduled_task.
 
@@ -86,6 +87,17 @@ class TestExecuteScheduledTaskFeatureFlags:
         scheduler._execute_scheduled_task("missing_task", "hello_world", {})
 
         mock_execute_db.assert_not_called()
+
+    @patch("apps.tasks.cron_scheduler.close_old_connections")
+    @patch("apps.tasks.models.Task")
+    def test_closes_old_connections_before_querying(self, mock_task_cls, mock_close):
+        """close_old_connections is called before any ORM access in _execute_scheduled_task."""
+        mock_task_cls.objects.filter.return_value.first.return_value = None  # task not found
+
+        scheduler = UnifiedTaskScheduler()
+        scheduler._execute_scheduled_task("missing_task", "hello_world", {})
+
+        mock_close.assert_called_once()
 
 
 @pytest.mark.unit
@@ -207,6 +219,33 @@ class TestPeriodicDatabaseSync:
 
         # Assert
         mock_execute.assert_not_called()
+
+    @patch("apps.tasks.cron_scheduler.close_old_connections")
+    @patch("apps.tasks.models.Task")
+    def test_closes_old_connections_before_querying(self, mock_task_model, mock_close):
+        """close_old_connections must be called before any ORM access."""
+        call_order = []
+        mock_close.side_effect = lambda: call_order.append("close")
+        mock_task_model.immediate_tasks.side_effect = lambda: call_order.append("query") or []
+        mock_task_model.scheduled_tasks.return_value = []
+        mock_task_model.recurring_tasks.return_value = []
+
+        scheduler = UnifiedTaskScheduler()
+        scheduler._periodic_database_sync()
+
+        mock_close.assert_called_once()
+        assert call_order[0] == "close"
+
+    @patch("apps.tasks.cron_scheduler.close_old_connections")
+    @patch("apps.tasks.models.Task")
+    def test_closes_old_connections_even_on_error(self, mock_task_model, mock_close):
+        """close_old_connections is called even when the sync body raises."""
+        mock_task_model.immediate_tasks.side_effect = Exception("db gone")
+
+        scheduler = UnifiedTaskScheduler()
+        scheduler._periodic_database_sync()
+
+        mock_close.assert_called_once()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
- Added calls to close_old_connections() before any ORM access in _execute_scheduled_task and _periodic_database_sync methods to ensure proper database connection handling.
- Implemented unit tests to verify that close_old_connections is invoked correctly, including scenarios where errors occur during database sync.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches background task execution paths by adding `close_old_connections()` before ORM access; misplacement could impact scheduler behavior but changes are small and well-covered by unit tests.
> 
> **Overview**
> Improves database connection hygiene in `UnifiedTaskScheduler` by calling `close_old_connections()` before any ORM access in `_execute_scheduled_task`, `_periodic_database_sync`, and `_execute_database_task`.
> 
> Extends unit coverage to assert `close_old_connections()` is invoked *before* queries and still called when errors occur, and marks the scheduled-task feature-flag test class with `@pytest.mark.django_db`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d642f577ab1995d0ed982644b8363e92480c3a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->