### PR TITLE
[AAP-69214] Retry of hourly collection task collects wrong hour's data

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,13 +43,6 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
 
-      - name: "Debug: Check file line count"
-        run: |
-          echo "File line count:"
-          wc -l apps/tasks/cron_scheduler.py
-          echo "Last 5 lines:"
-          tail -5 apps/tasks/cron_scheduler.py | cat -n
-
       - name: "Run pytest"
         env:
           METRICS_SERVICE_DATABASES__default__HOST: localhost
@@ -64,21 +57,6 @@ jobs:
           METRICS_SERVICE_MODE: test
         run: |
           uv run pytest -s -v --cov --cov-report=xml
-
-      - name: "Debug: Check coverage.xml"
-        run: |
-          echo "Checking cron_scheduler.py in coverage.xml:"
-          python3 << 'EOF'
-          import xml.etree.ElementTree as ET
-          tree = ET.parse('coverage.xml')
-          root = tree.getroot()
-          for cls in root.findall('.//class[@filename="tasks/cron_scheduler.py"]'):
-              lines = cls.findall('.//line')
-              line_nums = sorted([int(l.get('number')) for l in lines])
-              print(f"Total line entries: {len(lines)}")
-              print(f"Max line number: {line_nums[-1] if line_nums else 0}")
-              print(f"Lines >475: {[n for n in line_nums if n > 475]}")
-          EOF
 
       - name: "Upload code coverage report"
         if: github.event_name == 'pull_request'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,6 +43,13 @@ jobs:
         with:
           python-version-file: "pyproject.toml"
 
+      - name: "Debug: Check file line count"
+        run: |
+          echo "File line count:"
+          wc -l apps/tasks/cron_scheduler.py
+          echo "Last 5 lines:"
+          tail -5 apps/tasks/cron_scheduler.py | cat -n
+
       - name: "Run pytest"
         env:
           METRICS_SERVICE_DATABASES__default__HOST: localhost
@@ -57,6 +64,21 @@ jobs:
           METRICS_SERVICE_MODE: test
         run: |
           uv run pytest -s -v --cov --cov-report=xml
+
+      - name: "Debug: Check coverage.xml"
+        run: |
+          echo "Checking cron_scheduler.py in coverage.xml:"
+          python3 << 'EOF'
+          import xml.etree.ElementTree as ET
+          tree = ET.parse('coverage.xml')
+          root = tree.getroot()
+          for cls in root.findall('.//class[@filename="tasks/cron_scheduler.py"]'):
+              lines = cls.findall('.//line')
+              line_nums = sorted([int(l.get('number')) for l in lines])
+              print(f"Total line entries: {len(lines)}")
+              print(f"Max line number: {line_nums[-1] if line_nums else 0}")
+              print(f"Lines >475: {[n for n in line_nums if n > 475]}")
+          EOF
 
       - name: "Upload code coverage report"
         if: github.event_name == 'pull_request'

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -7,6 +7,7 @@ and database tasks without database polling, using APScheduler for optimal perfo
 
 import logging
 import threading
+from datetime import timedelta
 from typing import Any
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -18,6 +19,35 @@ from django.utils import timezone
 from .tasks import TASK_FUNCTIONS
 
 logger = logging.getLogger(__name__)
+
+
+def _inject_dispatch_timestamps(function_name: str, task_data: dict) -> dict:
+    """
+    Inject a fixed time-window timestamp into task_data at the moment a recurring
+    task is dispatched by the scheduler.
+
+    Time-sensitive collectors compute their target window from timezone.now() when
+    no explicit timestamp is present. If the task is retried hours later, "now" has
+    shifted and the retry collects the wrong window. By pinning the timestamp here —
+    before the task is even submitted — every retry of the same execution copy
+    operates on the originally intended window.
+
+    Only sets the key when it is absent, so manually created tasks that already
+    carry an explicit timestamp are left untouched.
+    """
+    task_data = task_data.copy()
+
+    if function_name == "collect_hourly_metrics" and "hour_timestamp" not in task_data:
+        now = timezone.now()
+        task_data["hour_timestamp"] = (now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)).isoformat()
+
+    elif function_name == "collect_snapshot_metrics" and "collection_timestamp" not in task_data:
+        now = timezone.now()
+        task_data["collection_timestamp"] = (
+            now.replace(hour=23, minute=0, second=0, microsecond=0) - timedelta(days=1)
+        ).isoformat()
+
+    return task_data
 
 
 class UnifiedTaskScheduler:
