### PR TITLE
[AAP-69219] ANONYMIZED_DATA_COLLECTION flag incorrectly stops all collections, not just anonymization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,10 +130,11 @@ The task system has several layers:
 
 ### Task Groups and Feature Flags
 
-`task_groups.py` defines two groups:
+`task_groups.py` defines three groups:
 
-- **`SYSTEM_TASKS_GROUP`** — Always enabled. Runs `cleanup_old_tasks` (daily 2 AM) and `hello_world` (hourly).
-- **`METRICS_COLLECTION_GROUP`** — Controlled by `ANONYMIZED_DATA_COLLECTION` feature flag (default: enabled, customer opt-out). Contains all hourly/daily collection, rollup, anonymization, and Segment transmission tasks.
+- **`SYSTEM_TASKS_GROUP`** — Always enabled. Runs `cleanup_old_tasks` (daily 5 AM) and `hello_world` (hourly).
+- **`METRICS_COLLECTION_GROUP`** — Always enabled (no feature flag). Contains all hourly/daily collection tasks, `daily_metrics_rollup`, and `cleanup_metrics_data`. Local metrics are collected regardless of the opt-out flag to prevent data gaps.
+- **`ANONYMIZATION_GROUP`** — Controlled by `ANONYMIZED_DATA_COLLECTION` feature flag (default: enabled, customer opt-out). Contains only `daily_anonymize_and_prepare` and `send_anonymized_to_segment` — the tasks that transmit data to Red Hat.
 
 Feature flags are stored in the `dynamic_settings_setting` DB table (managed by `apps/dynamic_settings/`). They fall back to `FEATURE_ENABLED` in Django settings if not in DB.
 

--- a/README.md
+++ b/README.md
@@ -112,18 +112,17 @@ GET /api/v1/tasks/available_functions/
 - `hello_world` - Simple test task for dispatcherd integration
 - `execute_db_task` - Execute database-defined tasks with lifecycle management
 
-**Anonymized Metrics Collection** (controlled by `ANONYMIZED_DATA_COLLECTION`, default: enabled, customer opt-out):
+**Metrics Collection Tasks** (always enabled - run regardless of opt-out flag):
 
-**Hourly Collection Tasks**:
 - `collect_hourly_metrics` - Collect time-series metrics every hour (collector type via `collector_type` parameter)
 - `collect_snapshot_metrics` - Collect daily snapshot metrics (collector type via `collector_type` parameter)
-
-**Daily Rollup, Anonymization, and Cleanup Tasks**:
-
 - `daily_metrics_rollup` - Merge hourly collections and create daily rollup summary
+- `cleanup_metrics_data` - Clean up old metrics data based on retention policies
+
+**Anonymization and Transmission Tasks** (controlled by `ANONYMIZED_DATA_COLLECTION`, default: enabled, customer opt-out):
+
 - `daily_anonymize_and_prepare` - Anonymize daily rollup and prepare for transmission
 - `send_anonymized_to_segment` - Send anonymized metrics to Segment.com
-- `cleanup_metrics_data` - Clean up old metrics data based on retention policies
 
 ## Background Tasks
 
@@ -171,7 +170,7 @@ METRICS_SERVICE_FEATURE_ENABLED__ANONYMIZED_DATA_COLLECTION=false
 
 These environment variables (or their default values) are used to populate the feature flags database tables during `mangage.py metrics_service init-default-settings`. You can also use `python manage.py metrics_service remove-default-settings` to remove these settings from the database.
 
-The feature flag values in the database then determine which task groups are active in the scheduler. If the value is missing from the database, the environment variables get used again.
+The feature flag value in the database determines whether the anonymization and transmission tasks run. Collection, rollup, and cleanup tasks always run regardless of this flag. If the value is missing from the database, the environment variable is used as the fallback.
 
 
 ## Development

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -138,13 +138,13 @@ SYSTEM_TASKS_GROUP = TaskGroup(
     ],
 )
 
