### PR TITLE
Fix task execution records

### DIFF
--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -116,7 +116,7 @@ def submit_task_to_dispatcher(task: Any) -> None:
 
     try:
         # Create execution record
-        TaskExecution.objects.create(task=task, status="pending", worker_id=f"dispatcher-{os.getpid()}")
+        execution = TaskExecution.objects.create(task=task, status="pending", worker_id=f"dispatcher-{os.getpid()}")
 
         # Ensure dispatcherd is configured before attempting to submit tasks
         from .dispatcherd_config import ensure_dispatcherd_configured
@@ -132,7 +132,7 @@ def submit_task_to_dispatcher(task: Any) -> None:
         queue = get_queue_for_function(task.function_name)
 
         # Submit to dispatcherd using execute_db_task as the entry point
-        submit_task(execute_db_task, kwargs={"task_id": task.id}, queue=queue)
+        submit_task(execute_db_task, kwargs={"task_id": task.id, "execution_id": execution.id}, queue=queue)
 
         # Update task status to indicate it's been submitted
         task.status = "pending"

--- a/tests/unit/tasks/test_tasks_system.py
+++ b/tests/unit/tasks/test_tasks_system.py
@@ -671,12 +671,14 @@ class TestSubmitTaskToDispatcherSuccess(TestCase):
         assert call_kwargs["kwargs"]["task_id"] == task.id
         assert call_kwargs["queue"] == "metrics_tasks"
 
+        # Verify execution_id is passed so execute_db_task can update the record
+        execution = TaskExecution.objects.filter(task=task).first()
+        assert execution is not None
+        assert call_kwargs["kwargs"]["execution_id"] == execution.id
+
         # Verify task status updated
         task.refresh_from_db()
         assert task.status == "pending"
-
-        # Verify execution record created
-        assert TaskExecution.objects.filter(task=task).exists()
 
     @patch("dispatcherd.publish.submit_task")
     @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- **What is being changed?** `submit_task_to_dispatcher` now captures the `TaskExecution` record it creates and passes its ID to `execute_db_task` via dispatcherd kwargs. The existing test for this path is updated to assert `execution_id` is included.
- **Why is this change needed?** `TaskExecution` records created by `submit_task_to_dispatcher` were never updated past `"pending"`. The execution ID was not passed to the worker, so `execute_db_task` always received `execution_id=None`, skipping all status updates on the execution record.
- **How does this change address the issue?** By passing `execution_id` in the submitted kwargs, `execute_db_task` can now look up the correct `TaskExecution` record and update it through its full lifecycle (`pending -> running -> completed/failed`).

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
- Docker running with `docker-compose up -d postgres`
- Dependencies installed: `uv sync --dev`

### Steps to Test
1. Run the targeted test for the fix: `uv run pytest tests/unit/tasks/test_tasks_system.py::TestSubmitTaskToDispatcherSuccess -v`
2. Run the full task system test suite: `uv run pytest tests/unit/tasks/test_tasks_system.py -v`
3. Run lint and format checks: `uv run poe check`

### Expected Results
<!-- Describe what should happen after following the steps -->
- All tests pass
- `test_submit_task_success_path` confirms `execution_id` is present in the kwargs submitted to dispatcherd and matches the created `TaskExecution` record's ID

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bug fix limited to task dispatch submission and its unit test; main risk is mismatched kwargs expectations between dispatcher and `execute_db_task` if other callers exist.
> 
> **Overview**
> Fixes task execution lifecycle tracking by capturing the created `TaskExecution` in `submit_task_to_dispatcher` and passing its `execution_id` to `execute_db_task` via dispatcherd kwargs, enabling the worker to update the correct execution record beyond `pending`.
> 
> Updates the dispatcher success-path unit test to assert `execution_id` is included in the submitted kwargs and matches the newly created `TaskExecution`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd10f7c224f45d24212dfeb79ac3070a89be93c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->