### PR TITLE
Tasks - restore 4 workers, atomically update execution state, fail & retry on parallel

### DIFF
--- a/apps/settings/dispatcherd.yaml
+++ b/apps/settings/dispatcherd.yaml
@@ -23,7 +23,7 @@ brokers:
 
 service:
   pool_kwargs:
-    max_workers: 1
+    max_workers: 4
 
   # Task execution settings
   task_settings:

--- a/apps/tasks/cleanup/cleanup_activitystream.py
+++ b/apps/tasks/cleanup/cleanup_activitystream.py
@@ -33,8 +33,8 @@ def cleanup_activitystream(**kwargs) -> dict[str, Any]:
     Returns:
         dict: Task result dictionary with cleanup statistics. Returns an error result
         dict (status="error") when ``days_old`` is not a positive integer rather than
-        raising, because this function runs inside ``task_execution_wrapper`` which
-        converts all exceptions to error dicts before they reach the caller.
+        raising, so that ``execute_db_task`` marks the task as failed with a clear
+        message instead of recording a raw exception traceback.
     """
     from ansible_base.activitystream.models import Entry as ActivityStreamEntry
 

--- a/apps/tasks/cleanup/cleanup_activitystream.py
+++ b/apps/tasks/cleanup/cleanup_activitystream.py
@@ -12,13 +12,11 @@ from typing import Any
 
 from django.utils import timezone
 
-from ..utils import create_task_result, log_task_execution, task, task_execution_wrapper
+from ..utils import create_task_result, log_task_execution
 
 logger = logging.getLogger(__name__)
 
 
-@task(queue="metrics_cleanup", decorate=False)
-@task_execution_wrapper("cleanup_activitystream")
 def cleanup_activitystream(**kwargs) -> dict[str, Any]:
     """
     Clean up old ActivityStream entries from the database.

--- a/apps/tasks/cleanup/cleanup_metrics_data.py
+++ b/apps/tasks/cleanup/cleanup_metrics_data.py
@@ -13,13 +13,11 @@ from typing import Any
 
 from django.utils import timezone
 
-from ..utils import create_task_result, log_task_execution, task, task_execution_wrapper
+from ..utils import create_task_result, log_task_execution
 
 logger = logging.getLogger(__name__)
 
 
-@task(queue="metrics_cleanup", decorate=False)
-@task_execution_wrapper("cleanup_metrics_data")
 def cleanup_metrics_data(**kwargs) -> dict[str, Any]:
     """
     Clean up old metrics data based on retention policies.

--- a/apps/tasks/cleanup/cleanup_old_tasks.py
+++ b/apps/tasks/cleanup/cleanup_old_tasks.py
@@ -12,13 +12,11 @@ from typing import Any
 
 from django.utils import timezone
 
-from ..utils import create_task_result, log_task_execution, task, task_execution_wrapper
+from ..utils import create_task_result, log_task_execution
 
 logger = logging.getLogger(__name__)
 
 
-@task(queue="metrics_cleanup", decorate=False)
-@task_execution_wrapper("cleanup_old_tasks")
 def cleanup_old_tasks(**kwargs) -> dict[str, Any]:
     """
     Clean up old completed and failed tasks from the database.

--- a/apps/tasks/collectors/collect_daily_metrics.py
+++ b/apps/tasks/collectors/collect_daily_metrics.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from django.utils import timezone
 
-from ..utils import generic_collect_metrics, get_db_connection, parse_datetime_string, task, task_execution_wrapper
+from ..utils import create_task_result, generic_collect_metrics, get_db_connection, parse_datetime_string
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +42,6 @@ def _get_daily_collectors():
     }
 
 
-@task(queue="metrics_collectors", decorate=False)
-@task_execution_wrapper("collect_daily_metrics")
 def collect_daily_metrics(**kwargs) -> dict[str, Any]:
     """
     Collect daily metrics for a specific collector type using a since/until time window.
@@ -64,13 +62,10 @@ def collect_daily_metrics(**kwargs) -> dict[str, Any]:
 
     Returns:
         dict: Task result with collection status and record ID
-
-    Raises:
-        ValueError: If collector_type is missing or invalid
     """
     collector_type = kwargs.pop("collector_type", None)
     if not collector_type:
-        raise ValueError("collector_type parameter is required")
+        return create_task_result("error", error="collector_type parameter is required")
 
     execution_id = kwargs.get("execution_id")
 
@@ -82,7 +77,7 @@ def collect_daily_metrics(**kwargs) -> dict[str, Any]:
     if hour_timestamp_str:
         today_midnight = parse_datetime_string(hour_timestamp_str)
         if today_midnight is None:
-            raise ValueError(f"Invalid hour_timestamp format: {hour_timestamp_str}")
+            return create_task_result("error", error=f"Invalid hour_timestamp format: {hour_timestamp_str}")
     else:
         now = timezone.now()
         today_midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -91,7 +86,7 @@ def collect_daily_metrics(**kwargs) -> dict[str, Any]:
     if since_str:
         since = parse_datetime_string(since_str)
         if since is None:
-            raise ValueError(f"Invalid since format: {since_str}")
+            return create_task_result("error", error=f"Invalid since format: {since_str}")
     else:
         since = today_midnight - timedelta(days=1)
 
@@ -99,7 +94,7 @@ def collect_daily_metrics(**kwargs) -> dict[str, Any]:
     if until_str:
         until = parse_datetime_string(until_str)
         if until is None:
-            raise ValueError(f"Invalid until format: {until_str}")
+            return create_task_result("error", error=f"Invalid until format: {until_str}")
     else:
         until = today_midnight
 

--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from django.utils import timezone
 
-from ..utils import generic_collect_metrics, get_db_connection, parse_datetime_string, task, task_execution_wrapper
+from ..utils import generic_collect_metrics, get_db_connection, parse_datetime_string
 
 logger = logging.getLogger(__name__)
 
@@ -61,8 +61,6 @@ def _get_hourly_collectors():
     }
 
 
-@task(queue="metrics_collectors", decorate=False)
-@task_execution_wrapper("collect_hourly_metrics")
 def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
     """
     Collect hourly metrics for a specific collector type.

--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -95,6 +95,9 @@ def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
         if hour_timestamp is None:
             raise ValueError(f"Invalid hour_timestamp format: {hour_timestamp_str}")
     else:
+        # Fallback only — the cron scheduler pins hour_timestamp into task_data
+        # at dispatch time via _inject_dispatch_timestamps(), so retries reuse
+        # the original window instead of recomputing from now.
         now = timezone.now()
         hour_timestamp = now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)
 

--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from django.utils import timezone
 
-from ..utils import generic_collect_metrics, get_db_connection, parse_datetime_string
+from ..utils import create_task_result, generic_collect_metrics, get_db_connection, parse_datetime_string
 
 logger = logging.getLogger(__name__)
 
@@ -77,13 +77,10 @@ def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
 
     Returns:
         dict: Task result with collection status and record ID
-
-    Raises:
-        ValueError: If collector_type is missing or invalid
     """
     collector_type = kwargs.pop("collector_type", None)
     if not collector_type:
-        raise ValueError("collector_type parameter is required")
+        return create_task_result("error", error="collector_type parameter is required")
 
     # Extract optional execution_id for linking to TaskExecution
     execution_id = kwargs.get("execution_id")  # Available when called via execute_db_task
@@ -93,7 +90,7 @@ def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
     if hour_timestamp_str:
         hour_timestamp = parse_datetime_string(hour_timestamp_str)
         if hour_timestamp is None:
-            raise ValueError(f"Invalid hour_timestamp format: {hour_timestamp_str}")
+            return create_task_result("error", error=f"Invalid hour_timestamp format: {hour_timestamp_str}")
     else:
         # Fallback only — the cron scheduler pins hour_timestamp into task_data
         # at dispatch time via _inject_dispatch_timestamps(), so retries reuse

--- a/apps/tasks/collectors/collect_snapshot_metrics.py
+++ b/apps/tasks/collectors/collect_snapshot_metrics.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from django.utils import timezone
 
-from ..utils import generic_collect_metrics, get_db_connection, parse_datetime_string, task, task_execution_wrapper
+from ..utils import generic_collect_metrics, get_db_connection, parse_datetime_string
 
 logger = logging.getLogger(__name__)
 
@@ -68,8 +68,6 @@ def _get_snapshot_collectors():
     }
 
 
-@task(queue="metrics_collectors", decorate=False)
-@task_execution_wrapper("collect_snapshot_metrics")
 def collect_snapshot_metrics(**kwargs) -> dict[str, Any]:
     """
     Collect snapshot metrics for a specific collector type.

--- a/apps/tasks/collectors/collect_snapshot_metrics.py
+++ b/apps/tasks/collectors/collect_snapshot_metrics.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from django.utils import timezone
 
-from ..utils import generic_collect_metrics, get_db_connection, parse_datetime_string
+from ..utils import create_task_result, generic_collect_metrics, get_db_connection, parse_datetime_string
 
 logger = logging.getLogger(__name__)
 
@@ -84,13 +84,10 @@ def collect_snapshot_metrics(**kwargs) -> dict[str, Any]:
 
     Returns:
         dict: Task result with collection status and record ID
-
-    Raises:
-        ValueError: If collector_type is missing or invalid
     """
     collector_type = kwargs.pop("collector_type", None)
     if not collector_type:
-        raise ValueError("collector_type parameter is required")
+        return create_task_result("error", error="collector_type parameter is required")
 
     # Extract optional execution_id for linking to TaskExecution
     execution_id = kwargs.get("execution_id")  # Available when called via execute_db_task
@@ -100,7 +97,7 @@ def collect_snapshot_metrics(**kwargs) -> dict[str, Any]:
     if collection_timestamp_str:
         collection_timestamp = parse_datetime_string(collection_timestamp_str)
         if collection_timestamp is None:
-            raise ValueError(f"Invalid collection_timestamp format: {collection_timestamp_str}")
+            return create_task_result("error", error=f"Invalid collection_timestamp format: {collection_timestamp_str}")
     else:
         # Snapshot collections belong to the previous day (the day being summarized)
         # Use 23:00 of the previous day to ensure they fall within the daily rollup's query window

--- a/apps/tasks/collectors/daily_anonymize_and_prepare.py
+++ b/apps/tasks/collectors/daily_anonymize_and_prepare.py
@@ -27,9 +27,13 @@ def daily_anonymize_and_prepare(**kwargs) -> dict[str, Any]:
     """
     Anonymize daily metrics summary and prepare payload for Segment
 
-    - Fetches DailyMetricsSummary non-anyonymized daily rollup
-    - anonymizes using anonymize_rollups() from metrics-utility
+    Acquires an advisory lock to prevent concurrent execution, then:
+    - Fetches DailyMetricsSummary with status=aggregated (upstream dependency)
+    - Anonymizes using anonymize_rollups() from metrics-utility
     - Creates AnonymizedMetricsPayload record
+
+    If the upstream dependency (aggregated summary) is not met or the lock
+    cannot be acquired, the task fails and will be retried automatically.
 
     Args:
         **kwargs: Task data containing:

--- a/apps/tasks/collectors/daily_anonymize_and_prepare.py
+++ b/apps/tasks/collectors/daily_anonymize_and_prepare.py
@@ -18,15 +18,11 @@ from ..utils import (
     create_task_result,
     generate_salt,
     log_task_execution,
-    task,
-    task_execution_wrapper,
 )
 
 logger = logging.getLogger(__name__)
 
 
-@task(queue="metrics_collectors", decorate=False)
-@task_execution_wrapper("daily_anonymize_and_prepare")
 def daily_anonymize_and_prepare(**kwargs) -> dict[str, Any]:
     """
     Anonymize daily metrics summary and prepare payload for Segment

--- a/apps/tasks/collectors/daily_metrics_rollup.py
+++ b/apps/tasks/collectors/daily_metrics_rollup.py
@@ -218,13 +218,10 @@ def daily_metrics_rollup(**kwargs) -> dict[str, Any]:
     Create daily summary from hourly rollups
 
     This task:
-    1. Checks that hourly collections exist for the target date
-    2. Merges hourly rollups into daily rollups using rollup processor merge logic
-    3. Extracts daily snapshot data (execution_environments, config)
-    4. Creates DailyMetricsSummary record with complete daily rollup
-
-    If the upstream dependency (hourly collections) is not met or the lock
-    cannot be acquired, the task fails and will be retried automatically.
+    - pulls hourly, daily, and snapshot collections for the target data
+    - fails if no hourlies exist
+    - merges them into a daily rollup
+    - saves to DailyMetricsSummary
 
     Args:
         **kwargs: Task data containing:

