### PR TITLE
[AAP-69215] Cron schedule collision - task cleanup and daily rollup both run at 2:00 AM

### DIFF
--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -115,7 +115,7 @@ SYSTEM_TASKS_GROUP = TaskGroup(
         {
             "task_id": "daily_task_cleanup",
             "function": "cleanup_old_tasks",
-            "cron": "0 2 * * *",  # Daily at 2 AM
+            "cron": "0 5 * * *",  # Daily at 5 AM
             "args": {
                 "days_old": 5,
                 "dry_run": False,

--- a/tests/unit/tasks/test_task_groups.py
+++ b/tests/unit/tasks/test_task_groups.py
@@ -190,6 +190,41 @@ class TestPredefinedTaskGroups(TestCase):
         enabled_tasks = METRICS_COLLECTION_GROUP.get_enabled_tasks()
         assert len(enabled_tasks) == 0
 
+    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
+    def test_no_duplicate_cron_slots(self):
+        """Assert that no two enabled tasks across all groups share the same cron hour:minute slot.
+
+        Two tasks sharing the same hour and minute may run concurrently, which can cause
+        data races (for example, a cleanup task deleting records that a rollup task is
+        actively writing). This test prevents that class of scheduling conflict from being
+        introduced silently.
+        """
+        from apps.tasks.task_groups import TASK_GROUPS
+
+        all_enabled_tasks = []
+        for group in TASK_GROUPS:
+            all_enabled_tasks.extend(group.get_enabled_tasks())
+
+        seen_slots: dict[tuple[str, str], str] = {}
+        for task in all_enabled_tasks:
+            cron = task.get("cron", "")
+            if not cron:
+                continue
+            parts = cron.split()
+            if len(parts) < 2:
+                continue
+            minute, hour = parts[0], parts[1]
+            # Only compare tasks that fire at a fixed hour (not wildcards)
+            if hour == "*" or minute == "*":
+                continue
+            slot = (hour, minute)
+            task_id = task["task_id"]
+            assert slot not in seen_slots, (
+                f"Tasks '{task_id}' and '{seen_slots[slot]}' share the same cron slot "
+                f"{hour}:{minute.zfill(2)} - reschedule one to avoid concurrent execution"
+            )
+            seen_slots[slot] = task_id
+
 
 class TestTaskGroupFunctions(TestCase):
     """Test utility functions for task groups."""

--- a/tests/unit/tasks/test_task_groups.py
+++ b/tests/unit/tasks/test_task_groups.py
@@ -205,7 +205,7 @@ class TestPredefinedTaskGroups(TestCase):
         for group in TASK_GROUPS:
             all_enabled_tasks.extend(group.get_enabled_tasks())
 
-        seen_slots: dict[tuple[str, str], str] = {}
+        seen_slots: dict[tuple[int, int], str] = {}
         for task in all_enabled_tasks:
             cron = task.get("cron", "")
             if not cron:
@@ -213,15 +213,16 @@ class TestPredefinedTaskGroups(TestCase):
             parts = cron.split()
             if len(parts) < 2:
                 continue
-            minute, hour = parts[0], parts[1]
-            # Only compare tasks that fire at a fixed hour (not wildcards)
-            if hour == "*" or minute == "*":
+            minute_raw, hour_raw = parts[0], parts[1]
+            # Only compare tasks that fire at a single fixed hour:minute.
+            if not (minute_raw.isdigit() and hour_raw.isdigit()):
                 continue
+            minute, hour = int(minute_raw), int(hour_raw)
             slot = (hour, minute)
             task_id = task["task_id"]
             assert slot not in seen_slots, (
                 f"Tasks '{task_id}' and '{seen_slots[slot]}' share the same cron slot "
-                f"{hour}:{minute.zfill(2)} - reschedule one to avoid concurrent execution"
+                f"{hour}:{minute:02d} - reschedule one to avoid concurrent execution"
             )
             seen_slots[slot] = task_id
 


### PR DESCRIPTION
# [AAP-69215] Cron schedule collision - task cleanup and daily rollup both run at 2:00 AM

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed? The cron expression for `daily_task_cleanup` in `apps/tasks/task_groups.py` is moved from `0 2 * * *` (2:00 AM) to `0 5 * * *` (5:00 AM).
- Why is this change needed? `daily_task_cleanup` and `daily_metrics_rollup` previously shared the same cron slot `(0 2 * * *)`. If both tasks ran at the same time, `cleanup_old_tasks` could delete `TaskExecution` records that `daily_metrics_rollup` was actively writing to with the `DailyMetricsSummary.rollup_task_execution` FK.
- How does this change address the issue? Moving `daily_task_cleanup` to 5:00 AM ensures it runs one hour after the last metrics pipeline task (cleanup_metrics_data at 4:00 AM).

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [x] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
A running local environment

### Steps to Test
1. Review `apps/tasks/task_groups.py` and confirm `daily_task_cleanup` has cron `0 5 * * *` and that no other enabled task shares that slot.
2. Run the unit test suite: `uv run pytest tests/unit/tasks/test_task_groups.py -v` - all 14 tests should pass, including the new `test_no_duplicate_cron_slots`.
3. Run `python manage.py metrics_service init-system-tasks` and confirm the updated cron expression (0 5 * * *) is written to the `daily_task_cleanup` row in the database.

### Expected Results
<!-- Describe what should happen after following the steps -->
- test_no_duplicate_cron_slots passes, confirming no two enabled tasks share the same hour:minute cron slot.
- The database record for daily_task_cleanup shows cron_expression = "0 5 * * *" after running init-system-tasks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the production schedule of `daily_task_cleanup`, which can impact maintenance timing and any downstream expectations. Adds a guard test to prevent future cron-hour/minute collisions across enabled tasks.
> 
> **Overview**
> Reschedules the system `daily_task_cleanup` cron from `0 2 * * *` to `0 5 * * *` to avoid running concurrently with other daily metrics jobs.
> 
> Adds a unit test (`test_no_duplicate_cron_slots`) that asserts no two *enabled* tasks across all `TASK_GROUPS` share the same fixed hour:minute cron slot, preventing future scheduling collisions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97a17bdc68138804d4d17b48527c83e33b314bf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->