@@ -373,7 +403,7 @@ class UnifiedTaskScheduler:
                 execution_task = Task.objects.create(
                     name=f"{task.name} (Execution {timezone.now().strftime('%Y-%m-%d %H:%M:%S')})",
                     function_name=task.function_name,
-                    task_data=task.task_data,
+                    task_data=_inject_dispatch_timestamps(task.function_name, task.task_data or {}),
                     scheduled_time=None,  # Execute immediately
                     cron_expression=None,  # This is not a recurring task
                     max_attempts=task.max_attempts,

--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -431,17 +431,33 @@ def generic_collect_metrics(
         # Process rollup if processor provided, otherwise use raw data
         rollup_data = config["rollup_processor"]().prepare(raw_data) if config["rollup_processor"] else raw_data
 
-        collection, created = HourlyMetricsCollection.objects.update_or_create(
-            collector_type=collector_type,
-            collection_timestamp=timestamp,
-            defaults={
-                "raw_data": rollup_data,
-                "status": "collected",
-                "error_message": "",
-                "collection_parameters": collection_params,
-                "task_execution": task_execution_instance,
-            },
-        )
+        try:
+            collection, created = HourlyMetricsCollection.objects.update_or_create(
+                collector_type=collector_type,
+                collection_timestamp=timestamp,
+                defaults={
+                    "raw_data": rollup_data,
+                    "status": "collected",
+                    "error_message": "",
+                    "collection_parameters": collection_params,
+                    "task_execution": task_execution_instance,
+                },
+            )
+        except IntegrityError:
+            # Another execution wrote this record first. The data is already saved, so return success.
+            logger.warning(
+                f"Duplicate collection skipped for {collector_type} at {timestamp.isoformat()} "
+                f"(unique constraint violation - record already written by concurrent execution)"
+            )
+            return create_task_result(
+                "success",
+                {
+                    "message": f"Skipped duplicate {collection_mode} collection for {collector_type}",
+                    "task_type": f"collect_{collector_type}",
+                    "collector_type": collector_type,
+                    "timestamp": timestamp.isoformat(),
+                },
+            )
 
         action = "Created" if created else "Updated"
         log_task_execution(f"collect_{collector_type}", "completed", f"{action} {collection_mode} ID: {collection.id}")
@@ -452,24 +468,6 @@ def generic_collect_metrics(
                 "message": f"{action} {collection_mode} collection for {collector_type}",
                 "task_type": f"collect_{collector_type}",
                 "collection_id": collection.id,
-                "collector_type": collector_type,
-                "timestamp": timestamp.isoformat(),
-            },
-        )
-
-    except IntegrityError:
-        # A concurrent execution already wrote this (collector_type, collection_timestamp) record.
-        # The unique_together constraint on HourlyMetricsCollection is the intended guard here —
-        # the data exists, so this execution has nothing left to do.
-        logger.warning(
-            f"Duplicate collection skipped for {collector_type} at {timestamp.isoformat()} "
-            f"(unique constraint violation — record already written by concurrent execution)"
-        )
-        return create_task_result(
-            "success",
-            {
-                "message": f"Skipped duplicate {collection_mode} collection for {collector_type}",
-                "task_type": f"collect_{collector_type}",
                 "collector_type": collector_type,
                 "timestamp": timestamp.isoformat(),
             },

--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -417,6 +417,8 @@ def generic_collect_metrics(
             # Task execution not found or deleted, continue without it
             logger.debug(f"TaskExecution {task_execution_id} not found, proceeding without link")
 
+    from django.db import IntegrityError
+
     try:
         # For snapshot collectors, filter out collection_time (audit-only param, not used by collector)
         actual_collector_kwargs = collector_kwargs.copy() if collector_kwargs else {}
@@ -450,6 +452,24 @@ def generic_collect_metrics(
                 "message": f"{action} {collection_mode} collection for {collector_type}",
                 "task_type": f"collect_{collector_type}",
                 "collection_id": collection.id,
+                "collector_type": collector_type,
+                "timestamp": timestamp.isoformat(),
+            },
+        )
+
+    except IntegrityError:
+        # A concurrent execution already wrote this (collector_type, collection_timestamp) record.
+        # The unique_together constraint on HourlyMetricsCollection is the intended guard here —
+        # the data exists, so this execution has nothing left to do.
+        logger.warning(
+            f"Duplicate collection skipped for {collector_type} at {timestamp.isoformat()} "
+            f"(unique constraint violation — record already written by concurrent execution)"
+        )
+        return create_task_result(
+            "success",
+            {
+                "message": f"Skipped duplicate {collection_mode} collection for {collector_type}",
+                "task_type": f"collect_{collector_type}",
                 "collector_type": collector_type,
                 "timestamp": timestamp.isoformat(),
             },

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.utils import timezone
 
-from apps.tasks.cron_scheduler import UnifiedTaskScheduler
+from apps.tasks.cron_scheduler import UnifiedTaskScheduler, _inject_dispatch_timestamps
 
 
 @pytest.mark.unit
@@ -461,3 +461,54 @@ class TestRemoveDatabaseTask:
 
         # Assert - still removed from tracking
         assert 1 not in scheduler._db_task_jobs
+
+
+@pytest.mark.unit
+class TestInjectDispatchTimestamps:
+    """
+    Test that _inject_dispatch_timestamps pins the correct time-window key into
+    task_data at dispatch time so retries always collect the originally intended window.
+    """
+
+    def test_injects_hour_timestamp_for_hourly_collector(self):
+        """collect_hourly_metrics tasks get hour_timestamp set to the previous full hour."""
+        fixed_now = timezone.now().replace(minute=30, second=0, microsecond=0)
+        expected = (fixed_now.replace(minute=0) - timedelta(hours=1)).isoformat()
+
+        with patch("apps.tasks.cron_scheduler.timezone") as mock_tz:
+            mock_tz.now.return_value = fixed_now
+            result = _inject_dispatch_timestamps("collect_hourly_metrics", {"collector_type": "unified_jobs"})
+
+        assert result["hour_timestamp"] == expected
+
+    def test_injects_collection_timestamp_for_snapshot_collector(self):
+        """collect_snapshot_metrics tasks get collection_timestamp set to yesterday at 23:00."""
+        fixed_now = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
+        expected = (fixed_now.replace(hour=23) - timedelta(days=1)).isoformat()
+
+        with patch("apps.tasks.cron_scheduler.timezone") as mock_tz:
+            mock_tz.now.return_value = fixed_now
+            result = _inject_dispatch_timestamps("collect_snapshot_metrics", {"collector_type": "config"})
+
+        assert result["collection_timestamp"] == expected
+
+    def test_does_not_overwrite_existing_hour_timestamp(self):
+        """An explicit hour_timestamp already in task_data must not be replaced."""
+        fixed_ts = "2024-01-15T10:00:00+00:00"
+        result = _inject_dispatch_timestamps(
+            "collect_hourly_metrics", {"collector_type": "unified_jobs", "hour_timestamp": fixed_ts}
+        )
+        assert result["hour_timestamp"] == fixed_ts
+
+    def test_does_not_modify_unrelated_functions(self):
+        """Functions not in the injection map are returned unchanged."""
+        original = {"some_key": "some_value"}
+        result = _inject_dispatch_timestamps("hello_world", original)
+        assert result == original
+
+    def test_returns_a_copy_not_the_original_dict(self):
+        """The original task_data dict must not be mutated."""
+        original = {"collector_type": "unified_jobs"}
+        result = _inject_dispatch_timestamps("collect_hourly_metrics", original)
+        assert "hour_timestamp" not in original
+        assert "hour_timestamp" in result

--- a/tests/unit/tasks/test_tasks_collector_advanced.py
+++ b/tests/unit/tasks/test_tasks_collector_advanced.py
@@ -6,7 +6,7 @@ that aren't covered by the basic comprehensive tests.
 """
 
 from datetime import UTC, date, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import TestCase
@@ -16,10 +16,93 @@ from apps.tasks.collectors.daily_metrics_rollup import daily_metrics_rollup
 from apps.tasks.collectors.send_anonymized_to_segment import send_anonymized_to_segment
 
 
+def _make_mock_collector_registry(collector_type: str):
+    """Return a minimal collector registry that never touches a real DB."""
+    mock_collector = MagicMock()
+    mock_collector.gather.return_value = {}
+    return {
+        collector_type: {
+            "collector_func": lambda **kw: mock_collector,
+            "rollup_processor": None,
+            "description": "test",
+        }
+    }
+
+
 @pytest.mark.unit
 @pytest.mark.django_db
-class TestHourlyCollectionTasks(TestCase):
-    """Test hourly collection tasks."""
+class TestHourlyCollectionTasks:
+    """Test that collect_hourly_metrics uses a scheduler-injected hour_timestamp correctly."""
+
+    def test_uses_provided_hour_timestamp(self):
+        """When hour_timestamp is supplied (as injected by the scheduler), it must be used as-is."""
+        fixed_ts = "2024-01-15T13:00:00+00:00"
+
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=_make_mock_collector_registry("unified_jobs")),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+            result = collect_hourly_metrics(collector_type="unified_jobs", hour_timestamp=fixed_ts)
+
+        assert result["status"] == "success"
+        assert result["timestamp"] == fixed_ts
+
+    def test_retry_with_injected_timestamp_ignores_wall_clock(self):
+        """A retry that supplies the original hour_timestamp must collect the same window even if wall clock has advanced."""
+        pinned_ts = "2024-01-15T13:00:00+00:00"
+        later_now = timezone.now() + timedelta(hours=3)
+
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=_make_mock_collector_registry("unified_jobs")),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+            patch("apps.tasks.collectors.collect_hourly_metrics.timezone") as mock_tz,
+        ):
+            mock_tz.now.return_value = later_now
+            from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+            result = collect_hourly_metrics(collector_type="unified_jobs", hour_timestamp=pinned_ts)
+
+        assert result["status"] == "success"
+        assert result["timestamp"] == pinned_ts
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestSnapshotCollectionTasks:
+    """Test that collect_snapshot_metrics uses a scheduler-injected collection_timestamp correctly."""
+
+    def test_uses_provided_collection_timestamp(self):
+        """When collection_timestamp is supplied (as injected by the scheduler), it must be used as-is."""
+        fixed_ts = "2024-01-14T23:00:00+00:00"
+
+        with (
+            patch("apps.tasks.collectors.collect_snapshot_metrics._get_snapshot_collectors", return_value=_make_mock_collector_registry("config")),
+            patch("apps.tasks.collectors.collect_snapshot_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            from apps.tasks.collectors.collect_snapshot_metrics import collect_snapshot_metrics
+
+            result = collect_snapshot_metrics(collector_type="config", collection_timestamp=fixed_ts)
+
+        assert result["status"] == "success"
+
+    def test_retry_with_injected_timestamp_ignores_wall_clock(self):
+        """A retry that supplies the original collection_timestamp must collect the same window even if wall clock has advanced."""
+        pinned_ts = "2024-01-14T23:00:00+00:00"
+        later_now = timezone.now() + timedelta(days=2)
+
+        with (
+            patch("apps.tasks.collectors.collect_snapshot_metrics._get_snapshot_collectors", return_value=_make_mock_collector_registry("config")),
+            patch("apps.tasks.collectors.collect_snapshot_metrics.get_db_connection", return_value=MagicMock()),
+            patch("apps.tasks.collectors.collect_snapshot_metrics.timezone") as mock_tz,
+        ):
+            mock_tz.now.return_value = later_now
+            from apps.tasks.collectors.collect_snapshot_metrics import collect_snapshot_metrics
+
+            result = collect_snapshot_metrics(collector_type="config", collection_timestamp=pinned_ts)
+
+        assert result["status"] == "success"
 
 
 @pytest.mark.unit

--- a/tests/unit/tasks/test_tasks_collector_advanced.py
+++ b/tests/unit/tasks/test_tasks_collector_advanced.py
@@ -39,7 +39,10 @@ class TestHourlyCollectionTasks:
         fixed_ts = "2024-01-15T13:00:00+00:00"
 
         with (
-            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=_make_mock_collector_registry("unified_jobs")),
+            patch(
+                "apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors",
+                return_value=_make_mock_collector_registry("unified_jobs"),
+            ),
             patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
         ):
             from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
@@ -55,7 +58,10 @@ class TestHourlyCollectionTasks:
         later_now = timezone.now() + timedelta(hours=3)
 
         with (
-            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=_make_mock_collector_registry("unified_jobs")),
+            patch(
+                "apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors",
+                return_value=_make_mock_collector_registry("unified_jobs"),
+            ),
             patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
             patch("apps.tasks.collectors.collect_hourly_metrics.timezone") as mock_tz,
         ):
@@ -78,7 +84,10 @@ class TestSnapshotCollectionTasks:
         fixed_ts = "2024-01-14T23:00:00+00:00"
 
         with (
-            patch("apps.tasks.collectors.collect_snapshot_metrics._get_snapshot_collectors", return_value=_make_mock_collector_registry("config")),
+            patch(
+                "apps.tasks.collectors.collect_snapshot_metrics._get_snapshot_collectors",
+                return_value=_make_mock_collector_registry("config"),
+            ),
             patch("apps.tasks.collectors.collect_snapshot_metrics.get_db_connection", return_value=MagicMock()),
         ):
             from apps.tasks.collectors.collect_snapshot_metrics import collect_snapshot_metrics
@@ -93,7 +102,10 @@ class TestSnapshotCollectionTasks:
         later_now = timezone.now() + timedelta(days=2)
 
         with (
-            patch("apps.tasks.collectors.collect_snapshot_metrics._get_snapshot_collectors", return_value=_make_mock_collector_registry("config")),
+            patch(
+                "apps.tasks.collectors.collect_snapshot_metrics._get_snapshot_collectors",
+                return_value=_make_mock_collector_registry("config"),
+            ),
             patch("apps.tasks.collectors.collect_snapshot_metrics.get_db_connection", return_value=MagicMock()),
             patch("apps.tasks.collectors.collect_snapshot_metrics.timezone") as mock_tz,
         ):

--- a/tests/unit/tasks/test_tasks_collector_advanced.py
+++ b/tests/unit/tasks/test_tasks_collector_advanced.py
@@ -482,3 +482,46 @@ class TestHourlyCollectionRetryBehavior(TestCase):
         assert collection.status == "collected", "New collection should have status='collected'"
         assert collection.error_message == ""
         assert collection.raw_data == {"new": "data"}
+
+    def test_integrity_error_treated_as_success(self):
+        """
+        Verify that an IntegrityError from a concurrent write is treated as success.
+
+        If two executions race to write the same (collector_type, collection_timestamp),
+        the unique_together constraint raises IntegrityError on the loser. Since the data
+        already exists, the task has nothing left to do and should return success rather
+        than failing and triggering a retry.
+        """
+        from datetime import datetime
+        from unittest.mock import MagicMock, patch
+
+        from django.db import IntegrityError
+
+        from apps.tasks.utils import generic_collect_metrics
+
+        collection_timestamp = datetime(2024, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        mock_collector = MagicMock()
+        mock_collector.gather.return_value = {"data": "value"}
+        mock_db = MagicMock()
+
+        collector_registry = {
+            "unified_jobs": {
+                "collector_func": lambda db: mock_collector,
+                "rollup_processor": None,
+            }
+        }
+
+        with patch("apps.tasks.models.HourlyMetricsCollection.objects") as mock_objects:
+            mock_objects.update_or_create.side_effect = IntegrityError("duplicate key value")
+
+            result = generic_collect_metrics(
+                collector_type="unified_jobs",
+                collector_registry=collector_registry,
+                collection_mode="hourly",
+                timestamp=collection_timestamp,
+                db_connection=mock_db,
+            )
+
+        assert result["status"] == "success"
+        assert "duplicate" in result["message"].lower()


### PR DESCRIPTION
# [AAP-69214] Retry of hourly collection task collects wrong hour's data

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- **What:** Adds timestamp injection at scheduler dispatch time for `collect_hourly_metrics` and `collect_snapshot_metrics` tasks, and adds graceful handling of `IntegrityError` from concurrent collection writes.
- **Why:** Both collectors derived their collection timestamp from `timezone.now()` on every run. If a task failed and was retried hours later, the "previous hour" calculation would shift, causing the retry to silently collect the wrong time window.
- **How:** A new `_inject_dispatch_timestamps` helper in `cron_scheduler.py` stamps `hour_timestamp` (or `collection_timestamp` for snapshots) into the execution task's `task_data` at the moment the scheduler creates it. Since `task_data` is passed on every run including retries, all later attempts automatically use the originally intended window. `IntegrityError` from a duplicate write is now caught separately, logged as a warning, and returns success. The data already exists so the task has nothing left to do.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

### Prerequisites
<!-- List any specific setup required -->
- Docker running with `docker-compose up -d postgres`
- `settings.local.py` present with local DB credentials


### Steps to Test
1. Run the new unit tests: `uv run pytest tests/unit/tasks/test_cron_scheduler.py::TestInjectDispatchTimestamps tests/unit/tasks/test_tasks_collector_advanced.py::TestHourlyCollectionTasks tests/unit/tasks/test_tasks_collector_advanced.py::TestSnapshotCollectionTasks tests/unit/tasks/test_tasks_collector_advanced.py::TestHourlyCollectionRetryBehavior::test_integrity_error_treated_as_success -v`
2. Run the full unit suite to check for any regressions  `uv run pytest -m unit`
3. To manually verify the retry fix: trigger a `collect_hourly_metrics` task and let it complete, then inspect `Task.task_data` in the DB. `hour_timestamp` should be present in the execution copy's `task_data`. Retry the task and confirm it collects the same time window.


### Expected Results
<!-- Describe what should happen after following the steps -->
- All new tests pass
- Full unit suite passes (468 tests)
- After a first scheduler-triggered run, the execution copy of the task has `hour_timestamp` in `task_data`
- A retry triggered hours later collects the same window as the original run


## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how recurring tasks are materialized and how `IntegrityError` is handled during metrics persistence, which can affect what data gets stored/updated under concurrency. Changes are localized and covered by new unit tests.
> 
> **Overview**
> Fixes retries of recurring metrics collectors collecting the *wrong time window* by injecting a deterministic `hour_timestamp` / `collection_timestamp` into the execution copy’s `task_data` when `UnifiedTaskScheduler` dispatches a recurring DB task.
> 
> Updates `generic_collect_metrics` to catch `IntegrityError` from concurrent `update_or_create` races and return a *successful* “skipped duplicate” result instead of failing and triggering retries. Adds unit tests for timestamp injection behavior and for the duplicate-write handling path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc7b9f87d415933c2eeacc5fe46ac90e74aa9fa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->