--- a/apps/tasks/collectors/daily_metrics_rollup.py
+++ b/apps/tasks/collectors/daily_metrics_rollup.py
@@ -150,6 +150,7 @@ def _merge_hourly_rollups(collections_by_type: dict[str, list]) -> tuple[dict, l
             daily_rollup[collector_type] = _merge_collects(collections, processor)
         else:
             logger.warning(f"No {collector_type} collection found for summary date")
+            missing_hours.append(f"{collector_type}:daily")
             daily_rollup[collector_type] = _merge_collects([], processor)
 
     return daily_rollup, missing_hours
@@ -250,6 +251,20 @@ def daily_metrics_rollup(**kwargs) -> dict[str, Any]:
         summary_date = timezone.now().date() - timedelta(days=1)
 
     log_task_execution("daily_metrics_rollup", "processing", f"Creating daily rollup for: {summary_date}")
+
+    # Check upstream dependency: at least some hourly collections must exist
+    from ..models import HourlyMetricsCollection
+
+    start_dt = timezone.make_aware(datetime.combine(summary_date, datetime.min.time()))
+    end_dt = start_dt + timedelta(days=1)
+    has_collections = HourlyMetricsCollection.objects.filter(
+        collection_timestamp__gte=start_dt, collection_timestamp__lt=end_dt, status="collected"
+    ).exists()
+
+    if not has_collections:
+        msg = f"No collected hourly metrics found for {summary_date} — upstream dependency not met"
+        log_task_execution("daily_metrics_rollup", "skipped", msg)
+        return create_task_result("error", error=msg)
 
     try:
         # Query and group hourly collections by type

--- a/apps/tasks/collectors/daily_metrics_rollup.py
+++ b/apps/tasks/collectors/daily_metrics_rollup.py
@@ -15,8 +15,6 @@ from django.utils import timezone
 from ..utils import (
     create_task_result,
     log_task_execution,
-    task,
-    task_execution_wrapper,
 )
 
 logger = logging.getLogger(__name__)
@@ -214,8 +212,6 @@ def _save_daily_summary(
     return daily_summary, created, hourly_collections_count
 
 
-@task(queue="metrics_collectors", decorate=False)
-@task_execution_wrapper("daily_metrics_rollup")
 def daily_metrics_rollup(**kwargs) -> dict[str, Any]:
     """
     Create daily summary from hourly rollups

--- a/apps/tasks/collectors/daily_metrics_rollup.py
+++ b/apps/tasks/collectors/daily_metrics_rollup.py
@@ -218,21 +218,13 @@ def daily_metrics_rollup(**kwargs) -> dict[str, Any]:
     Create daily summary from hourly rollups
 
     This task:
-    1. Queries all hourly rollup collections for the previous day
+    1. Checks that hourly collections exist for the target date
     2. Merges hourly rollups into daily rollups using rollup processor merge logic
     3. Extracts daily snapshot data (execution_environments, config)
     4. Creates DailyMetricsSummary record with complete daily rollup
 
-    Collectors:
-        - Hourly merged (from HourlyMetricsCollection):
-            - job_host_summary_service
-            - unified_jobs
-            - credentials_service
-        - Daily snapshots (from HourlyMetricsCollection):
-            - execution_environments
-            - controller_version_service
-            - table_metadata
-            - config
+    If the upstream dependency (hourly collections) is not met or the lock
+    cannot be acquired, the task fails and will be retried automatically.
 
     Args:
         **kwargs: Task data containing:

--- a/apps/tasks/collectors/send_anonymized_to_segment.py
+++ b/apps/tasks/collectors/send_anonymized_to_segment.py
@@ -16,8 +16,6 @@ from django.utils import timezone
 from ..utils import (
     create_task_result,
     log_task_execution,
-    task,
-    task_execution_wrapper,
 )
 
 logger = logging.getLogger(__name__)
@@ -210,8 +208,6 @@ def send_to_segment(user_id: str, event_name: str, segment_data: dict, segment_m
         return f"error: {str(e)}"
 
 
-@task(queue="metrics_collectors", decorate=False)
-@task_execution_wrapper("send_anonymized_to_segment")
 def send_anonymized_to_segment(**kwargs) -> dict[str, Any]:
     """
     Send anonymized payload to Segment.

--- a/apps/tasks/collectors/send_anonymized_to_segment.py
+++ b/apps/tasks/collectors/send_anonymized_to_segment.py
@@ -232,14 +232,23 @@ def send_anonymized_to_segment(**kwargs) -> dict[str, Any]:
     payload_id = kwargs.get("payload_id")
     stale_minutes = kwargs.get("stale_minutes", 10)
 
-    log_task_execution("send_anonymized_to_segment", "processing", "Sending anonymized payloads to Segment")
-
     try:
-        # Threshold for stale "sending" payloads (process crashed before completion)
         stale_threshold = timezone.now() - timedelta(minutes=stale_minutes)
 
-        # Get payloads to send
+        # Check for pending payloads early to avoid unnecessary work
         payloads = _get_payloads_to_send(payload_id, max_payloads, stale_threshold)
+        if not payloads:
+            log_task_execution("send_anonymized_to_segment", "skipped", "No pending payloads to send")
+            return create_task_result(
+                "success",
+                {
+                    "task_type": "send_anonymized_to_segment",
+                    "results": {"sent": 0, "failed": 0, "skipped": 0, "recovered": 0},
+                    "total_processed": 0,
+                },
+            )
+
+        log_task_execution("send_anonymized_to_segment", "processing", "Sending anonymized payloads to Segment")
 
         # Initialize results
         results = {"sent": 0, "failed": 0, "skipped": 0, "recovered": 0}

--- a/apps/tasks/collectors/send_anonymized_to_segment.py
+++ b/apps/tasks/collectors/send_anonymized_to_segment.py
@@ -212,12 +212,14 @@ def send_anonymized_to_segment(**kwargs) -> dict[str, Any]:
     """
     Send anonymized payload to Segment.
 
-    This task:
+    Acquires an advisory lock to prevent concurrent execution, then:
     1. Fetches AnonymizedMetricsPayload records with status=pending/retry
     2. Recovers stale "sending" payloads (stuck for > 10 minutes)
     3. Sends to Segment using send_to_segment helper
     4. Updates payload status based on result
-    5. Handles retries for failed sends
+
+    If no payloads are pending, this is a no-op (returns success with 0 sent).
+    If the lock cannot be acquired, the task fails and will be retried.
 
     Args:
         **kwargs: Task data containing:

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -8,15 +8,12 @@ and database tasks without database polling, using APScheduler for optimal perfo
 import logging
 import threading
 from datetime import timedelta
-from typing import Any
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from django.db import close_old_connections
 from django.utils import timezone
-
-from .tasks import TASK_FUNCTIONS
 
 logger = logging.getLogger(__name__)
 
@@ -66,53 +63,11 @@ class UnifiedTaskScheduler:
         """Initialize the task scheduler."""
         self.scheduler = BackgroundScheduler()
         self.running = False
-        self._lock = threading.Lock()  # FIXME unused?
+        self._lock = threading.Lock()
         self.check_interval = check_interval
-
-        # Task registry for scheduled tasks from task groups
-        # FIXME dead? .. not, used to register ap scheduler cron thing .. but scheduled somewhere else?
-        self.task_registry: dict[str, dict[str, Any]] = {}
-        self._load_task_registry()
 
         # Database task tracking
         self._db_task_jobs: dict[int, str] = {}  # task_id -> job_id mapping
-
-    def _load_task_registry(self):
-        """
-        Load task registry from database (source of truth).
-
-        All tasks including system tasks are stored in the tasks_task table.
-        Task group definitions are synced to the database on startup.
-        """
-        try:
-            from .models import Task
-
-            # Load all system tasks (recurring) from database
-            # FIXME: ==system cronjobs .. why just these? .. ok, only used to register those, while the rest happens in periodic_database_sync .. keep just there? .. still should just do pending, and probably not filter by system tasks?
-            system_tasks = Task.objects.filter(is_system_task=True, cron_expression__isnull=False).exclude(
-                status__in=["cancelled", "completed"]
-            )
-            # TODO:^ so.. should be either Task.recurring_tasks(); or nothing at all until we start & sync
-
-            # Convert to registry format
-            self.task_registry = {}
-            for task in system_tasks:
-                self.task_registry[task.name] = {
-                    "function": task.function_name,
-                    "cron": task.cron_expression,
-                    "args": task.task_data or {},
-                    "description": task.description,
-                    "enabled": True,  # All in DB are enabled
-                    "task_id": task.name,
-                    "db_id": task.id,
-                }
-
-            logger.info(f"Loaded {len(self.task_registry)} system tasks from database")
-
-        except Exception as e:
-            logger.error(f"Failed to load task registry from database: {str(e)}")
-            # Fallback to empty registry
-            self.task_registry = {}
 
     def start(self):
         """Start the cron scheduler."""
@@ -122,9 +77,6 @@ class UnifiedTaskScheduler:
                 return
 
             try:
-                # Add all tasks to the scheduler (feature flag check happens at runtime)
-                self._add_registry_tasks()
-
                 # Start the scheduler
                 self.scheduler.start()
                 self.running = True
@@ -136,15 +88,14 @@ class UnifiedTaskScheduler:
                 self.scheduler.add_job(
                     func=self._periodic_database_sync,
                     trigger="interval",
-                    seconds=self.check_interval,  # Check every minute by default
+                    seconds=self.check_interval,
                     id="periodic_db_sync",
                     name="Periodic Database Task Sync",
-                    replace_existing=True,  # FIXME?
+                    replace_existing=True,
                     max_instances=1,  # Prevent overlapping executions
                 )
 
                 logger.info("Task scheduler started")
-                logger.info(f"Registered {len(self.task_registry)} task group tasks")
                 logger.info(f"Loaded {len(self._db_task_jobs)} database tasks")
                 logger.info(f"Periodic database sync will run every {self.check_interval} seconds")
 
@@ -166,91 +117,6 @@ class UnifiedTaskScheduler:
             except Exception as e:
                 logger.error(f"Error stopping cron scheduler: {str(e)}")
 
-    def _add_registry_tasks(self):
-        """Add all enabled tasks from the registry to the scheduler."""
-        for task_id, config in self.task_registry.items():
-            if not config.get("enabled", True):
-                logger.debug(f"Skipping disabled task: {task_id}")
-                continue
-
-            try:
-                self._add_scheduled_task(task_id, config)
-            except Exception as e:
-                logger.error(f"Failed to add task {task_id}: {str(e)}")
-
-    def _add_scheduled_task(self, task_id: str, config: dict[str, Any]):
-        """Add a single scheduled task to the scheduler."""
-        function_name = config["function"]
-
-        # Validate function exists
-        if function_name not in TASK_FUNCTIONS:
-            raise ValueError(f"Unknown task function: {function_name}")
-
-        # Create trigger based on cron expression
-        trigger = CronTrigger.from_crontab(config["cron"])
-
-        # Add job to scheduler (feature flag is checked at runtime via args['_feature_flag'])
-        self.scheduler.add_job(
-            func=self._execute_scheduled_task,
-            trigger=trigger,
-            args=[task_id, function_name, config.get("args", {})],
-            id=task_id,
-            name=config.get("description", task_id),
-            replace_existing=True,
-            max_instances=1,  # Prevent overlapping executions
-        )
-
-        logger.info(f"Added scheduled task: {task_id} ({config['cron']})")
-
-    def _execute_scheduled_task(self, task_id: str, function_name: str, args: dict[str, Any]):
-        """
-        Execute a scheduled task by looking it up from the DB and routing through execute_db_task.
-
-        This ensures task_data always comes from the DB (maintained by init-system-tasks),
-        and all tasks go through the same lifecycle management path as DB-scheduled tasks.
-
-        Args:
-            task_id: Unique identifier for the task (matches Task.name for system tasks)
-            function_name: Unused. The function to execute is determined by the DB task record
-                  inside _execute_database_task; this parameter exists only because APScheduler
-                  was originally registered with it and removing it would require re-registering
-                  all scheduled jobs.
-            args: Unused. The feature flag and other task data are re-read from task.task_data
-                  at runtime to reflect the current DB state.
-        """
-        close_old_connections()
-        try:
-            from .models import Task
-
-            task = Task.objects.filter(name=task_id, is_system_task=True).first()
-
-            if not task:
-                logger.error(
-                    f"System task '{task_id}' not found in database - run 'manage.py metrics_service init-system-tasks'"
-                )
-                return
-
-            if task.status in ("cancelled", "completed"):
-                logger.warning(f"System task '{task_id}' has status '{task.status}' and will not be executed")
-                return
-
-            # Re-check the feature flag stored in task_data so that disabling the flag
-            # at runtime stops execution without requiring a scheduler restart.
-            feature_flag = task.task_data.get("_feature_flag") if task.task_data else None
-            if feature_flag:
-                from .task_groups import get_feature_enabled_from_db
-
-                if not get_feature_enabled_from_db(feature_flag):
-                    logger.info(f"Skipping task '{task_id}': feature flag '{feature_flag}' is disabled")
-                    return
-
-            self._execute_database_task(task.id)
-
-        except Exception as e:
-            logger.error(f"Failed to execute scheduled task {task_id}: {str(e)}")
-
-    # FIXME: is this what does it, or is it all apscheduler now?
-    # FIXME: sync_database_tasks vs periodic_database_sync
     def _sync_database_tasks(self):
         """Synchronize database tasks with the scheduler."""
         try:
@@ -400,6 +266,24 @@ class UnifiedTaskScheduler:
                 logger.warning(f"Database task {task_id} not found")
                 self._remove_database_task(task_id)
                 return
+
+            if task.status in ("cancelled", "completed"):
+                logger.warning(f"Task '{task.name}' has status '{task.status}' and will not be executed")
+                self._remove_database_task(task_id)
+                return
+
+            # Check feature flag at runtime so toggling takes effect without restart
+            feature_flag = task.task_data.get("_feature_flag") if task.task_data else None
+            if feature_flag:
+                from .task_groups import get_feature_enabled_from_db
+
+                if not get_feature_enabled_from_db(feature_flag):
+                    logger.info(f"Skipping task '{task.name}': feature flag '{feature_flag}' is disabled")
+                    # Remove non-recurring tasks from tracking so they can be
+                    # retried on the next periodic sync when the flag is re-enabled.
+                    if not task.cron_expression:
+                        self._remove_database_task(task_id)
+                    return
 
             # Handle recurring tasks by creating a new execution record
             if task.cron_expression:

--- a/apps/tasks/dispatcherd_config.py
+++ b/apps/tasks/dispatcherd_config.py
@@ -211,7 +211,6 @@ def get_queue_for_function(function_name: str) -> str:
     queue_mapping = {
         # System/general tasks
         "hello_world": "metrics_tasks",
-        "execute_db_task": "metrics_tasks",
         # Cleanup tasks
         "cleanup_old_tasks": "metrics_cleanup",
         "cleanup_metrics_data": "metrics_cleanup",

--- a/apps/tasks/models.py
+++ b/apps/tasks/models.py
@@ -132,7 +132,7 @@ class Task(NamedCommonModel, AuditableModel, StatusTrackingMixin):
         if self.status != "pending":
             return False
 
-        # Check if scheduled time has passed
+        # Check if immediate or scheduled time has passed
         return not (self.scheduled_time and self.scheduled_time > timezone.now())
 
     def can_retry(self) -> bool:
@@ -235,6 +235,14 @@ class Task(NamedCommonModel, AuditableModel, StatusTrackingMixin):
             return "croniter not available"
         except Exception:
             return "Invalid cron_expression"
+
+    @classmethod
+    def ready_to_run(cls):
+        """Queryset equivalent of is_ready_to_run() — pending non-recurring tasks whose scheduled_time has passed or is null."""
+        return cls.objects.filter(
+            status="pending",
+            cron_expression__isnull=True,
+        ).filter(models.Q(scheduled_time__isnull=True) | models.Q(scheduled_time__lte=timezone.now()))
 
     @classmethod
     def immediate_tasks(cls):

--- a/apps/tasks/models.py
+++ b/apps/tasks/models.py
@@ -6,7 +6,7 @@ and FIXME: split out - also models for collects, rollups and anonymized
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.db import models
@@ -144,13 +144,18 @@ class Task(NamedCommonModel, AuditableModel, StatusTrackingMixin):
         """
         return self.attempts < self.max_attempts and self.status == "failed"
 
-    def retry(self) -> bool:
+    def retry(self, delay_seconds: int = 0) -> bool:
         """
         Retry a failed task by resetting its status to pending.
 
         The attempts counter is NOT reset to properly enforce max_attempts limit.
         This ensures that the total number of execution attempts (automatic + manual retries)
         respects the max_attempts setting and prevents indefinite retries.
+
+        Args:
+            delay_seconds: Optional delay before the task becomes eligible for execution.
+                When set, scheduled_time is set to now + delay so the periodic sync
+                won't pick it up until the delay has elapsed.
 
         Returns:
             bool: True if task was successfully reset for retry, False otherwise
@@ -163,9 +168,12 @@ class Task(NamedCommonModel, AuditableModel, StatusTrackingMixin):
         self.started_at = None
         self.completed_at = None
         # NOTE: Do NOT reset attempts to 0 here. The attempts counter must persist
-        # across retries to properly enforce the max_attempts limit. Without this,
-        # users could bypass max_attempts by repeatedly calling retry().
-        # FIXME: users SHOULD be able to ignore max_attempts when manually retrying???
+        # across retries to properly enforce the max_attempts limit.
+
+        if delay_seconds > 0:
+            self.scheduled_time = timezone.now() + timedelta(seconds=delay_seconds)
+        else:
+            self.scheduled_time = None
 
         self.save()
 

--- a/apps/tasks/simple/hello_world.py
+++ b/apps/tasks/simple/hello_world.py
@@ -8,13 +8,11 @@ Used for testing the dispatcherd integration.
 import logging
 from typing import Any
 
-from ..utils import create_task_result, task, task_execution_wrapper
+from ..utils import create_task_result
 
 logger = logging.getLogger(__name__)
 
 
-@task(queue="metrics_tasks", decorate=False)
-@task_execution_wrapper("hello_world")
 def hello_world(**kwargs) -> dict[str, Any]:
     """
     Simple hello world task for testing.

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -52,6 +52,17 @@ TASK_FUNCTIONS = {
     "send_anonymized_to_segment": send_anonymized_to_segment,
 }
 
+# Tasks that require a PostgreSQL advisory lock during scheduled execution.
+# The lock key is the function name. Locking is applied in execute_db_task,
+# so direct invocations (e.g. run_task.py) run without contention.
+TASK_LOCKS = {
+    "collect_hourly_metrics",
+    "collect_snapshot_metrics",
+    "daily_metrics_rollup",
+    "daily_anonymize_and_prepare",
+    "send_anonymized_to_segment",
+}
+
 # Enhanced task metadata for dashboard display
 TASK_METADATA = {
     # Testing
@@ -315,5 +326,6 @@ __all__ = [
     "send_anonymized_to_segment",
     # Configuration
     "TASK_FUNCTIONS",
+    "TASK_LOCKS",
     "TASK_METADATA",
 ]

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -29,7 +29,6 @@ from .collectors.send_anonymized_to_segment import send_anonymized_to_segment
 from .simple.hello_world import hello_world
 from .tasks_system import (
     create_system_tasks,
-    execute_db_task,
     get_system_task_info,
     submit_task_to_dispatcher,
 )
@@ -43,7 +42,6 @@ TASK_FUNCTIONS = {
     "cleanup_old_tasks": cleanup_old_tasks,
     "cleanup_activitystream": cleanup_activitystream,
     "cleanup_metrics_data": cleanup_metrics_data,
-    "execute_db_task": execute_db_task,
     # Metrics Collection (hourly time-series, daily snapshots, and daily time-range)
     "collect_hourly_metrics": collect_hourly_metrics,
     "collect_snapshot_metrics": collect_snapshot_metrics,
@@ -119,16 +117,6 @@ TASK_METADATA = {
             {"name": "Dry run", "data": {"dry_run": True}},
             {"name": "Extended retention (30 days)", "data": {"days_old": 30}},
         ],
-    },
-    # System
-    "execute_db_task": {
-        "category": "System",
-        "description": "Execute a database-defined task with comprehensive lifecycle management",
-        "parameters": {
-            "task_id": {"type": "integer", "required": True, "description": "ID of the task to execute"},
-            "execution_id": {"type": "integer", "description": "ID of the execution record (optional)"},
-        },
-        "examples": [{"name": "Execute task by ID", "data": {"task_id": 123}}],
     },
     "cleanup_metrics_data": {
         "category": "Maintenance",
@@ -314,7 +302,6 @@ __all__ = [
     "cleanup_old_tasks",
     "cleanup_activitystream",
     "cleanup_metrics_data",
-    "execute_db_task",
     "submit_task_to_dispatcher",
     "create_system_tasks",
     "get_system_task_info",

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -235,7 +235,7 @@ def create_system_tasks() -> dict[str, Any]:
     # Get all task group definitions. Use get_all_tasks_for_init() (not get_all_enabled_tasks())
     # so that feature-flagged tasks such as daily_anonymize and send_to_segment_daily are always
     # written to the DB with _feature_flag stored in task_data. The runtime check in
-    # cron_scheduler._execute_scheduled_task() then gates execution without requiring re-init
+    # cron_scheduler._execute_database_task() then gates execution without requiring re-init
     # when the flag is toggled.
     task_groups = get_all_tasks_for_init()
 

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -84,6 +84,9 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
     if not task_id:
         return create_task_result("error", error="task_id is required")
 
+    task = None
+    execution = None
+
     try:
         from .models import Task
 
@@ -142,7 +145,7 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
         return result
 
     except Exception as e:
-        return handle_task_error(None, None, task_id=task_id, exception=e)
+        return handle_task_error(task, execution, task_id=task_id, exception=e)
 
 
 def submit_task_to_dispatcher(task: Any) -> None:
@@ -188,16 +191,6 @@ def submit_task_to_dispatcher(task: Any) -> None:
         task.status = "failed"
         task.error_message = f"Failed to submit to dispatcher: {str(e)}"
         task.save()
-        # FIXME: no execution here, move inside execute_db_task
-        # Also mark the TaskExecution row as failed so it doesn't stay pending
-        # forever. Guard with try/except in case the create() call itself failed
-        # and `execution` was never bound.
-        try:
-            execution.status = "failed"
-            execution.error_message = f"Failed to submit to dispatcher: {str(e)}"
-            execution.save()
-        except Exception as save_err:  # execution may be unbound if create() failed
-            logger.debug(f"Could not mark TaskExecution as failed: {save_err}")
 
 
 # runs during `manage.py metrics_service init-system-tasks`

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -8,7 +8,7 @@ communication, and testing tasks with proper error handling and status tracking.
 import logging
 from typing import Any
 
-from django.db import models
+from django.db import models, transaction
 
 from .utils import (
     create_task_result,
@@ -42,21 +42,26 @@ def _claim_task(task_id):
 
     from .models import Task, TaskExecution
 
-    claimed = Task.objects.filter(id=task_id, status="pending").update(
-        status="running",
-        started_at=timezone.now(),
-        attempts=models.F("attempts") + 1,
-    )
-    if not claimed:
-        return None, None
+    with transaction.atomic():
+        claimed = (
+            Task.ready_to_run()
+            .filter(id=task_id)
+            .update(
+                status="running",
+                started_at=timezone.now(),
+                attempts=models.F("attempts") + 1,
+            )
+        )
+        if not claimed:
+            return None, None
 
-    task = Task.objects.get(id=task_id)
+        task = Task.objects.get(id=task_id)
 
-    execution = TaskExecution.objects.create(
-        task=task,
-        status="running",
-        worker_id=f"dispatcher-{os.getpid()}",
-    )
+        execution = TaskExecution.objects.create(
+            task=task,
+            status="running",
+            worker_id=f"dispatcher-{os.getpid()}",
+        )
 
     return task, execution
 

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -66,6 +66,68 @@ def _claim_task(task_id):
     return task, execution
 
 
+def execute_function(task, execution, task_function, locked):
+    try:
+        if locked:
+            return run_with_lock(
+                task.function_name,  # lock_key
+                task.name,
+                task_function,
+                execution_id=execution.id,
+                **task.task_data,
+            )
+        else:
+            return task_function(execution_id=execution.id, **task.task_data)
+
+    except Exception as e:
+        logger.exception(f"Task {task.function_name} raised: {e}")
+        return create_task_result("error", error=f"Task execution failed: {e}")
+
+
+def execute_claimed(task, execution):
+    # Import TASK_FUNCTIONS here to avoid circular import
+    # This import happens at runtime, not module load time
+    from .tasks import TASK_FUNCTIONS, TASK_LOCKS
+
+    # Validate task function exists
+    if task.function_name not in TASK_FUNCTIONS:
+        error_msg = f"Task function '{task.function_name}' not found in TASK_FUNCTIONS"
+        return handle_task_error(task, execution, error_msg)
+
+    log_task_execution(task.function_name, "start", f"Starting {task.function_name} task")
+    log_task_execution(task.name, "running", f"Executing function: {task.function_name}")
+
+    # Execute the actual task function, with advisory lock if required
+    # Forwarding execution_id the task can link collections back to TaskExecution
+    task_function = TASK_FUNCTIONS[task.function_name]
+    locked = task.function_name in TASK_LOCKS
+    result = execute_function(task, execution, task_function, locked)
+
+    # Complete task execution
+    status = "completed" if result.get("status") == "success" else "failed"
+    error_message = result.get("error", "") if status == "failed" else ""
+
+    update_task_status(task, execution, status=status, result_data=result, error_message=error_message)
+
+    if status == "completed":
+        log_task_execution(task.function_name, "complete", f"Task {task.function_name} completed successfully")
+    else:
+        error_msg = f"{task.function_name} task failed: {error_message}"
+        log_task_execution(task.function_name, "error", error_msg, level="error")
+    log_task_execution(task.name, "completed", f"Task execution finished with status: {status}")
+
+    # Auto-retry if the task failed and has attempts remaining
+    if status == "failed":
+        task.refresh_from_db()
+        if task.can_retry():
+            retry_delay = task.task_data.get("retry_delay_seconds", 600)
+            delay_msg = f" (delay {retry_delay}s)" if retry_delay else ""
+            logger.info(f"Auto-retrying task {task.name} (attempt {task.attempts}/{task.max_attempts}){delay_msg}")
+            task.retry(delay_seconds=retry_delay)
+
+    return result
+
+
 # This is the sole dispatcherd entry point — all DB tasks are routed through it.
 @task(queue="metrics_tasks", decorate=False)
 def execute_db_task(**kwargs) -> dict[str, Any]:
@@ -103,58 +165,12 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
             logger.warning(f"Task {task_id} already claimed by another worker, skipping")
             return create_task_result("error", error="Task already claimed by another worker")
 
-        # Import TASK_FUNCTIONS here to avoid circular import
-        # This import happens at runtime, not module load time
-        from .tasks import TASK_FUNCTIONS, TASK_LOCKS
-
-        # Validate task function exists
-        if task.function_name not in TASK_FUNCTIONS:
-            error_msg = f"Task function '{task.function_name}' not found in TASK_FUNCTIONS"
-            return handle_task_error(task, execution, error_msg)
-
-        log_task_execution(task.function_name, "start", f"Starting {task.function_name} task")
-        log_task_execution(task.name, "running", f"Executing function: {task.function_name}")
-
-        # Execute the actual task function, with advisory lock if required
-        # Forwarding execution_id the task can link collections back to TaskExecution
-        task_function = TASK_FUNCTIONS[task.function_name]
-        try:
-            if task.function_name in TASK_LOCKS:
-                result = run_with_lock(
-                    task.function_name, task.name, task_function, execution_id=execution.id, **task.task_data
-                )
-            else:
-                result = task_function(execution_id=execution.id, **task.task_data)
-        except Exception as e:
-            logger.exception(f"Task {task.function_name} raised: {e}")
-            result = create_task_result("error", error=f"Task execution failed: {e}")
-
-        # Complete task execution
-        status = "completed" if result.get("status") == "success" else "failed"
-        error_message = result.get("error", "") if status == "failed" else ""
-
-        update_task_status(task, execution, status=status, result_data=result, error_message=error_message)
-
-        if status == "completed":
-            log_task_execution(task.function_name, "complete", f"Task {task.function_name} completed successfully")
-        else:
-            error_msg = f"{task.function_name} task failed: {error_message}"
-            log_task_execution(task.function_name, "error", error_msg, level="error")
-        log_task_execution(task.name, "completed", f"Task execution finished with status: {status}")
-
-        # Auto-retry if the task failed and has attempts remaining
-        if status == "failed":
-            task.refresh_from_db()
-            if task.can_retry():
-                retry_delay = task.task_data.get("retry_delay_seconds", 600)
-                delay_msg = f" (delay {retry_delay}s)" if retry_delay else ""
-                logger.info(f"Auto-retrying task {task.name} (attempt {task.attempts}/{task.max_attempts}){delay_msg}")
-                task.retry(delay_seconds=retry_delay)
-
-        return result
+        return execute_claimed(task, execution)
 
     except Exception as e:
-        return handle_task_error(task, execution, task_id=task_id, exception=e)
+        return handle_task_error(
+            task, execution, task_id=task_id, execution_id=(execution.id if execution else None), exception=e
+        )
 
 
 def submit_task_to_dispatcher(task: Any) -> None:

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -133,8 +133,10 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
         if status == "failed":
             task.refresh_from_db()
             if task.can_retry():
-                logger.info(f"Auto-retrying task {task.name} (attempt {task.attempts}/{task.max_attempts})")
-                task.retry()
+                retry_delay = task.task_data.get("retry_delay_seconds", 600)
+                delay_msg = f" (delay {retry_delay}s)" if retry_delay else ""
+                logger.info(f"Auto-retrying task {task.name} (attempt {task.attempts}/{task.max_attempts}){delay_msg}")
+                task.retry(delay_seconds=retry_delay)
 
         return result
 

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -113,12 +113,16 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
         # Execute the actual task function, with advisory lock if required
         # Forwarding execution_id the task can link collections back to TaskExecution
         task_function = TASK_FUNCTIONS[task.function_name]
-        if task.function_name in TASK_LOCKS:
-            result = run_with_lock(
-                task.function_name, task.name, task_function, execution_id=execution.id, **task.task_data
-            )
-        else:
-            result = task_function(execution_id=execution.id, **task.task_data)
+        try:
+            if task.function_name in TASK_LOCKS:
+                result = run_with_lock(
+                    task.function_name, task.name, task_function, execution_id=execution.id, **task.task_data
+                )
+            else:
+                result = task_function(execution_id=execution.id, **task.task_data)
+        except Exception as e:
+            logger.exception(f"Task {task.function_name} raised: {e}")
+            result = create_task_result("error", error=f"Task execution failed: {e}")
 
         # Complete task execution
         status = "completed" if result.get("status") == "success" else "failed"

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -15,6 +15,7 @@ from .utils import (
     ensure_django_setup,
     handle_task_error,
     log_task_execution,
+    run_with_lock,
     update_task_status,
 )
 
@@ -47,7 +48,7 @@ def _claim_task(task_id):
         attempts=models.F("attempts") + 1,
     )
     if not claimed:
-        return None
+        return None, None
 
     task = Task.objects.get(id=task_id)
 
@@ -86,18 +87,17 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
     try:
         from .models import Task
 
-        result = _claim_task(task_id)
-        if result is None:
+        task, execution = _claim_task(task_id)
+        if task is None:
             if not Task.objects.filter(id=task_id).exists():
                 return create_task_result("error", error=f"Task matching query does not exist: {task_id}")
+
             logger.warning(f"Task {task_id} already claimed by another worker, skipping")
             return create_task_result("error", error="Task already claimed by another worker")
 
-        task, execution = result
-
         # Import TASK_FUNCTIONS here to avoid circular import
         # This import happens at runtime, not module load time
-        from .tasks import TASK_FUNCTIONS
+        from .tasks import TASK_FUNCTIONS, TASK_LOCKS
 
         # Validate task function exists
         if task.function_name not in TASK_FUNCTIONS:
@@ -107,14 +107,15 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
         log_task_execution(task.function_name, "start", f"Starting {task.function_name} task")
         log_task_execution(task.name, "running", f"Executing function: {task.function_name}")
 
-        # Execute the actual task function, forwarding execution_id so inner
-        # tasks (e.g. collect_daily_metrics) can link their collections back to
-        # this TaskExecution record.
+        # Execute the actual task function, with advisory lock if required
+        # Forwarding execution_id the task can link collections back to TaskExecution
         task_function = TASK_FUNCTIONS[task.function_name]
-        task_kwargs = {**task.task_data}
-        if execution_id:
-            task_kwargs["execution_id"] = execution_id
-        result = task_function(**task_kwargs)
+        if task.function_name in TASK_LOCKS:
+            result = run_with_lock(
+                task.function_name, task.name, task_function, execution_id=execution.id, **task.task_data
+            )
+        else:
+            result = task_function(execution_id=execution.id, **task.task_data)
 
         # Complete task execution
         status = "completed" if result.get("status") == "success" else "failed"
@@ -187,7 +188,7 @@ def submit_task_to_dispatcher(task: Any) -> None:
         task.status = "failed"
         task.error_message = f"Failed to submit to dispatcher: {str(e)}"
         task.save()
-        # FIXME
+        # FIXME: no execution here, move inside execute_db_task
         # Also mark the TaskExecution row as failed so it doesn't stay pending
         # forever. Guard with try/except in case the create() call itself failed
         # and `execution` was never bound.

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -6,13 +6,13 @@ communication, and testing tasks with proper error handling and status tracking.
 """
 
 import logging
-import os
 from typing import Any
+
+from django.db import models
 
 from .utils import (
     create_task_result,
     ensure_django_setup,
-    get_task_and_execution,
     handle_task_error,
     log_task_execution,
     update_task_status,
@@ -33,10 +33,34 @@ except ImportError:
         return decorator
 
 
-# FIXME: is this really a task, or more like a task runner .. used by submit_task_to_dispatcher
-# ... doesn't that mean that this is the ONLY task? apart from periodic sync? .. or what other submit_task bare
+def _claim_task(task_id):
+    """Atomically claim a task for execution, returning (task, execution) or None if already claimed."""
+    import os
+
+    from django.utils import timezone
+
+    from .models import Task, TaskExecution
+
+    claimed = Task.objects.filter(id=task_id, status="pending").update(
+        status="running",
+        started_at=timezone.now(),
+        attempts=models.F("attempts") + 1,
+    )
+    if not claimed:
+        return None
+
+    task = Task.objects.get(id=task_id)
+
+    execution = TaskExecution.objects.create(
+        task=task,
+        status="running",
+        worker_id=f"dispatcher-{os.getpid()}",
+    )
+
+    return task, execution
 
 
+# This is the sole dispatcherd entry point — all DB tasks are routed through it.
 @task(queue="metrics_tasks", decorate=False)
 def execute_db_task(**kwargs) -> dict[str, Any]:
     """
@@ -49,23 +73,27 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
     Args:
         **kwargs: Task data containing:
             - task_id (int): ID of the task to execute (required)
-            - execution_id (int): ID of the execution record (optional)
 
     Returns:
         dict: Task result dictionary with execution status and results
     """
     ensure_django_setup()
-    log_task_execution("execute_db_task", "start", "Starting database task execution")
 
     task_id = kwargs.get("task_id")
     if not task_id:
         return create_task_result("error", error="task_id is required")
 
-    execution_id = kwargs.get("execution_id")
-
     try:
-        # Get task and execution objects
-        task, execution = get_task_and_execution(task_id, execution_id)
+        from .models import Task
+
+        result = _claim_task(task_id)
+        if result is None:
+            if not Task.objects.filter(id=task_id).exists():
+                return create_task_result("error", error=f"Task matching query does not exist: {task_id}")
+            logger.warning(f"Task {task_id} already claimed by another worker, skipping")
+            return create_task_result("error", error="Task already claimed by another worker")
+
+        task, execution = result
 
         # Import TASK_FUNCTIONS here to avoid circular import
         # This import happens at runtime, not module load time
@@ -76,8 +104,7 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
             error_msg = f"Task function '{task.function_name}' not found in TASK_FUNCTIONS"
             return handle_task_error(task, execution, error_msg)
 
-        # Start task execution
-        update_task_status(task, execution, status="running")
+        log_task_execution(task.function_name, "start", f"Starting {task.function_name} task")
         log_task_execution(task.name, "running", f"Executing function: {task.function_name}")
 
         # Execute the actual task function, forwarding execution_id so inner
@@ -95,6 +122,11 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
 
         update_task_status(task, execution, status=status, result_data=result, error_message=error_message)
 
+        if status == "completed":
+            log_task_execution(task.function_name, "complete", f"Task {task.function_name} completed successfully")
+        else:
+            error_msg = f"{task.function_name} task failed: {error_message}"
+            log_task_execution(task.function_name, "error", error_msg, level="error")
         log_task_execution(task.name, "completed", f"Task execution finished with status: {status}")
 
         # Auto-retry if the task failed and has attempts remaining
@@ -107,7 +139,7 @@ def execute_db_task(**kwargs) -> dict[str, Any]:
         return result
 
     except Exception as e:
-        return handle_task_error(None, None, task_id=task_id, execution_id=execution_id, exception=e)
+        return handle_task_error(None, None, task_id=task_id, exception=e)
 
 
 def submit_task_to_dispatcher(task: Any) -> None:
@@ -120,7 +152,10 @@ def submit_task_to_dispatcher(task: Any) -> None:
     from .models import TaskExecution
 
     try:
-        execution = TaskExecution.objects.create(task=task, status="pending", worker_id=f"dispatcher-{os.getpid()}")
+        # Guard against duplicate submissions
+        if TaskExecution.objects.filter(task=task, status__in=["pending", "running"]).exists():
+            logger.warning(f"Task {task.name} (ID: {task.id}) already has a pending or running execution, skipping")
+            return
 
         # Ensure dispatcherd is configured before attempting to submit tasks
         from .dispatcherd_config import ensure_dispatcherd_configured
@@ -136,7 +171,8 @@ def submit_task_to_dispatcher(task: Any) -> None:
         queue = get_queue_for_function(task.function_name)
 
         # Submit to dispatcherd using execute_db_task as the entry point
-        submit_task(execute_db_task, kwargs={"task_id": task.id, "execution_id": execution.id}, queue=queue)
+        # TaskExecution is created inside _claim_task to avoid orphaned records
+        submit_task(execute_db_task, kwargs={"task_id": task.id}, queue=queue)
 
         # Update task status to indicate it's been submitted
         task.status = "pending"
@@ -149,6 +185,7 @@ def submit_task_to_dispatcher(task: Any) -> None:
         task.status = "failed"
         task.error_message = f"Failed to submit to dispatcher: {str(e)}"
         task.save()
+        # FIXME
         # Also mark the TaskExecution row as failed so it doesn't stay pending
         # forever. Guard with try/except in case the create() call itself failed
         # and `execution` was never bound.

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -220,11 +220,8 @@ def _create_task_from_group(task_id: str, config: dict[str, Any], results: dict[
         results: Results dict to update
         task_model: Task model class
     """
-    # FIXME: feature_flag .. update
-    # Prepare task data including feature flag for runtime checking
     task_data = config.get("args", {}).copy()
     if config.get("feature_flag"):
-        # FIXME: no, unless users can edit feature flags by posting args .. separate field from task_data? or the task just looks itself up?
         task_data["_feature_flag"] = config["feature_flag"]
 
     new_task = task_model.objects.create(

--- a/apps/tasks/tests/test_feature_flag_runtime_check.py
+++ b/apps/tasks/tests/test_feature_flag_runtime_check.py
@@ -1,8 +1,8 @@
 """
 Tests for runtime feature flag checking in task scheduler.
 
-The implementation reads _feature_flag from task.task_data (live DB) at execution time,
-then routes through _execute_database_task. All DB access is mocked here so these tests
+The implementation reads _feature_flag from task.task_data (live DB) at execution time
+in _execute_database_task. All DB access is mocked here so these tests
 do not require @pytest.mark.django_db.
 """
 
@@ -13,11 +13,19 @@ import pytest
 from apps.tasks.cron_scheduler import UnifiedTaskScheduler
 
 
-def _make_mock_task(task_id=42, task_data=None):
+def _make_mock_task(task_id=42, task_data=None, status="pending", cron_expression="0 * * * *"):
     """Return a MagicMock resembling a Task DB object."""
     mock_task = MagicMock()
     mock_task.id = task_id
+    mock_task.name = f"test_task_{task_id}"
     mock_task.task_data = task_data if task_data is not None else {}
+    mock_task.status = status
+    mock_task.cron_expression = cron_expression
+    mock_task.function_name = "hello_world"
+    mock_task.max_attempts = 3
+    mock_task.timeout_seconds = 3600
+    mock_task.created_by = None
+    mock_task.is_system_task = True
     return mock_task
 
 
@@ -25,62 +33,55 @@ def _make_mock_task(task_id=42, task_data=None):
 class TestFeatureFlagRuntimeCheck:
     """Test runtime feature flag checking for task execution.
 
-    _execute_scheduled_task reads _feature_flag from the live DB task record so that
+    _execute_database_task reads _feature_flag from the live DB task record so that
     toggling the flag takes effect immediately without restarting the scheduler or
     re-running init-system-tasks.
     """
 
-    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
     @patch("apps.tasks.models.Task")
-    def test_task_executes_when_feature_flag_enabled(self, mock_task_cls, mock_get_feature, mock_execute_db):
-        """Task is routed to _execute_database_task when its feature flag is enabled."""
+    def test_task_executes_when_feature_flag_enabled(self, mock_task_cls, mock_get_feature, mock_submit):
+        """Task is submitted when its feature flag is enabled."""
         mock_get_feature.return_value = True
-        mock_task_cls.objects.filter.return_value.first.return_value = _make_mock_task(
-            task_id=1, task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
-        )
+        mock_task = _make_mock_task(task_id=1, task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"})
+        mock_task_cls.objects.get.return_value = mock_task
+        mock_task_cls.objects.create.return_value = MagicMock(id=100, name="execution_copy")
 
         scheduler = UnifiedTaskScheduler()
-        scheduler._execute_scheduled_task(
-            task_id="test_task",
-            function_name="hello_world",
-            args={},
-        )
+        scheduler._execute_database_task(1)
 
         mock_get_feature.assert_called_once_with("ANONYMIZED_DATA_COLLECTION")
-        mock_execute_db.assert_called_once_with(1)
+        mock_submit.assert_called_once()
 
-    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
     @patch("apps.tasks.models.Task")
-    def test_task_skips_when_feature_flag_disabled(self, mock_task_cls, mock_get_feature, mock_execute_db):
+    def test_task_skips_when_feature_flag_disabled(self, mock_task_cls, mock_get_feature, mock_submit):
         """Task is NOT dispatched when its feature flag is disabled in the DB."""
         mock_get_feature.return_value = False
-        mock_task_cls.objects.filter.return_value.first.return_value = _make_mock_task(
+        mock_task_cls.objects.get.return_value = _make_mock_task(
             task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
         )
 
         scheduler = UnifiedTaskScheduler()
-        scheduler._execute_scheduled_task(
-            task_id="test_task",
-            function_name="hello_world",
-            args={},
-        )
+        scheduler._execute_database_task(42)
 
         mock_get_feature.assert_called_once_with("ANONYMIZED_DATA_COLLECTION")
-        mock_execute_db.assert_not_called()
+        mock_submit.assert_not_called()
 
-    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
     @patch("apps.tasks.models.Task")
-    def test_task_executes_when_no_feature_flag(self, mock_task_cls, mock_execute_db):
+    def test_task_executes_when_no_feature_flag(self, mock_task_cls, mock_submit):
         """Task executes without a feature flag check when task_data has no _feature_flag."""
         mock_task = _make_mock_task(task_id=5, task_data={})
-        mock_task_cls.objects.filter.return_value.first.return_value = mock_task
+        mock_task_cls.objects.get.return_value = mock_task
+        mock_task_cls.objects.create.return_value = MagicMock(id=100, name="execution_copy")
 
         scheduler = UnifiedTaskScheduler()
-        scheduler._execute_scheduled_task(task_id="test_task", function_name="hello_world", args={})
+        scheduler._execute_database_task(5)
 
-        mock_execute_db.assert_called_once_with(5)
+        mock_submit.assert_called_once()
 
     def test_get_all_enabled_tasks_includes_feature_flag(self):
         """get_all_enabled_tasks propagates the group's feature_flag into each task config."""
@@ -94,41 +95,38 @@ class TestFeatureFlagRuntimeCheck:
                 assert "feature_flag" in all_tasks[task_id]
                 assert all_tasks[task_id]["feature_flag"] == "ANONYMIZED_DATA_COLLECTION"
 
-    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
     @patch("apps.tasks.models.Task")
-    def test_feature_flag_checked_at_execution_time(self, mock_task_cls, mock_get_feature, mock_execute_db):
+    def test_feature_flag_checked_at_execution_time(self, mock_task_cls, mock_get_feature, mock_submit):
         """Flag is re-read from DB on each fire so runtime changes take effect immediately."""
-        mock_task_cls.objects.filter.return_value.first.return_value = _make_mock_task(
-            task_id=10, task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
-        )
+        mock_task = _make_mock_task(task_id=10, task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"})
+        mock_task_cls.objects.get.return_value = mock_task
+        mock_task_cls.objects.create.return_value = MagicMock(id=100, name="execution_copy")
+
         scheduler = UnifiedTaskScheduler()
 
         # First fire — flag enabled
         mock_get_feature.return_value = True
-        scheduler._execute_scheduled_task(task_id="test_task", function_name="hello_world", args={})
-        assert mock_execute_db.call_count == 1
+        scheduler._execute_database_task(10)
+        assert mock_submit.call_count == 1
 
         # Second fire — flag disabled at runtime, no restart needed
         mock_get_feature.return_value = False
-        scheduler._execute_scheduled_task(task_id="test_task", function_name="hello_world", args={})
-        assert mock_execute_db.call_count == 1  # Not incremented
+        scheduler._execute_database_task(10)
+        assert mock_submit.call_count == 1  # Not incremented
 
-    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
     @patch("apps.tasks.models.Task")
-    def test_feature_flag_error_prevents_execution(self, mock_task_cls, mock_get_feature, mock_execute_db):
+    def test_feature_flag_error_prevents_execution(self, mock_task_cls, mock_get_feature, mock_submit):
         """Errors reading the feature flag are caught by the outer try/except; task is not dispatched."""
         mock_get_feature.side_effect = Exception("Database error")
-        mock_task_cls.objects.filter.return_value.first.return_value = _make_mock_task(
+        mock_task_cls.objects.get.return_value = _make_mock_task(
             task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
         )
 
         scheduler = UnifiedTaskScheduler()
-        scheduler._execute_scheduled_task(
-            task_id="test_task",
-            function_name="hello_world",
-            args={},
-        )
+        scheduler._execute_database_task(42)
 
-        mock_execute_db.assert_not_called()
+        mock_submit.assert_not_called()

--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -109,7 +109,7 @@ def handle_task_error(
     except Exception as save_error:
         logger.error(f"Failed to update task status after error: {save_error}")
 
-    return {"status": "error", "error": error_message}
+    return create_task_result("error", error=error_message)
 
 
 def update_task_status(
@@ -352,7 +352,7 @@ def generic_collect_metrics(
 
     if collector_type not in collector_registry:
         valid = ", ".join(sorted(collector_registry.keys()))
-        raise ValueError(f"Unknown collector_type: {collector_type}. Valid types: {valid}")
+        return create_task_result("error", error=f"Unknown collector_type: {collector_type}. Valid types: {valid}")
 
     config = collector_registry[collector_type]
     log_task_execution(f"collect_{collector_type}", "processing", f"Collecting {collector_type} ({collection_mode})")

--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -2,7 +2,6 @@
 Utility functions for task management and execution.
 """
 
-import functools
 import logging
 from datetime import UTC
 from typing import Any
@@ -29,54 +28,6 @@ def ensure_django_setup():
 
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "metrics_service.settings")
         django.setup()
-
-
-def task_execution_wrapper(task_name: str):
-    """
-    Decorator to handle common task execution patterns.
-
-    This decorator:
-    - Ensures Django setup
-    - Logs task start and completion
-    - Handles exceptions with proper error responses
-    - Returns standardized task results
-
-    Args:
-        task_name: Name of the task for logging
-    """
-
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(**kwargs):
-            ensure_django_setup()
-            log_task_execution(task_name, "start", f"Starting {task_name} task")
-
-            try:
-                result = func(**kwargs)
-                log_task_execution(task_name, "complete", f"Task {task_name} completed successfully")
-                return result
-            except Exception as e:
-                error_msg = f"{task_name} task failed: {str(e)}"
-                log_task_execution(task_name, "error", error_msg, level="error")
-                return create_task_result("error", error=error_msg)
-
-        return wrapper
-
-    return decorator
-
-
-def get_task_and_execution(task_id: int, execution_id: int | None) -> tuple[Any, Any]:
-    """Get task and execution objects with proper locking."""
-    from .models import Task, TaskExecution
-
-    with transaction.atomic():
-        task = Task.objects.get(id=task_id)
-        execution = None
-
-        if execution_id:
-            execution = TaskExecution.objects.get(id=execution_id)
-
-    return task, execution
 
 
 def handle_task_error(
@@ -276,28 +227,6 @@ def log_task_execution(task_name: str, operation: str, details: str = "", level:
 
     log_func = getattr(logger, level.lower(), logger.info)
     log_func(message)
-
-
-# =============================================================================
-# Dispatcherd Task Decorator
-# =============================================================================
-
-try:
-    from dispatcherd.publish import task
-except ImportError:
-
-    def task():
-        """Fallback task decorator when dispatcherd is not available."""
-
-        def decorator(func):
-            return func
-
-        return decorator
-
-
-# =============================================================================
-# Database and Data Utilities
-# =============================================================================
 
 
 def parse_datetime_string(date_str: str | None) -> Any:

--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -285,6 +285,31 @@ def get_db_connection(db_name: str = "awx"):
     return django_connection.connection
 
 
+def run_with_lock(lock_key: str, task_name: str, fn, **kwargs):
+    """
+    Execute a task function under a PostgreSQL advisory lock.
+
+    If the lock cannot be acquired (another instance of the same task is running),
+    returns an error result which triggers auto-retry.
+
+    Args:
+        lock_key: Unique key for the advisory lock
+        task_name: Task name for logging
+        fn: Task function to execute
+        **kwargs: Arguments to pass to fn
+    """
+    from django.db import connection
+    from metrics_utility.library.lock import lock
+
+    with lock(lock_key, wait=False, db=connection) as acquired:
+        if not acquired:
+            msg = f"Could not acquire lock '{lock_key}' — another {task_name} instance is running"
+            logger.warning(msg)
+            log_task_execution(task_name, "skipped", msg)
+            return create_task_result("error", error=msg)
+        return fn(**kwargs)
+
+
 def generate_salt() -> str:
     """
     Generate a unique UUID4 salt for anonymization.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -31,33 +31,18 @@ class BaseTaskSchedulerTest(unittest.TestCase):
 
     def test_task_scheduler_init(self):
         """Test UnifiedTaskScheduler initialization."""
-        from unittest.mock import Mock
-
         from apps.tasks.cron_scheduler import UnifiedTaskScheduler
 
-        with patch("apps.tasks.models.Task") as mock_task_model:
-            # Mock empty database
-            mock_queryset = Mock()
-            mock_queryset.exclude.return_value = []
-            mock_task_model.objects.filter.return_value = mock_queryset
-
-            scheduler = UnifiedTaskScheduler(check_interval=30)
+        scheduler = UnifiedTaskScheduler(check_interval=30)
         self.assertEqual(scheduler.check_interval, 30)
         self.assertFalse(scheduler.running)
 
     def test_task_scheduler_stop(self):
         """Test UnifiedTaskScheduler stop method."""
-        from unittest.mock import Mock, patch
 
         from apps.tasks.cron_scheduler import UnifiedTaskScheduler
 
-        with patch("apps.tasks.models.Task") as mock_task_model:
-            # Mock empty database
-            mock_queryset = Mock()
-            mock_queryset.exclude.return_value = []
-            mock_task_model.objects.filter.return_value = mock_queryset
-
-            scheduler = UnifiedTaskScheduler()
+        scheduler = UnifiedTaskScheduler()
         scheduler.running = True
         with patch.object(scheduler.scheduler, "shutdown"):
             scheduler.stop()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -17,7 +17,6 @@ class BaseTaskFunctionsTest(unittest.TestCase):
         from apps.tasks.tasks import TASK_FUNCTIONS
 
         expected_functions = [
-            "execute_db_task",
             "hello_world",
             "cleanup_old_tasks",
         ]

--- a/tests/unit/core/test_core_models.py
+++ b/tests/unit/core/test_core_models.py
@@ -113,7 +113,7 @@ class TaskModelTestCase(TestCase):
         self.assertTrue(self.task.can_retry())
 
         # Failed task with attempts >= max_attempts cannot be retried
-        self.task.attempts = 3
+        self.task.attempts = 5
         self.task.save()
         self.assertFalse(self.task.can_retry())
 

--- a/tests/unit/dashboard/test_dashboard_views.py
+++ b/tests/unit/dashboard/test_dashboard_views.py
@@ -74,8 +74,7 @@ class TestDashboardViews(TestCase):
         # Mock TASK_FUNCTIONS
         mock_task_functions.keys.return_value = [
             "hello_world",
-            "execute_db_task",
-            "hello_world",
+            "cleanup_old_tasks",
         ]
 
         # Mock render to return a mock response
@@ -104,8 +103,7 @@ class TestDashboardViews(TestCase):
         assert context["user"] == self.user
         assert context["available_functions"] == [
             "hello_world",
-            "execute_db_task",
-            "hello_world",
+            "cleanup_old_tasks",
         ]
         assert context["database_driven"] is True
 

--- a/tests/unit/tasks/collectors/test_collect_daily_metrics.py
+++ b/tests/unit/tasks/collectors/test_collect_daily_metrics.py
@@ -320,33 +320,29 @@ class TestCollectDailyMetrics:
     @patch("apps.tasks.collectors.collect_daily_metrics.generic_collect_metrics")
     @patch("apps.tasks.collectors.collect_daily_metrics.get_db_connection")
     @patch("apps.tasks.collectors.collect_daily_metrics._get_daily_collectors")
-    def test_returns_error_dict_when_generic_raises(self, mock_registry, mock_get_db, mock_generic):
-        """When generic_collect_metrics raises, the wrapper returns an error dict."""
+    def test_raises_when_generic_raises(self, mock_registry, mock_get_db, mock_generic):
+        """When generic_collect_metrics raises, the exception propagates."""
         mock_registry.return_value = {"task_executions_service": {}}
         mock_get_db.return_value = MagicMock()
         mock_generic.side_effect = RuntimeError("upstream failure")
 
         from apps.tasks.collectors.collect_daily_metrics import collect_daily_metrics
 
-        result = collect_daily_metrics(collector_type="task_executions_service")
-
-        assert result["status"] == "error"
-        assert "upstream failure" in result["error"]
+        with pytest.raises(RuntimeError, match="upstream failure"):
+            collect_daily_metrics(collector_type="task_executions_service")
 
     @patch("apps.tasks.collectors.collect_daily_metrics.generic_collect_metrics")
     @patch("apps.tasks.collectors.collect_daily_metrics.get_db_connection")
     @patch("apps.tasks.collectors.collect_daily_metrics._get_daily_collectors")
-    def test_returns_error_dict_when_db_connection_raises(self, mock_registry, mock_get_db, mock_generic):
-        """When get_db_connection raises, the wrapper returns an error dict."""
+    def test_raises_when_db_connection_raises(self, mock_registry, mock_get_db, mock_generic):
+        """When get_db_connection raises, the exception propagates."""
         mock_registry.return_value = {"task_executions_service": {}}
         mock_get_db.side_effect = Exception("DB unavailable")
 
         from apps.tasks.collectors.collect_daily_metrics import collect_daily_metrics
 
-        result = collect_daily_metrics(collector_type="task_executions_service")
-
-        assert result["status"] == "error"
-        assert "DB unavailable" in result["error"]
+        with pytest.raises(Exception, match="DB unavailable"):
+            collect_daily_metrics(collector_type="task_executions_service")
         mock_generic.assert_not_called()
 
     # ------------------------------------------------------------------

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -2,7 +2,6 @@
 Enhanced unit tests for cron_scheduler.py to improve coverage.
 
 Tests cover:
-- Feature flag checking in _execute_scheduled_task
 - _periodic_database_sync task discovery and routing
 - Error handling in _add_database_scheduled_task
 - Error handling in _add_database_recurring_task
@@ -16,95 +15,6 @@ import pytest
 from django.utils import timezone
 
 from apps.tasks.cron_scheduler import UnifiedTaskScheduler, _inject_dispatch_timestamps
-
-
-@pytest.mark.unit
-@pytest.mark.django_db
-class TestExecuteScheduledTaskFeatureFlags:
-    """Test feature flag checking in _execute_scheduled_task.
-
-    The implementation reads _feature_flag from task.task_data (live DB) at runtime,
-    then routes through _execute_database_task. All DB access is mocked here.
-    """
-
-    def _make_mock_task(self, task_id=42, task_data=None):
-        """Return a MagicMock that looks like a Task with the given task_data."""
-        mock_task = MagicMock()
-        mock_task.id = task_id
-        mock_task.task_data = task_data if task_data is not None else {}
-        return mock_task
-
-    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
-    @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
-    @patch("apps.tasks.models.Task")
-    def test_skips_task_when_feature_flag_disabled(self, mock_task_cls, mock_get_feature_enabled, mock_execute_db):
-        """Task is skipped when its feature flag is disabled in the DB."""
-        scheduler = UnifiedTaskScheduler()
-        mock_get_feature_enabled.return_value = False
-        mock_task_cls.objects.filter.return_value.first.return_value = self._make_mock_task(
-            task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
-        )
-
-        scheduler._execute_scheduled_task("test_task", "hello_world", {})
-
-        mock_get_feature_enabled.assert_called_once_with("ANONYMIZED_DATA_COLLECTION")
-        mock_execute_db.assert_not_called()
-
-    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
-    @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
-    @patch("apps.tasks.models.Task")
-    def test_executes_task_when_feature_flag_enabled(self, mock_task_cls, mock_get_feature_enabled, mock_execute_db):
-        """Task proceeds to _execute_database_task when its feature flag is enabled."""
-        scheduler = UnifiedTaskScheduler()
-        mock_get_feature_enabled.return_value = True
-        mock_task = self._make_mock_task(task_id=42, task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"})
-        mock_task_cls.objects.filter.return_value.first.return_value = mock_task
-
-        scheduler._execute_scheduled_task("test_task", "hello_world", {})
-
-        mock_get_feature_enabled.assert_called_once_with("ANONYMIZED_DATA_COLLECTION")
-        mock_execute_db.assert_called_once_with(42)
-
-    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
-    @patch("apps.tasks.models.Task")
-    def test_executes_task_when_no_feature_flag(self, mock_task_cls, mock_execute_db):
-        """Task proceeds without a feature flag check when task_data has no _feature_flag."""
-        scheduler = UnifiedTaskScheduler()
-        mock_task = self._make_mock_task(task_id=7, task_data={})
-        mock_task_cls.objects.filter.return_value.first.return_value = mock_task
-
-        scheduler._execute_scheduled_task("test_task", "hello_world", {})
-
-        mock_execute_db.assert_called_once_with(7)
-
-    @patch.object(UnifiedTaskScheduler, "_execute_database_task")
-    @patch("apps.tasks.models.Task")
-    def test_logs_error_when_task_not_in_db(self, mock_task_cls, mock_execute_db):
-        """Logs an error and skips execution when the system task is missing from DB."""
-        scheduler = UnifiedTaskScheduler()
-        mock_task_cls.objects.filter.return_value.first.return_value = None
-
-        scheduler._execute_scheduled_task("missing_task", "hello_world", {})
-
-        mock_execute_db.assert_not_called()
-
-    @patch("apps.tasks.cron_scheduler.close_old_connections")
-    @patch("apps.tasks.models.Task")
-    def test_closes_old_connections_before_querying(self, mock_task_cls, mock_close):
-        """close_old_connections must be called before any ORM access in _execute_scheduled_task."""
-        # Instantiate first so _load_task_registry()'s Task.objects.filter() call in __init__
-        # does not pollute the call_order we install below.
-        scheduler = UnifiedTaskScheduler()
-
-        call_order = []
-        mock_close.side_effect = lambda: call_order.append("close")
-        mock_task_cls.objects.filter.side_effect = lambda **_: (
-            call_order.append("query") or MagicMock(first=lambda: None)
-        )
-
-        scheduler._execute_scheduled_task("missing_task", "hello_world", {})
-
-        assert call_order[0] == "close", f"Expected close_old_connections first, got: {call_order}"
 
 
 @pytest.mark.unit
@@ -359,7 +269,9 @@ class TestExecuteDatabaseTaskErrors:
 
         mock_task = MagicMock()
         mock_task.id = 1
+        mock_task.name = "test_task"
         mock_task.status = "running"
+        mock_task.task_data = {}
         mock_task.cron_expression = None
         mock_task_model.objects.get.return_value = mock_task
 

--- a/tests/unit/tasks/test_dispatcherd_config.py
+++ b/tests/unit/tasks/test_dispatcherd_config.py
@@ -484,7 +484,6 @@ class TestGetQueueForFunction:
     def test_returns_correct_queue_for_general_tasks(self):
         """Test that general tasks are routed to metrics_tasks queue."""
         assert get_queue_for_function("hello_world") == "metrics_tasks"
-        assert get_queue_for_function("execute_db_task") == "metrics_tasks"
 
     def test_returns_default_queue_for_unknown_function(self):
         """Test that unknown functions are routed to default metrics_tasks queue."""
@@ -498,7 +497,6 @@ class TestGetQueueForFunction:
         function_queue_map = {
             # System/general tasks
             "hello_world": "metrics_tasks",
-            "execute_db_task": "metrics_tasks",
             # Cleanup tasks
             "cleanup_old_tasks": "metrics_cleanup",
             "cleanup_metrics_data": "metrics_cleanup",

--- a/tests/unit/tasks/test_models.py
+++ b/tests/unit/tasks/test_models.py
@@ -82,6 +82,26 @@ class TestTaskModel:
 
         assert task.can_retry() is False
 
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
+    def test_retry_with_delay_sets_scheduled_time(self, mock_submit):
+        """Test retry(delay_seconds=...) sets scheduled_time in the future."""
+        task = Task.objects.create(
+            name="Delayed Retry Task",
+            function_name="hello_world",
+            status="failed",
+            attempts=1,
+            max_attempts=3,
+        )
+
+        before = timezone.now()
+        result = task.retry(delay_seconds=120)
+
+        assert result is True
+        task.refresh_from_db()
+        assert task.status == "pending"
+        assert task.scheduled_time is not None
+        assert task.scheduled_time >= before + timedelta(seconds=119)
+
     def test_can_delete_regular_task(self):
         """Test can_delete returns True for regular tasks"""
         task = Task.objects.create(name="Regular Task", function_name="test_func", is_system_task=False)

--- a/tests/unit/tasks/test_models_enhanced.py
+++ b/tests/unit/tasks/test_models_enhanced.py
@@ -56,8 +56,8 @@ class TestTaskRetry:
         assert task.attempts == 1  # Attempts NOT reset
         mock_submit.assert_called_once_with(task)
 
-    def test_retry_skips_scheduled_task(self, user):
-        """Test retry doesn't submit scheduled task (lines 174-178)."""
+    def test_retry_clears_scheduled_time_and_submits(self, user):
+        """Test retry without delay clears scheduled_time and submits immediately."""
         # Arrange
         future_time = timezone.now() + timedelta(hours=1)
         task = Task.objects.create(
@@ -78,7 +78,8 @@ class TestTaskRetry:
         assert result is True
         task.refresh_from_db()
         assert task.status == "pending"
-        mock_submit.assert_not_called()  # Not submitted, handled by scheduler
+        assert task.scheduled_time is None
+        mock_submit.assert_called_once_with(task)
 
     def test_retry_skips_recurring_task(self, user):
         """Test retry doesn't submit recurring task (lines 174-178)."""

--- a/tests/unit/tasks/test_tasks_collector_advanced.py
+++ b/tests/unit/tasks/test_tasks_collector_advanced.py
@@ -123,22 +123,20 @@ class TestDailyRollupTask(TestCase):
     """Test daily metrics rollup task."""
 
     def test_daily_metrics_rollup_no_collections(self):
-        """Test daily rollup with no hourly collections."""
+        """Test daily rollup skips when no hourly collections exist."""
 
         summary_date = date(2024, 1, 15)
         result = daily_metrics_rollup(summary_date=summary_date.isoformat())
 
-        assert result["status"] == "success"
-        assert "summary_id" in result
-        assert result["hourly_collections_count"] == 0
+        assert result["status"] == "error"
+        assert "upstream dependency not met" in result["error"]
 
     def test_daily_metrics_rollup_default_date(self):
-        """Test daily rollup with default date (yesterday)."""
+        """Test daily rollup skips when no collections for yesterday."""
         result = daily_metrics_rollup()
 
-        assert result["status"] == "success"
-        # Should use yesterday's date
-        assert "summary_date" in result
+        assert result["status"] == "error"
+        assert "upstream dependency not met" in result["error"]
 
 
 @pytest.mark.unit

--- a/tests/unit/tasks/test_tasks_system.py
+++ b/tests/unit/tasks/test_tasks_system.py
@@ -22,9 +22,9 @@ from apps.tasks import tasks, tasks_system
 from apps.tasks.models import Task, TaskExecution
 from apps.tasks.tasks import (
     TASK_FUNCTIONS,
-    execute_db_task,
     submit_task_to_dispatcher,
 )
+from apps.tasks.tasks_system import execute_db_task
 from tests.test_utils import get_test_password
 
 User = get_user_model()
@@ -135,7 +135,6 @@ class TestTaskRegistry(TestCase):
     def test_task_functions_contains_expected_functions(self):
         """Test TASK_FUNCTIONS contains all expected task functions."""
         expected_functions = [
-            "execute_db_task",
             "hello_world",
             "cleanup_old_tasks",
         ]

--- a/tests/unit/tasks/test_tasks_system.py
+++ b/tests/unit/tasks/test_tasks_system.py
@@ -169,9 +169,9 @@ class TestExecuteDbTask(TestCase):
         assert execution.status == "failed"
         assert "Boom" in execution.error_message
 
-        # The Task itself should also be failed
+        # The Task should be auto-retried (back to pending) since max_attempts=3
         self.task.refresh_from_db()
-        assert self.task.status == "failed"
+        assert self.task.status == "pending"
 
     @pytest.mark.django_db(transaction=True)
     def test_execute_db_task_with_advisory_lock(self):
@@ -179,7 +179,7 @@ class TestExecuteDbTask(TestCase):
         self.task.function_name = "daily_metrics_rollup"
         self.task.save()
 
-        with patch("apps.tasks.utils.run_with_lock") as mock_lock:
+        with patch("apps.tasks.tasks_system.run_with_lock") as mock_lock:
             mock_lock.return_value = {"status": "success"}
             result = execute_db_task(task_id=self.task.id)
 
@@ -194,7 +194,7 @@ class TestExecuteDbTask(TestCase):
         self.task.max_attempts = 3
         self.task.save()
 
-        with patch("apps.tasks.utils.run_with_lock") as mock_lock:
+        with patch("apps.tasks.tasks_system.run_with_lock") as mock_lock:
             mock_lock.return_value = {"status": "error", "error": "Could not acquire lock"}
             result = execute_db_task(task_id=self.task.id)
 

--- a/tests/unit/tasks/test_tasks_system.py
+++ b/tests/unit/tasks/test_tasks_system.py
@@ -150,6 +150,38 @@ class TestExecuteDbTask(TestCase):
         assert "Test exception" in result["error"]
 
     @pytest.mark.django_db(transaction=True)
+    def test_execute_db_task_with_advisory_lock(self):
+        """Test that tasks in TASK_LOCKS go through run_with_lock."""
+        self.task.function_name = "daily_metrics_rollup"
+        self.task.save()
+
+        with patch("apps.tasks.utils.run_with_lock") as mock_lock:
+            mock_lock.return_value = {"status": "success"}
+            result = execute_db_task(task_id=self.task.id)
+
+        assert result["status"] == "success"
+        mock_lock.assert_called_once()
+        assert mock_lock.call_args[0][0] == "daily_metrics_rollup"
+
+    @pytest.mark.django_db(transaction=True)
+    def test_execute_db_task_contended_lock_triggers_retry(self):
+        """Test that a task which cannot acquire its advisory lock fails and is retried."""
+        self.task.function_name = "daily_metrics_rollup"
+        self.task.max_attempts = 3
+        self.task.save()
+
+        with patch("apps.tasks.utils.run_with_lock") as mock_lock:
+            mock_lock.return_value = {"status": "error", "error": "Could not acquire lock"}
+            result = execute_db_task(task_id=self.task.id)
+
+        assert result["status"] == "error"
+        assert "lock" in result["error"].lower()
+
+        self.task.refresh_from_db()
+        # Task should have been auto-retried (back to pending)
+        assert self.task.status == "pending"
+
+    @pytest.mark.django_db(transaction=True)
     def test_execute_db_task_auto_retry_with_delay(self):
         """Test auto-retry sets delay from task_data retry_delay_seconds."""
         from django.utils import timezone

--- a/tests/unit/tasks/test_tasks_system.py
+++ b/tests/unit/tasks/test_tasks_system.py
@@ -65,16 +65,48 @@ class TestExecuteDbTask(TestCase):
         assert self.task.completed_at is not None
 
     @pytest.mark.django_db(transaction=True)
-    def test_execute_db_task_with_execution_record(self):
-        """Test task execution with TaskExecution record."""
-        execution = TaskExecution.objects.create(task=self.task, status="pending")
+    def test_execute_db_task_already_claimed(self):
+        """Test that a task already claimed by another worker is skipped."""
+        self.task.status = "running"
+        self.task.save()
 
-        result = execute_db_task(task_id=self.task.id, execution_id=execution.id)
+        result = execute_db_task(task_id=self.task.id)
+
+        assert result["status"] == "error"
+        assert "already claimed" in result["error"]
+
+        # Task status should remain running (not overwritten)
+        self.task.refresh_from_db()
+        assert self.task.status == "running"
+
+    @pytest.mark.django_db(transaction=True)
+    def test_losing_claim_creates_no_execution(self):
+        """Test that a failed claim leaves no orphaned TaskExecution records.
+
+        Before the fix, submit_task_to_dispatcher created a TaskExecution eagerly,
+        and a losing claimer would leave it stuck as pending forever. Now _claim_task
+        only creates the execution on success, so a loser must produce zero records.
+        """
+        # Simulate another worker already claimed the task
+        self.task.status = "running"
+        self.task.save()
+
+        result = execute_db_task(task_id=self.task.id)
+
+        assert result["status"] == "error"
+        # No TaskExecution should have been created
+        assert TaskExecution.objects.filter(task=self.task).count() == 0
+
+    @pytest.mark.django_db(transaction=True)
+    def test_execute_db_task_creates_execution_record(self):
+        """Test that execute_db_task creates a TaskExecution record via _claim_task."""
+        result = execute_db_task(task_id=self.task.id)
 
         assert result["status"] == "success"
 
-        # Check execution record was updated
-        execution.refresh_from_db()
+        # _claim_task should have created an execution record
+        execution = TaskExecution.objects.filter(task=self.task).first()
+        assert execution is not None
         assert execution.status == "completed"
 
     def test_execute_db_task_no_task_id(self):
@@ -89,7 +121,7 @@ class TestExecuteDbTask(TestCase):
         result = execute_db_task(task_id=99999)
 
         assert result["status"] == "error"
-        assert "Task execution failed: Task matching query does not exist" in result["error"]
+        assert "Task matching query does not exist" in result["error"]
 
     def test_execute_db_task_function_not_found(self):
         """Test execute_db_task with unknown function name."""
@@ -144,14 +176,14 @@ class TestTaskRegistry(TestCase):
             assert callable(TASK_FUNCTIONS[func_name]), f"{func_name} is not callable"
 
     def test_task_function_signatures(self):
-        """Test task functions accept keyword arguments and return dicts."""
-        for _func_name, func in TASK_FUNCTIONS.items():
-            try:
-                result = func()
-                assert isinstance(result, dict), f"{func.__name__} didn't return a dict"
-                assert "status" in result, f"{func.__name__} result missing 'status' key"
-            except Exception as e:
-                pytest.fail(f"Function {func.__name__} raised exception: {e}")
+        """Test task functions accept keyword arguments."""
+        import inspect
+
+        for func_name, func in TASK_FUNCTIONS.items():
+            sig = inspect.signature(func)
+            # Every task function must accept **kwargs
+            has_var_keyword = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+            assert has_var_keyword, f"{func_name} does not accept **kwargs"
 
 
 # =============================================================================
@@ -214,10 +246,10 @@ class TestTaskDispatcher(TestCase):
         self.task = Task(name="Submit Task", function_name="hello_world", created_by=self.user)
         self.task.save()
 
-    @patch("apps.tasks.models.TaskExecution.objects.create")
-    def test_submit_task_to_dispatcher_handles_exception(self, mock_create):
+    @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")
+    def test_submit_task_to_dispatcher_handles_exception(self, mock_ensure_config):
         """Test submit_task_to_dispatcher handles exceptions gracefully."""
-        mock_create.side_effect = Exception("Database error")
+        mock_ensure_config.side_effect = Exception("Connection error")
 
         submit_task_to_dispatcher(self.task)
 
@@ -225,6 +257,24 @@ class TestTaskDispatcher(TestCase):
         self.task.refresh_from_db()
         assert self.task.status == "failed"
         assert "Failed to submit to dispatcher" in self.task.error_message
+
+    @patch("dispatcherd.publish.submit_task")
+    @patch("apps.tasks.dispatcherd_config.ensure_dispatcherd_configured")
+    @patch("apps.tasks.dispatcherd_config.get_queue_for_function")
+    def test_submit_skips_when_active_execution_exists(self, mock_get_queue, mock_ensure_config, mock_submit):
+        """Test that submit_task_to_dispatcher is a no-op when a pending/running execution exists."""
+        # Create an existing pending execution
+        from apps.tasks.models import TaskExecution
+
+        TaskExecution.objects.create(task=self.task, status="pending", worker_id="other-worker")
+
+        submit_task_to_dispatcher(self.task)
+
+        # Should not have submitted anything
+        mock_submit.assert_not_called()
+
+        # Should still have only the one execution
+        assert TaskExecution.objects.filter(task=self.task).count() == 1
 
     def test_dispatcherd_decorator_functionality(self):
         """Test dispatcherd decorator is properly configured."""
@@ -667,12 +717,11 @@ class TestSubmitTaskToDispatcherSuccess(TestCase):
         mock_submit.assert_called_once()
         call_kwargs = mock_submit.call_args.kwargs
         assert call_kwargs["kwargs"]["task_id"] == task.id
+        assert "execution_id" not in call_kwargs["kwargs"]
         assert call_kwargs["queue"] == "metrics_tasks"
 
-        # Verify execution_id is passed so execute_db_task can update the record
-        execution = TaskExecution.objects.filter(task=task).first()
-        assert execution is not None
-        assert call_kwargs["kwargs"]["execution_id"] == execution.id
+        # TaskExecution is no longer created here — _claim_task creates it
+        assert TaskExecution.objects.filter(task=task).count() == 0
 
         # Verify task status updated
         task.refresh_from_db()

--- a/tests/unit/tasks/test_tasks_system.py
+++ b/tests/unit/tasks/test_tasks_system.py
@@ -137,6 +137,7 @@ class TestExecuteDbTask(TestCase):
         self.task.refresh_from_db()
         assert self.task.status == "failed"
 
+    @pytest.mark.django_db(transaction=True)
     @patch("apps.tasks.tasks.TASK_FUNCTIONS")
     def test_execute_db_task_function_exception(self, mock_task_functions):
         """Test execute_db_task when task function raises exception."""
@@ -148,6 +149,29 @@ class TestExecuteDbTask(TestCase):
 
         assert result["status"] == "error"
         assert "Test exception" in result["error"]
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("apps.tasks.tasks.TASK_FUNCTIONS")
+    def test_execute_db_task_exception_marks_execution_failed(self, mock_task_functions):
+        """Test that an exception after _claim_task marks the TaskExecution as failed.
+
+        Before the fix, the except block passed None for both task and execution,
+        leaving the TaskExecution stuck in "running" status forever.
+        """
+        mock_function = Mock(side_effect=Exception("Boom"))
+        mock_task_functions.__getitem__.return_value = mock_function
+        mock_task_functions.__contains__.return_value = True
+
+        execute_db_task(task_id=self.task.id)
+
+        # The TaskExecution created by _claim_task must be marked as failed
+        execution = TaskExecution.objects.get(task=self.task)
+        assert execution.status == "failed"
+        assert "Boom" in execution.error_message
+
+        # The Task itself should also be failed
+        self.task.refresh_from_db()
+        assert self.task.status == "failed"
 
     @pytest.mark.django_db(transaction=True)
     def test_execute_db_task_with_advisory_lock(self):

--- a/tests/unit/tasks/test_tasks_system.py
+++ b/tests/unit/tasks/test_tasks_system.py
@@ -149,6 +149,32 @@ class TestExecuteDbTask(TestCase):
         assert result["status"] == "error"
         assert "Test exception" in result["error"]
 
+    @pytest.mark.django_db(transaction=True)
+    def test_execute_db_task_auto_retry_with_delay(self):
+        """Test auto-retry sets delay from task_data retry_delay_seconds."""
+        from django.utils import timezone
+
+        self.task.function_name = "hello_world"
+        self.task.max_attempts = 3
+        self.task.task_data = {"retry_delay_seconds": 120}
+        self.task.save()
+
+        before = timezone.now()
+
+        with patch("apps.tasks.tasks.TASK_FUNCTIONS") as mock_fns:
+            mock_fns.__contains__.return_value = True
+            mock_fns.__getitem__.return_value = Mock(return_value={"status": "error", "error": "fail"})
+            result = execute_db_task(task_id=self.task.id)
+
+        assert result["status"] == "error"
+        self.task.refresh_from_db()
+        # Task should have been retried with delay
+        assert self.task.status == "pending"
+        assert self.task.scheduled_time is not None
+        # scheduled_time should be ~120s after the retry call
+        delta = (self.task.scheduled_time - before).total_seconds()
+        assert 118 <= delta <= 125, f"Expected scheduled_time ~120s in the future, got {delta:.1f}s"
+
 
 # =============================================================================
 # Task Registry Tests

--- a/tests/unit/tasks/test_tasks_utils_comprehensive.py
+++ b/tests/unit/tasks/test_tasks_utils_comprehensive.py
@@ -35,58 +35,6 @@ class TaskUtilsTestCase(TestCase):
         task.save()
         return task
 
-    @patch("apps.tasks.utils.log_task_execution")
-    def test_task_execution_wrapper_success(self, mock_log):
-        """Test task execution wrapper with successful task."""
-
-        @utils.task_execution_wrapper("test_task")
-        def test_function(**kwargs):
-            return {"status": "success", "data": kwargs}
-
-        result = test_function(param1="value1", param2="value2")
-
-        self.assertEqual(mock_log.call_count, 2)  # start and complete
-        mock_log.assert_any_call("test_task", "start", "Starting test_task task")
-        mock_log.assert_any_call("test_task", "complete", "Task test_task completed successfully")
-
-        self.assertEqual(result["status"], "success")
-        self.assertEqual(result["data"]["param1"], "value1")
-
-    @patch("apps.tasks.utils.log_task_execution")
-    @patch("apps.tasks.utils.create_task_result")
-    def test_task_execution_wrapper_error(self, mock_create_result, mock_log):
-        """Test task execution wrapper with task error."""
-        mock_create_result.return_value = {"status": "error", "error": "Test error"}
-
-        @utils.task_execution_wrapper("test_task")
-        def test_function(**kwargs):
-            raise ValueError("Test error")
-
-        result = test_function(param1="value1")
-
-        self.assertEqual(mock_log.call_count, 2)  # start and error
-        mock_log.assert_any_call("test_task", "start", "Starting test_task task")
-        mock_log.assert_any_call("test_task", "error", "test_task task failed: Test error", level="error")
-
-        mock_create_result.assert_called_once_with("error", error="test_task task failed: Test error")
-        self.assertEqual(result["status"], "error")
-
-    def test_get_task_and_execution_with_execution(self):
-        """Test getting task and execution with execution ID."""
-        execution = TaskExecution.objects.create(task=self.task, status="pending", worker_id="test-worker")
-
-        task, exec_result = utils.get_task_and_execution(self.task.id, execution.id)
-
-        self.assertEqual(task.id, self.task.id)
-        self.assertEqual(exec_result.id, execution.id)
-
-    def test_get_task_and_execution_without_execution(self):
-        """Test getting task without execution ID."""
-        task, exec_result = utils.get_task_and_execution(self.task.id, None)
-
-        self.assertEqual(task.id, self.task.id)
-        self.assertIsNone(exec_result)
-
     def test_handle_task_error_with_instances(self):
         """Test error handling with task and execution instances."""
         execution = TaskExecution.objects.create(task=self.task, status="running", worker_id="test-worker")

--- a/tests/unit/tasks/test_tasks_utils_comprehensive.py
+++ b/tests/unit/tasks/test_tasks_utils_comprehensive.py
@@ -264,6 +264,35 @@ class TestGetDbConnection(TestCase):
         self.assertEqual(result, mock_raw_conn)
 
 
+class TestRunWithLock(TestCase):
+    """Test run_with_lock function."""
+
+    @patch("metrics_utility.library.lock.lock")
+    def test_run_with_lock_acquired(self, mock_lock_cls):
+        """Test run_with_lock when lock is acquired."""
+        mock_lock_cls.return_value.__enter__ = MagicMock(return_value=True)
+        mock_lock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        fn = MagicMock(return_value={"status": "success"})
+        result = utils.run_with_lock("my_lock", "my_task", fn, foo="bar")
+
+        fn.assert_called_once_with(foo="bar")
+        self.assertEqual(result["status"], "success")
+
+    @patch("metrics_utility.library.lock.lock")
+    def test_run_with_lock_not_acquired(self, mock_lock_cls):
+        """Test run_with_lock when lock cannot be acquired."""
+        mock_lock_cls.return_value.__enter__ = MagicMock(return_value=False)
+        mock_lock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        fn = MagicMock()
+        result = utils.run_with_lock("my_lock", "my_task", fn)
+
+        fn.assert_not_called()
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Could not acquire lock", result["error"])
+
+
 class TestGenerateSalt(TestCase):
     """Test generate_salt function."""
 

--- a/tests/unit/tasks/test_unified_scheduler.py
+++ b/tests/unit/tasks/test_unified_scheduler.py
@@ -10,7 +10,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 from apscheduler.schedulers.background import BackgroundScheduler
-from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 from apps.tasks.cron_scheduler import (
@@ -19,53 +18,6 @@ from apps.tasks.cron_scheduler import (
     start_scheduler,
     stop_scheduler,
 )
-
-User = get_user_model()
-
-
-@pytest.fixture
-def mock_task_groups():
-    """Mock task groups data."""
-    return {
-        "test_task_1": {
-            "function": "hello_world",
-            "cron": "0 */1 * * *",
-            "args": {"message": "test"},
-            "enabled": True,
-            "description": "Test task 1",
-        },
-        "test_task_2": {
-            "function": "cleanup_old_tasks",
-            "cron": "0 2 * * *",
-            "args": {},
-            "enabled": False,
-            "description": "Test task 2",
-        },
-    }
-
-
-@pytest.fixture
-def mock_db_tasks():
-    """Mock database Task objects."""
-    task1 = Mock()
-    task1.id = 1
-    task1.name = "test_task_1"
-    task1.function_name = "hello_world"
-    task1.cron_expression = "0 */1 * * *"
-    task1.task_data = {"message": "test"}
-    task1.description = "Test task 1"
-    task1.status = "pending"
-
-    task2 = Mock()
-    task2.id = 2
-    task2.name = "test_task_2"
-    task2.function_name = "cleanup_old_tasks"
-    task2.cron_expression = "0 2 * * *"
-    task2.task_data = {}
-    task2.description = "Test task 2"
-    task2.status = "pending"
-
-    return [task1, task2]
 
 
 @pytest.fixture
@@ -104,99 +56,34 @@ def mock_recurring_task():
     return task
 
 
-@pytest.fixture(autouse=True)
-def mock_task_database():
-    """Auto-mock the Task database for all tests."""
-    with patch("apps.tasks.models.Task") as mock_task_database:
-        # Mock empty database by default
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = []
-        mock_task_database.objects.filter.return_value = mock_queryset
-        yield mock_task_database
-
-
-@pytest.fixture
-def mock_task_functions():
-    """Mock task functions."""
-    return {
-        "hello_world": Mock(),
-        "cleanup_old_tasks": Mock(),
-        "execute_db_task": Mock(),
-    }
-
-
 @pytest.fixture
 def scheduler():
     """Create a UnifiedTaskScheduler instance."""
-    with patch("apps.tasks.models.Task") as mock_task_model:
-        # Mock empty database
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = []
-        mock_task_model.objects.filter.return_value = mock_queryset
-        return UnifiedTaskScheduler()
+    return UnifiedTaskScheduler()
 
 
 @pytest.mark.unit
 class TestUnifiedTaskScheduler:
     """Test cases for UnifiedTaskScheduler class."""
 
-    def test_init(self, mock_task_database, mock_db_tasks):
+    def test_init(self):
         """Test scheduler initialization."""
-        # Mock the database query to return tasks
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = mock_db_tasks
-        mock_task_database.objects.filter.return_value = mock_queryset
-
         scheduler = UnifiedTaskScheduler()
 
         assert isinstance(scheduler.scheduler, BackgroundScheduler)
         assert scheduler.running is False
-        # Should have loaded tasks from database
-        assert len(scheduler.task_registry) == 2
-        assert "test_task_1" in scheduler.task_registry
-        assert "test_task_2" in scheduler.task_registry
-
-    def test_init_with_load_error(self, mock_task_database):
-        """Test initialization handles load errors gracefully."""
-        # Make database query fail
-        mock_task_database.objects.filter.side_effect = Exception("Database error")
-
-        scheduler = UnifiedTaskScheduler()
-
-        assert scheduler.task_registry == {}
-
-    def test_load_task_registry_success(self, mock_task_database, mock_db_tasks):
-        """Test successful task registry loading."""
-        # Mock the database query
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = mock_db_tasks
-        mock_task_database.objects.filter.return_value = mock_queryset
-
-        scheduler = UnifiedTaskScheduler()
-
-        scheduler._load_task_registry()
-
-        # Verify tasks were loaded
-        assert len(scheduler.task_registry) == 2
+        assert scheduler._db_task_jobs == {}
 
     @pytest.mark.django_db
-    @patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {"hello_world": Mock()})
-    def test_start_success(self, mock_task_database, mock_db_tasks):
+    def test_start_success(self):
         """Test successful scheduler start."""
-        # Mock the database query
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = mock_db_tasks
-        mock_task_database.objects.filter.return_value = mock_queryset
-
         scheduler = UnifiedTaskScheduler()
         scheduler.scheduler.start = Mock()
-        scheduler._add_registry_tasks = Mock()
         scheduler._sync_database_tasks = Mock()
 
         scheduler.start()
 
         assert scheduler.running is True
-        scheduler._add_registry_tasks.assert_called_once()
         scheduler.scheduler.start.assert_called_once()
 
     def test_start_already_running(self):
@@ -206,13 +93,8 @@ class TestUnifiedTaskScheduler:
 
         scheduler.start()  # Should just return without error
 
-    def test_start_failure(self, mock_task_database):
+    def test_start_failure(self):
         """Test scheduler start failure."""
-        # Mock empty database
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = []
-        mock_task_database.objects.filter.return_value = mock_queryset
-
         scheduler = UnifiedTaskScheduler()
         scheduler.scheduler.start = Mock(side_effect=Exception("Start error"))
 
@@ -220,13 +102,8 @@ class TestUnifiedTaskScheduler:
             scheduler.start()
 
     @pytest.mark.django_db
-    def test_stop_success(self, mock_task_database):
+    def test_stop_success(self):
         """Test successful scheduler stop."""
-        # Mock empty database
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = []
-        mock_task_database.objects.filter.return_value = mock_queryset
-
         scheduler = UnifiedTaskScheduler()
         scheduler.running = True
         scheduler._db_task_jobs[1] = "job_1"
@@ -238,13 +115,8 @@ class TestUnifiedTaskScheduler:
         assert len(scheduler._db_task_jobs) == 0
         scheduler.scheduler.shutdown.assert_called_once()
 
-    def test_stop_not_running(self, mock_task_database):
+    def test_stop_not_running(self):
         """Test stopping scheduler when not running."""
-        # Mock empty database
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = []
-        mock_task_database.objects.filter.return_value = mock_queryset
-
         scheduler = UnifiedTaskScheduler()
         scheduler.running = False
         scheduler.scheduler.shutdown = Mock()
@@ -253,136 +125,13 @@ class TestUnifiedTaskScheduler:
 
         scheduler.scheduler.shutdown.assert_not_called()
 
-    def test_stop_failure(self, mock_task_database):
+    def test_stop_failure(self):
         """Test scheduler stop failure."""
-        # Mock empty database
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = []
-        mock_task_database.objects.filter.return_value = mock_queryset
-
         scheduler = UnifiedTaskScheduler()
         scheduler.running = True
         scheduler.scheduler.shutdown = Mock(side_effect=Exception("Stop error"))
 
         scheduler.stop()  # Should catch exception
-
-    @patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {"hello_world": Mock(), "cleanup_old_tasks": Mock()})
-    def test_add_registry_tasks(self, mock_task_database, mock_task_groups):
-        """Test adding registry tasks to scheduler."""
-        # Mock empty database
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = []
-        mock_task_database.objects.filter.return_value = mock_queryset
-
-        scheduler = UnifiedTaskScheduler()
-        scheduler.task_registry = mock_task_groups
-        scheduler._add_scheduled_task = Mock()
-
-        scheduler._add_registry_tasks()
-
-        # Should add enabled task and skip disabled one
-        scheduler._add_scheduled_task.assert_called_once_with("test_task_1", mock_task_groups["test_task_1"])
-
-    @patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {"hello_world": Mock()})
-    def test_add_registry_tasks_with_error(self, mock_task_database):
-        """Test adding registry tasks with error."""
-        # Mock empty database
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = []
-        mock_task_database.objects.filter.return_value = mock_queryset
-
-        scheduler = UnifiedTaskScheduler()
-        scheduler.task_registry = {"test_task": {"function": "hello_world", "enabled": True}}
-        scheduler._add_scheduled_task = Mock(side_effect=Exception("Add error"))
-
-        scheduler._add_registry_tasks()  # Should catch exception
-
-    @patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {"hello_world": Mock()})
-    @patch("apps.tasks.cron_scheduler.CronTrigger")
-    def test_add_scheduled_task_success(self, mock_cron_trigger, mock_task_database):
-        """Test successful scheduled task addition."""
-        # Mock empty database
-        mock_queryset = Mock()
-        mock_queryset.exclude.return_value = []
-        mock_task_database.objects.filter.return_value = mock_queryset
-
-        mock_trigger = Mock()
-        mock_cron_trigger.from_crontab.return_value = mock_trigger
-
-        scheduler = UnifiedTaskScheduler()
-        scheduler.scheduler.add_job = Mock()
-
-        config = {
-            "function": "hello_world",
-            "cron": "0 */1 * * *",
-            "args": {"message": "test"},
-            "description": "Test task",
-        }
-
-        scheduler._add_scheduled_task("test_task", config)
-
-        mock_cron_trigger.from_crontab.assert_called_once_with("0 */1 * * *")
-        scheduler.scheduler.add_job.assert_called_once_with(
-            func=scheduler._execute_scheduled_task,
-            trigger=mock_trigger,
-            args=["test_task", "hello_world", {"message": "test"}],
-            id="test_task",
-            name="Test task",
-            replace_existing=True,
-            max_instances=1,
-        )
-
-    @patch("apps.tasks.cron_scheduler.TASK_FUNCTIONS", {})
-    def test_add_scheduled_task_unknown_function(self):
-        """Test adding scheduled task with unknown function."""
-        scheduler = UnifiedTaskScheduler()
-        config = {"function": "unknown_function", "cron": "0 */1 * * *"}
-
-        with pytest.raises(ValueError, match="Unknown task function: unknown_function"):
-            scheduler._add_scheduled_task("test_task", config)
-
-    def test_execute_scheduled_task_success(self):
-        """Test successful scheduled task execution routes through _execute_database_task."""
-        scheduler = UnifiedTaskScheduler()
-
-        mock_task = Mock()
-        mock_task.id = 42
-        mock_task.status = "pending"
-        mock_task.task_data = {}
-
-        with (
-            patch("apps.tasks.models.Task") as mock_task_model,
-            patch.object(scheduler, "_execute_database_task") as mock_execute_db,
-        ):
-            mock_task_model.objects.filter.return_value.first.return_value = mock_task
-
-            scheduler._execute_scheduled_task("test_task", "hello_world", {"message": "test"})
-
-            mock_task_model.objects.filter.assert_called_once_with(name="test_task", is_system_task=True)
-            mock_execute_db.assert_called_once_with(mock_task.id)
-
-    def test_execute_scheduled_task_task_not_found(self):
-        """Test executing scheduled task when task is not found in DB logs error and returns."""
-        scheduler = UnifiedTaskScheduler()
-
-        with (
-            patch("apps.tasks.models.Task") as mock_task_model,
-            patch.object(scheduler, "_execute_database_task") as mock_execute_db,
-        ):
-            mock_task_model.objects.filter.return_value.first.return_value = None
-
-            scheduler._execute_scheduled_task("missing_task", "hello_world", {})  # Should log error and return
-
-            mock_execute_db.assert_not_called()
-
-    def test_execute_scheduled_task_config_error(self):
-        """Test executing scheduled task when an unexpected error occurs is handled gracefully."""
-        scheduler = UnifiedTaskScheduler()
-
-        with patch("apps.tasks.models.Task") as mock_task_model:
-            mock_task_model.objects.filter.side_effect = Exception("DB error")
-
-            scheduler._execute_scheduled_task("test_task", "hello_world", {})  # Should catch error
 
     def test_get_queue_for_function_known_functions(self):
         """Test queue mapping for known functions (now using shared function from dispatcherd_config)."""
@@ -439,6 +188,7 @@ class TestDatabaseTaskManagement:
             mock_remove.assert_called_once_with(job_id)
             assert task_id not in scheduler._db_task_jobs
 
+    @pytest.mark.django_db
     @patch("apps.tasks.models.Task")
     @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
     def test_execute_database_task(self, mock_submit, mock_task_model, scheduler):
@@ -449,6 +199,7 @@ class TestDatabaseTaskManagement:
         mock_task.name = "Test"
         mock_task.cron_expression = None  # Non-recurring task
         mock_task.status = "pending"
+        mock_task.task_data = {}
 
         mock_task_model.objects.get.return_value = mock_task
 
@@ -458,6 +209,7 @@ class TestDatabaseTaskManagement:
             mock_submit.assert_called_once_with(mock_task)
             mock_remove.assert_called_once_with(task_id)
 
+    @pytest.mark.django_db
     @patch("apps.tasks.models.Task")
     @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
     def test_execute_database_task_recurring(self, mock_submit, mock_task_model, scheduler):
@@ -492,6 +244,101 @@ class TestDatabaseTaskManagement:
             # Should not remove recurring tasks
             mock_remove.assert_not_called()
 
+    @pytest.mark.django_db
+    @patch("apps.tasks.models.Task")
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
+    def test_execute_database_task_cancelled_status(self, mock_submit, mock_task_model, scheduler):
+        """Test that a cancelled task is removed and not executed."""
+        task_id = 1
+        mock_task = Mock()
+        mock_task.id = task_id
+        mock_task.name = "Cancelled Task"
+        mock_task.status = "cancelled"
+        mock_task.task_data = {}
+
+        mock_task_model.objects.get.return_value = mock_task
+        mock_task_model.DoesNotExist = Exception
+
+        with patch.object(scheduler, "_remove_database_task") as mock_remove:
+            scheduler._execute_database_task(task_id)
+
+            mock_submit.assert_not_called()
+            mock_remove.assert_called_once_with(task_id)
+
+    @pytest.mark.django_db
+    @patch("apps.tasks.models.Task")
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
+    def test_execute_database_task_completed_status(self, mock_submit, mock_task_model, scheduler):
+        """Test that a completed task is removed and not executed."""
+        task_id = 1
+        mock_task = Mock()
+        mock_task.id = task_id
+        mock_task.name = "Completed Task"
+        mock_task.status = "completed"
+        mock_task.task_data = {}
+
+        mock_task_model.objects.get.return_value = mock_task
+        mock_task_model.DoesNotExist = Exception
+
+        with patch.object(scheduler, "_remove_database_task") as mock_remove:
+            scheduler._execute_database_task(task_id)
+
+            mock_submit.assert_not_called()
+            mock_remove.assert_called_once_with(task_id)
+
+    @pytest.mark.django_db
+    @patch("apps.tasks.task_groups.get_feature_enabled_from_db", return_value=False)
+    @patch("apps.tasks.models.Task")
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
+    def test_execute_database_task_feature_flag_disabled_non_recurring(
+        self, mock_submit, mock_task_model, mock_flag, scheduler
+    ):
+        """Test that a non-recurring task with disabled feature flag is skipped and removed from tracking."""
+        task_id = 1
+        mock_task = Mock()
+        mock_task.id = task_id
+        mock_task.name = "Flagged Task"
+        mock_task.status = "pending"
+        mock_task.task_data = {"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
+        mock_task.cron_expression = None
+
+        mock_task_model.objects.get.return_value = mock_task
+        mock_task_model.DoesNotExist = Exception
+
+        with patch.object(scheduler, "_remove_database_task") as mock_remove:
+            scheduler._execute_database_task(task_id)
+
+            mock_submit.assert_not_called()
+            # Non-recurring tasks are removed so they can be retried after flag re-enable
+            mock_remove.assert_called_once_with(task_id)
+
+    @pytest.mark.django_db
+    @patch("apps.tasks.task_groups.get_feature_enabled_from_db", return_value=False)
+    @patch("apps.tasks.models.Task")
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
+    def test_execute_database_task_feature_flag_disabled_recurring(
+        self, mock_submit, mock_task_model, mock_flag, scheduler
+    ):
+        """Test that a recurring task with disabled feature flag is skipped but stays in tracking."""
+        task_id = 2
+        mock_task = Mock()
+        mock_task.id = task_id
+        mock_task.name = "Recurring Flagged Task"
+        mock_task.status = "pending"
+        mock_task.task_data = {"_feature_flag": "ANONYMIZED_DATA_COLLECTION"}
+        mock_task.cron_expression = "0 3 * * *"
+
+        mock_task_model.objects.get.return_value = mock_task
+        mock_task_model.DoesNotExist = Exception
+
+        with patch.object(scheduler, "_remove_database_task") as mock_remove:
+            scheduler._execute_database_task(task_id)
+
+            mock_submit.assert_not_called()
+            # Recurring tasks stay in tracking so they fire again on next cron tick
+            mock_remove.assert_not_called()
+
+    @pytest.mark.django_db
     @patch("apps.tasks.models.Task")
     def test_execute_database_task_not_found(self, mock_task_model, scheduler):
         """Test executing a task that doesn't exist."""
@@ -579,7 +426,6 @@ class TestGlobalSchedulerFunctions:
     [
         # System/general tasks
         ("hello_world", "metrics_tasks"),
-        ("execute_db_task", "metrics_tasks"),
         # Cleanup tasks
         ("cleanup_old_tasks", "metrics_cleanup"),
         ("cleanup_metrics_data", "metrics_cleanup"),


### PR DESCRIPTION
Issue: AAP-69212, AAP-69213

Restore dispatcherd to 4 workers.

Make sure we atomically update task status when running, only running once.

Allow collector tasks to lock and fail when locked.
Simplify the tasking wrappers - execute_db_task consolidates that, and can no longer run itself.
(`TASK_LOCKS` specifies which task holds which locks - right now, any hourly collector blocks any other hourly collector)

Adds a 10 minute retry interval to all  tasks (rather than immediately)