-# Metrics Collection Group - Controlled by ANONYMIZED_DATA_COLLECTION
-# All metrics tasks (collection, rollup, anonymization, sending) are controlled by a single flag
-# since anonymization requires the collected data to work.
+# Metrics Collection Group - Always enabled, no feature flag.
+# Raw collection, rollup, and cleanup run regardless of the ANONYMIZED_DATA_COLLECTION flag.
+# Operators who opt out of sending data to Red Hat will still collect local metrics
+# to prevent a data gap if sending is enabled later.
 METRICS_COLLECTION_GROUP = TaskGroup(
     name="metrics_collection",
-    description="Metrics collection, rollup, anonymization, and transmission to Red Hat",
-    feature_flag="ANONYMIZED_DATA_COLLECTION",
+    description="Metrics collection, rollup, and cleanup (always enabled)",
     tasks=[
         # Hourly Collection Tasks
         {
@@ -230,7 +230,31 @@ METRICS_COLLECTION_GROUP = TaskGroup(
             "description": "Create daily rollup from hourly collections",
             "category": "daily_rollup",
         },
-        # Anonymization and Sending
+        # Cleanup Task
+        {
+            "task_id": "cleanup_metrics_data",
+            "function": "cleanup_metrics_data",
+            "cron": "0 4 * * *",  # Daily at 4:00 AM
+            "args": {
+                "hourly_retention_days": 7,
+                "daily_retention_days": 30,
+                "payload_retention_days": 7,
+            },
+            "enabled": True,
+            "description": "Clean up old metrics data based on retention policies",
+            "category": "maintenance",
+        },
+    ],
+)
+
+# Anonymization Group - Controlled by ANONYMIZED_DATA_COLLECTION.
+# Only these two tasks are gated by the flag, disabling it stops data being sent to Red Hat
+# while leaving local collection intact so there is no data gap after enabling again.
+ANONYMIZATION_GROUP = TaskGroup(
+    name="anonymization",
+    description="Anonymization and transmission of metrics to Red Hat (opt-out via ANONYMIZED_DATA_COLLECTION)",
+    feature_flag="ANONYMIZED_DATA_COLLECTION",
+    tasks=[
         {
             "task_id": "daily_anonymize",
             "function": "daily_anonymize_and_prepare",
@@ -249,20 +273,6 @@ METRICS_COLLECTION_GROUP = TaskGroup(
             "description": "Send anonymized payloads to Segment",
             "category": "daily_send",
         },
-        # Cleanup Task
-        {
-            "task_id": "cleanup_metrics_data",
-            "function": "cleanup_metrics_data",
-            "cron": "0 4 * * *",  # Daily at 4:00 AM
-            "args": {
-                "hourly_retention_days": 7,
-                "daily_retention_days": 30,
-                "payload_retention_days": 7,
-            },
-            "enabled": True,
-            "description": "Clean up old metrics data based on retention policies",
-            "category": "maintenance",
-        },
     ],
 )
 
@@ -270,12 +280,17 @@ METRICS_COLLECTION_GROUP = TaskGroup(
 TASK_GROUPS = [
     SYSTEM_TASKS_GROUP,
     METRICS_COLLECTION_GROUP,
+    ANONYMIZATION_GROUP,
 ]
 
 
 def get_all_enabled_tasks() -> dict[str, dict[str, Any]]:
     """
     Get all enabled tasks from all groups.
+
+    Group-level feature flags are evaluated at call, so tasks whose group flag
+    is disabled are excluded. Use get_all_tasks_for_init() when you need
+    all tasks unconditionally.
 
     Returns:
         Dictionary mapping task_id to task configuration for all enabled tasks.
@@ -291,6 +306,35 @@ def get_all_enabled_tasks() -> dict[str, dict[str, Any]]:
             task_config["group"] = group.name
             task_config["group_description"] = group.description
             # Add group's feature flag for runtime checking
+            if group.feature_flag:
+                task_config["feature_flag"] = group.feature_flag
+            all_tasks[task_id] = task_config
+
+    return all_tasks
+
+
+def get_all_tasks_for_init() -> dict[str, dict[str, Any]]:
+    """
+    Get all tasks from all groups for use by init-system-tasks.
+
+    This function does NOT evaluate group-level feature flags.
+    Every task that has enabled=True (or no enabled field) is included.
+    The group's feature_flag is embedded in each task config.
+
+    Returns:
+        Dictionary mapping task_id to task configuration for all individually-enabled
+        tasks across all groups, with feature_flag included where applicable.
+    """
+    all_tasks = {}
+
+    for group in TASK_GROUPS:
+        # Respect individual task enabled fields but ignore the group-level flag.
+        individually_enabled = [task for task in group.tasks if task.get("enabled", True)]
+        for task in individually_enabled:
+            task_id = task["task_id"]
+            task_config = task.copy()
+            task_config["group"] = group.name
+            task_config["group_description"] = group.description
             if group.feature_flag:
                 task_config["feature_flag"] = group.feature_flag
             all_tasks[task_id] = task_config

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -164,7 +164,7 @@ def create_system_tasks() -> dict[str, Any]:
     """
     try:
         from .models import Task
-        from .task_groups import get_all_enabled_tasks
+        from .task_groups import get_all_tasks_for_init
     except ImportError:
         # Handle case where Django isn't fully set up yet
         return {"error": "ERROR_DJANGO_NOT_READY", "created": 0, "removed": 0}
@@ -179,8 +179,12 @@ def create_system_tasks() -> dict[str, Any]:
         results["tasks"].append(f"Removed {removed_count} existing system tasks")
         logger.info(f"Removed {removed_count} existing system tasks")
 
-    # Get all task group definitions
-    task_groups = get_all_enabled_tasks()
+    # Get all task group definitions. Use get_all_tasks_for_init() (not get_all_enabled_tasks())
+    # so that feature-flagged tasks such as daily_anonymize and send_to_segment_daily are always
+    # written to the DB with _feature_flag stored in task_data. The runtime check in
+    # cron_scheduler._execute_scheduled_task() then gates execution without requiring re-init
+    # when the flag is toggled.
+    task_groups = get_all_tasks_for_init()
 
     # Create fresh tasks from task groups
     for task_id, config in task_groups.items():

--- a/tests/unit/tasks/test_task_groups.py
+++ b/tests/unit/tasks/test_task_groups.py
@@ -10,10 +10,12 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase, override_settings
 
 from apps.tasks.task_groups import (
+    ANONYMIZATION_GROUP,
     METRICS_COLLECTION_GROUP,
     SYSTEM_TASKS_GROUP,
     TaskGroup,
     get_all_enabled_tasks,
+    get_all_tasks_for_init,
 )
 
 
@@ -162,14 +164,12 @@ class TestPredefinedTaskGroups(TestCase):
         assert "daily_task_cleanup" in task_ids
         assert "hourly_health_check" in task_ids
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
-    def test_metrics_collection_group_enabled(self):
-        """Test metrics collection group when feature flag is enabled."""
+    def test_metrics_collection_group_always_enabled(self):
+        """Test metrics collection group has no feature flag and always returns its tasks."""
         assert METRICS_COLLECTION_GROUP.name == "metrics_collection"
-        assert METRICS_COLLECTION_GROUP.feature_flag == "ANONYMIZED_DATA_COLLECTION"
+        assert METRICS_COLLECTION_GROUP.feature_flag is None
 
         task_ids = [task["task_id"] for task in METRICS_COLLECTION_GROUP.get_enabled_tasks()]
-        # Should have all tasks when flag is enabled
         assert len(task_ids) > 0
         # Hourly collection tasks
         assert "hourly_job_host_summary" in task_ids
@@ -180,15 +180,30 @@ class TestPredefinedTaskGroups(TestCase):
         assert "daily_execution_environments" in task_ids
         # Daily processing tasks
         assert "cleanup_metrics_data" in task_ids
-        assert "daily_anonymize" in task_ids
         assert "daily_metrics_rollup" in task_ids
+        # Anonymize and send tasks must NOT be in this group
+        assert "daily_anonymize" not in task_ids
+        assert "send_to_segment_daily" not in task_ids
+
+    def test_anonymization_group_structure(self):
+        """Test ANONYMIZATION_GROUP contains only the two opt-out tasks with the correct flag."""
+        assert ANONYMIZATION_GROUP.name == "anonymization"
+        assert ANONYMIZATION_GROUP.feature_flag == "ANONYMIZED_DATA_COLLECTION"
+
+        task_ids = [task["task_id"] for task in ANONYMIZATION_GROUP.tasks]
+        assert set(task_ids) == {"daily_anonymize", "send_to_segment_daily"}
+
+    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
+    def test_anonymization_group_enabled(self):
+        """Test ANONYMIZATION_GROUP returns both tasks when flag is enabled."""
+        task_ids = [task["task_id"] for task in ANONYMIZATION_GROUP.get_enabled_tasks()]
+        assert "daily_anonymize" in task_ids
         assert "send_to_segment_daily" in task_ids
 
     @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": False})
-    def test_metrics_collection_group_disabled(self):
-        """Test metrics collection group when feature flag is disabled."""
-        enabled_tasks = METRICS_COLLECTION_GROUP.get_enabled_tasks()
-        assert len(enabled_tasks) == 0
+    def test_anonymization_group_disabled(self):
+        """Test ANONYMIZATION_GROUP returns no tasks when flag is disabled."""
+        assert ANONYMIZATION_GROUP.get_enabled_tasks() == []
 
     @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
     def test_no_duplicate_cron_slots(self):
@@ -231,28 +246,64 @@ class TestTaskGroupFunctions(TestCase):
     """Test utility functions for task groups."""
 
     @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": False})
-    def test_get_all_enabled_tasks(self):
-        """Test getting all enabled tasks from all groups."""
+    def test_get_all_enabled_tasks_flag_false(self):
+        """Collection tasks are present when flag is false, only anonymize/send are absent."""
         all_tasks = get_all_enabled_tasks()
-
-        # Should have only system tasks when metrics collection is disabled
         task_ids = list(all_tasks.keys())
 
         # System tasks (always enabled)
         assert "daily_task_cleanup" in task_ids
         assert "hourly_health_check" in task_ids
 
-        # Metrics collection tasks (disabled)
-        assert "hourly_job_host_summary" not in task_ids
-        assert "hourly_host_metrics" not in task_ids
-        assert "daily_metrics_rollup" not in task_ids
+        # Metrics collection tasks - (always enabled regardless of the flag)
+        assert "hourly_job_host_summary" in task_ids
+        assert "daily_metrics_rollup" in task_ids
+        assert "cleanup_metrics_data" in task_ids
+
+        # Anonymize and send tasks (must be absent when flag is false)
         assert "daily_anonymize" not in task_ids
         assert "send_to_segment_daily" not in task_ids
 
-        # Check that group information is added to tasks
+        # Every returned task config must have the group metadata
         for _task_id, task_config in all_tasks.items():
             assert "group" in task_config
             assert "group_description" in task_config
+
+    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
+    def test_get_all_enabled_tasks_flag_true(self):
+        """All tasks including anonymize/send are present when flag is true."""
+        all_tasks = get_all_enabled_tasks()
+        task_ids = list(all_tasks.keys())
+
+        assert "daily_anonymize" in task_ids
+        assert "send_to_segment_daily" in task_ids
+        assert "hourly_job_host_summary" in task_ids
+        assert "daily_metrics_rollup" in task_ids
+
+    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": False})
+    def test_get_all_tasks_for_init_includes_flagged_tasks(self):
+        """get_all_tasks_for_init() returns anonymize/send tasks even when flag is false."""
+        all_tasks = get_all_tasks_for_init()
+        task_ids = list(all_tasks.keys())
+
+        # Anonymize/send tasks must be present regardless of the flag
+        assert "daily_anonymize" in task_ids
+        assert "send_to_segment_daily" in task_ids
+
+        # The feature_flag must be stored in their config for runtime checking
+        assert all_tasks["daily_anonymize"]["feature_flag"] == "ANONYMIZED_DATA_COLLECTION"
+        assert all_tasks["send_to_segment_daily"]["feature_flag"] == "ANONYMIZED_DATA_COLLECTION"
+
+        # Collection tasks must also be present
+        assert "hourly_job_host_summary" in task_ids
+        assert "daily_metrics_rollup" in task_ids
+        assert "daily_task_cleanup" in task_ids
+
+    def test_get_all_tasks_for_init_excludes_individually_disabled_tasks(self):
+        """get_all_tasks_for_init() still respects per-task enabled=False."""
+        all_tasks = get_all_tasks_for_init()
+        # hourly_job_events has enabled=False in METRICS_COLLECTION_GROUP
+        assert "hourly_job_events" not in all_tasks
 
 
 class TestTaskGroupIntegration(TestCase):
@@ -274,36 +325,38 @@ class TestTaskGroupIntegration(TestCase):
 
     @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
     def test_all_flags_enabled(self):
-        """Test when metrics collection feature flag is enabled."""
+        """Test that all tasks are present when ANONYMIZED_DATA_COLLECTION is enabled."""
         all_tasks = get_all_enabled_tasks()
-
-        # Should have tasks from all groups
         task_ids = list(all_tasks.keys())
 
         # System tasks
         assert any("cleanup" in task_id for task_id in task_ids)
 
-        # Metrics collection tasks
+        # Metrics collection tasks (always on)
         assert any("hourly" in task_id for task_id in task_ids)
         assert "daily_metrics_rollup" in task_ids
 
-        # Anonymization tasks
+        # Anonymization tasks (from ANONYMIZATION_GROUP, enabled when flag is true)
         assert "daily_anonymize" in task_ids
         assert "send_to_segment_daily" in task_ids
 
     @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": False})
-    def test_minimal_system_only(self):
-        """Test when only system tasks are enabled."""
+    def test_flag_false_stops_only_anonymize_send(self):
+        """Collection and cleanup tasks are present when flag is false; only anonymize/send are absent."""
         all_tasks = get_all_enabled_tasks()
-
-        # Only system tasks should be present
         task_ids = list(all_tasks.keys())
-        # System tasks should be present
-        assert any("cleanup" in task_id for task_id in task_ids)
 
-        # Should only have system tasks
-        task_ids = list(all_tasks.keys())
-        system_task_ids = [task["task_id"] for task in SYSTEM_TASKS_GROUP.tasks]
+        # System tasks must still be present
+        assert "daily_task_cleanup" in task_ids
+        assert "hourly_health_check" in task_ids
 
-        for task_id in task_ids:
-            assert task_id in system_task_ids
+        # Metrics collection tasks must still be present
+        assert "hourly_job_host_summary" in task_ids
+        assert "hourly_unified_jobs" in task_ids
+        assert "hourly_credentials" in task_ids
+        assert "daily_metrics_rollup" in task_ids
+        assert "cleanup_metrics_data" in task_ids
+
+        # Only these two must be absent
+        assert "daily_anonymize" not in task_ids
+        assert "send_to_segment_daily" not in task_ids

--- a/tests/unit/tasks/test_tasks_system.py
+++ b/tests/unit/tasks/test_tasks_system.py
@@ -172,8 +172,7 @@ class TestSystemTaskCreation(TestCase):
 
     def test_create_system_tasks_with_disabled_tasks(self):
         """Test handling of disabled system tasks."""
-        # Disabled tasks are filtered by get_all_enabled_tasks()
-        with patch("apps.tasks.task_groups.get_all_enabled_tasks", return_value={}):
+        with patch("apps.tasks.task_groups.get_all_tasks_for_init", return_value={}):
             result = tasks_system.create_system_tasks()
 
             # All tasks filtered out
@@ -188,7 +187,7 @@ class TestSystemTaskCreation(TestCase):
         """
         for name in ("task_a", "task_b"):
             Task.objects.create(name=name, function_name="hello_world", is_system_task=True)
-        with patch("apps.tasks.task_groups.get_all_enabled_tasks", return_value={}):
+        with patch("apps.tasks.task_groups.get_all_tasks_for_init", return_value={}):
             result = tasks_system.create_system_tasks()
 
         assert result["removed"] == 2
@@ -716,7 +715,7 @@ class TestCreateSystemTasksExceptionHandling(TestCase):
         )
 
     @patch("apps.tasks.tasks_system._create_task_from_group")
-    @patch("apps.tasks.task_groups.get_all_enabled_tasks")
+    @patch("apps.tasks.task_groups.get_all_tasks_for_init")
     def test_handles_exception_creating_individual_task(self, mock_get_tasks, mock_create_task):
         """Test create_system_tasks handles exceptions per task."""
         # Arrange


### PR DESCRIPTION
# [AAP-69219] ANONYMIZED_DATA_COLLECTION flag incorrectly stops all collections, not just anonymization

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed? - `METRICS_COLLECTION_GROUP` is split into two groups. The new
  `METRICS_COLLECTION_GROUP` has no feature flag and always runs all collection, rollup, and
  cleanup tasks. A new `ANONYMIZATION_GROUP` carries `feature_flag="ANONYMIZED_DATA_COLLECTION"`
  and contains only `daily_anonymize_and_prepare` and `send_anonymized_to_segment`. A new
  `get_all_tasks_for_init()` function is added and used by `init-system-tasks` so all tasks are
  unconditionally written to the DB on init regardless of the current flag value.
- Why is this change needed? - Setting `ANONYMIZED_DATA_COLLECTION=false` previously disabled
  all 12 tasks in `METRICS_COLLECTION_GROUP`, including raw collection, rollup, and cleanup. The
  intent of the flag is to stop data being sent to Red Hat - not to stop local collection. When
  collection stops, any operator who later re-enables sending is left with a permanent gap in
  their historical metrics data.
- How does this change address the issue? - The flag now only gates the two tasks that transmit
  data externally. Collection and cleanup tasks run unconditionally. The existing runtime check in
  `cron_scheduler._execute_scheduled_task()` (which reads `_feature_flag` from `task_data`) gates
  the anonymize/send tasks at execution time, so toggling the flag activates or deactivates them
  immediately without requiring a restart or re-run of `init-system-tasks`.


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
- A working local environment

### Steps to Test
1. Set `ANONYMIZED_DATA_COLLECTION=false`
2. Run `python manage.py metrics_service init-system-tasks`
3. Query the `tasks_task` table and confirm `hourly_job_host_summary`, `hourly_unified_jobs`,
   `hourly_credentials`, `daily_execution_environments`, `daily_config`,
   `daily_controller_version`, `daily_table_metadata`, `daily_metrics_rollup`, and
   `cleanup_metrics_data` are all present
4. Confirm `daily_anonymize` and `send_to_segment_daily` are also present in the DB and that
   the `task_data` JSON contains `"_feature_flag": "ANONYMIZED_DATA_COLLECTION"`
5. Start the service and confirm collection tasks execute on schedule. Also confirm `daily_anonymize`
   and `send_to_segment_daily` are skipped with a log line containing "feature flag is disabled"
6. Set `ANONYMIZED_DATA_COLLECTION=true` and confirm the anonymize/send tasks execute on their
   next scheduled run without restarting the service or running init again.

### Expected Results
<!-- Describe what should happen after following the steps -->
- With flag=false: all collection, rollup, and cleanup tasks run, anonymize and send tasks are
  skipped at runtime
- With flag=true: all tasks including anonymize and send run normally
- No data gap occurs when the flag is toggled from false back to true

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task scheduling/initialization so opt-out no longer disables local metrics collection; mistakes could lead to missing scheduled jobs or unintended data transmission if the new grouping/flag embedding is wrong.
> 
> **Overview**
> Fixes `ANONYMIZED_DATA_COLLECTION` behavior so opting out stops only *anonymization/transmission* while keeping local metrics collection, rollup, and cleanup running to avoid historical data gaps.
> 
> This splits the previously flag-gated metrics group into an always-on `METRICS_COLLECTION_GROUP` plus a new flag-gated `ANONYMIZATION_GROUP`, updates `init-system-tasks` to write feature-flagged tasks to the DB via new `get_all_tasks_for_init()` (so runtime flag toggles work without re-init), and refreshes unit tests/docs to reflect the new task grouping and expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 885d71bc4a1947d1b16bbdcd63bc292aae7f553d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->