### PR TITLE
[AAP-70359] Implement subscription cost API endpoint

### DIFF
--- a/apps/dashboard_reports/serializers.py
+++ b/apps/dashboard_reports/serializers.py
@@ -1,9 +1,10 @@
+import decimal
 from typing import Any
 
 from dateutil.relativedelta import relativedelta
 from rest_framework import serializers
 
-from apps.dashboard_reports.models import JobData
+from apps.dashboard_reports.models import JobData, SubscriptionCost
 
 
 def sec2time(sec: int) -> str:
@@ -210,3 +211,39 @@ class ReportDetailSerializer(serializers.Serializer):
 
     def get_total_time_saving(self, obj: dict[str, Any]) -> float:
         return self._get_rounded_value(obj, "total_time_savings", divisor=3600)
+
+
+class SubscriptionCostSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True, help_text="ID of the subscription cost entry")
+    monthly_subscription_cost = serializers.DecimalField(
+        max_digits=15,
+        decimal_places=2,
+        help_text="Monthly subscription cost for AAP subscription",
+        min_value=decimal.Decimal("0.00"),
+    )
+
+    engineer_avg_hourly_rate = serializers.DecimalField(
+        max_digits=15,
+        decimal_places=2,
+        help_text="Average hourly rate for engineers performing manual work",
+        min_value=decimal.Decimal("0.00"),
+    )
+
+    include_template_creation_time_in_costs = serializers.BooleanField(
+        default=True,
+        help_text="Include template creation time in cost calculations. If false, costs related to template creation time will be excluded.",
+    )
+
+    def update(self, instance: SubscriptionCost, validated_data: dict[str, Any]) -> SubscriptionCost:
+        instance.monthly_subscription_cost = validated_data.get(
+            "monthly_subscription_cost", instance.monthly_subscription_cost
+        )
+        instance.engineer_avg_hourly_rate = validated_data.get(
+            "engineer_avg_hourly_rate", instance.engineer_avg_hourly_rate
+        )
+        instance.include_template_creation_time_in_costs = validated_data.get(
+            "include_template_creation_time_in_costs", instance.include_template_creation_time_in_costs
+        )
+        instance.save()
+
+        return instance

--- a/apps/dashboard_reports/urls.py
+++ b/apps/dashboard_reports/urls.py
@@ -7,6 +7,7 @@ from apps.dashboard_reports.viewsets import (
     LabelsViewSet,
     OrganizationsViewSet,
     ProjectsViewSet,
+    SubscriptionCostViewSet,
 )
 
 app_name = "dashboard_reports"
@@ -17,6 +18,7 @@ router.register(r"templates", JobTemplatesViewSet, basename="templates")
 router.register(r"projects", ProjectsViewSet, basename="projects")
 router.register(r"labels", LabelsViewSet, basename="labels")
 router.register(r"report", DashboardReportViewSet, basename="report")
+router.register(r"subscription_costs", SubscriptionCostViewSet, basename="subscription_costs")
 
 urlpatterns = [
     # Dashboard report endpoints at /api/v1/

--- a/apps/dashboard_reports/viewsets/__init__.py
+++ b/apps/dashboard_reports/viewsets/__init__.py
@@ -4,6 +4,7 @@ from .job_templates import JobTemplatesViewSet
 from .labels import LabelsViewSet
 from .organizations import OrganizationsViewSet
 from .projects import ProjectsViewSet
+from .subscription_cost import SubscriptionCostViewSet
 
 __all__ = [
     "FilterOptionsViewSet",
@@ -12,4 +13,5 @@ __all__ = [
     "ProjectsViewSet",
     "LabelsViewSet",
     "DashboardReportViewSet",
+    "SubscriptionCostViewSet",
 ]

--- a/apps/dashboard_reports/viewsets/subscription_cost.py
+++ b/apps/dashboard_reports/viewsets/subscription_cost.py
@@ -1,0 +1,55 @@
+import logging
+from typing import Any
+
+from django.db.models import QuerySet
+from rest_framework import status
+from rest_framework.mixins import ListModelMixin, UpdateModelMixin
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from apps.core.permissions import DeveloperModeRequired
+from apps.dashboard_reports.models import SubscriptionCost
+from apps.dashboard_reports.serializers import SubscriptionCostSerializer
+
+logger = logging.getLogger(__name__)
+
+
+class SubscriptionCostViewSet(ListModelMixin, UpdateModelMixin, GenericViewSet):
+    """
+    ViewSet for retrieving subscription cost from metrics service database.
+
+    Provides listing and updating subscription cost entries. This allows users (with correct permissions) to view and modify the cost of subscriptions as needed.
+
+    Endpoints:
+        GET /api/v1/dashboard_reports/subscription_costs/ - List subscription cost entries (without pagination)
+        PUT /api/v1/dashboard_reports/subscription_costs/{id}/ - Update an existing subscription cost entry by ID
+
+    Query Parameters:
+        id (int): ID of the subscription cost entry to edit
+    """
+
+    versioning_class = None  # Disable versioning for this viewset
+    permission_classes = [DeveloperModeRequired]
+    serializer_class = SubscriptionCostSerializer
+    pagination_class = None  # Disable pagination for this viewset
+
+    list_error_msg = "Failed to fetch subscription costs"
+    retrieve_error_msg = "Failed to fetch subscription cost details"
+
+    def not_found_msg(self, pk: int) -> str:
+        return f"Subscription cost with id {pk} not found"
+
+    def get_queryset(self) -> QuerySet[SubscriptionCost]:
+        return SubscriptionCost.objects.all()
+
+    def update(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """
+        Updates the cost of a subscription.
+        """
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/tests/unit/dashboard_reports/test_subscription_cost.py
+++ b/tests/unit/dashboard_reports/test_subscription_cost.py
@@ -1,0 +1,481 @@
+"""
+Unit tests for the SubscriptionCost API endpoint.
+
+Covers:
+- SubscriptionCostViewSet: list and update endpoints
+- SubscriptionCostSerializer: field validation
+- Permission enforcement via DeveloperModeRequired
+- SubscriptionCost.get_subscription_cost_by_id classmethod
+"""
+
+import decimal
+
+import pytest
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.core.models import User
+from apps.dashboard_reports.models import SubscriptionCost
+from apps.dashboard_reports.serializers import SubscriptionCostSerializer
+from apps.dashboard_reports.viewsets.subscription_cost import SubscriptionCostViewSet
+from tests.test_utils import get_test_password
+
+# =============================================================================
+# SubscriptionCostViewSet Tests - List and Update
+# =============================================================================
+
+
+@pytest.mark.unit
+@override_settings(MODE="development")
+class TestSubscriptionCostViewSet(APITestCase):
+    """Test SubscriptionCostViewSet list and update endpoints."""
+
+    def setUp(self) -> None:
+        """Set up test data."""
+        self.user = User.objects.create_superuser(
+            username="admin", email="admin@example.com", password=get_test_password()
+        )
+        self.subscription_cost = SubscriptionCost.get()
+        # Snapshot original values so tearDown can restore them
+        self._original_monthly = self.subscription_cost.monthly_subscription_cost
+        self._original_rate = self.subscription_cost.engineer_avg_hourly_rate
+        self._original_include = self.subscription_cost.include_template_creation_time_in_costs
+
+    def tearDown(self) -> None:
+        """Restore SubscriptionCost to its original default values."""
+        self.subscription_cost.monthly_subscription_cost = self._original_monthly
+        self.subscription_cost.engineer_avg_hourly_rate = self._original_rate
+        self.subscription_cost.include_template_creation_time_in_costs = self._original_include
+        self.subscription_cost.save()
+
+    # ------------------------------------------------------------------
+    # List Tests
+    # ------------------------------------------------------------------
+
+    def test_list_returns_200(self) -> None:
+        """Test GET /api/v1/dashboard_reports/subscription_costs/ returns 200."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-list")
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_list_returns_subscription_cost_entries(self) -> None:
+        """Test list endpoint returns the existing SubscriptionCost entries."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-list")
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert isinstance(response.data, list)
+        assert len(response.data) >= 1
+
+    def test_list_response_contains_expected_fields(self) -> None:
+        """Test list response contains all expected serializer fields."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-list")
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        entry = response.data[0]
+        expected_fields = {
+            "id",
+            "monthly_subscription_cost",
+            "engineer_avg_hourly_rate",
+            "include_template_creation_time_in_costs",
+        }
+        assert expected_fields.issubset(set(entry.keys()))
+
+    def test_list_pagination_is_disabled(self) -> None:
+        """Test list endpoint returns a plain list, not a paginated response."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-list")
+        response = self.client.get(url)
+
+        # Pagination would wrap results in a dict with a 'results' key
+        assert isinstance(response.data, list)
+
+    # ------------------------------------------------------------------
+    # Update Tests
+    # ------------------------------------------------------------------
+
+    def test_update_returns_200(self) -> None:
+        """Test PUT /api/v1/dashboard_reports/subscription_costs/{id}/ returns 200."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        data = {
+            "monthly_subscription_cost": "1500.00",
+            "engineer_avg_hourly_rate": "75.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_update_persists_monthly_subscription_cost(self) -> None:
+        """Test updating monthly_subscription_cost persists the new value."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        data = {
+            "monthly_subscription_cost": "2000.00",
+            "engineer_avg_hourly_rate": self.subscription_cost.engineer_avg_hourly_rate,
+            "include_template_creation_time_in_costs": self.subscription_cost.include_template_creation_time_in_costs,
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert decimal.Decimal(response.data["monthly_subscription_cost"]) == decimal.Decimal("2000.00")
+
+        self.subscription_cost.refresh_from_db()
+        assert self.subscription_cost.monthly_subscription_cost == decimal.Decimal("2000.00")
+
+    def test_update_persists_engineer_avg_hourly_rate(self) -> None:
+        """Test updating engineer_avg_hourly_rate persists the new value."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        data = {
+            "monthly_subscription_cost": self.subscription_cost.monthly_subscription_cost,
+            "engineer_avg_hourly_rate": "99.50",
+            "include_template_creation_time_in_costs": self.subscription_cost.include_template_creation_time_in_costs,
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert decimal.Decimal(response.data["engineer_avg_hourly_rate"]) == decimal.Decimal("99.50")
+
+        self.subscription_cost.refresh_from_db()
+        assert self.subscription_cost.engineer_avg_hourly_rate == decimal.Decimal("99.50")
+
+    def test_update_persists_include_template_creation_time_in_costs(self) -> None:
+        """Test toggling include_template_creation_time_in_costs persists correctly."""
+        self.client.force_authenticate(user=self.user)
+
+        original = self.subscription_cost.include_template_creation_time_in_costs
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        data = {
+            "monthly_subscription_cost": self.subscription_cost.monthly_subscription_cost,
+            "engineer_avg_hourly_rate": self.subscription_cost.engineer_avg_hourly_rate,
+            "include_template_creation_time_in_costs": not original,
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["include_template_creation_time_in_costs"] == (not original)
+
+        self.subscription_cost.refresh_from_db()
+        assert self.subscription_cost.include_template_creation_time_in_costs == (not original)
+
+    def test_update_falls_back_to_existing_values_for_missing_fields(self) -> None:
+        """Test that omitting a field in the request body keeps the existing value."""
+        self.client.force_authenticate(user=self.user)
+
+        original_rate = self.subscription_cost.engineer_avg_hourly_rate
+        original_include = self.subscription_cost.include_template_creation_time_in_costs
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        # Only send monthly_subscription_cost; the other two fields are omitted entirely
+        data = {
+            "monthly_subscription_cost": "500.00",
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert decimal.Decimal(response.data["engineer_avg_hourly_rate"]) == original_rate
+        assert response.data["include_template_creation_time_in_costs"] == original_include
+
+    def test_update_with_nonexistent_id_returns_404(self) -> None:
+        """Test PUT with a non-existent PK returns 404."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": 999999})
+        data = {
+            "monthly_subscription_cost": "100.00",
+            "engineer_avg_hourly_rate": "50.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_update_with_partial_data_preserves_other_fields(self) -> None:
+        """Test that omitting fields in the request body keeps existing DB values,
+        i.e. the viewset falls back to the instance values for missing fields."""
+        self.client.force_authenticate(user=self.user)
+
+        # Set known starting values
+        self.subscription_cost.monthly_subscription_cost = decimal.Decimal("1000.00")
+        self.subscription_cost.engineer_avg_hourly_rate = decimal.Decimal("50.00")
+        self.subscription_cost.include_template_creation_time_in_costs = True
+        self.subscription_cost.save()
+
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        # Only send monthly_subscription_cost, omit the other two fields entirely
+        data = {
+            "monthly_subscription_cost": "1234.00",
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert decimal.Decimal(response.data["monthly_subscription_cost"]) == decimal.Decimal("1234.00")
+        # These were not sent — they should be unchanged
+        assert decimal.Decimal(response.data["engineer_avg_hourly_rate"]) == decimal.Decimal("50.00")
+        assert response.data["include_template_creation_time_in_costs"] is True
+
+        self.subscription_cost.refresh_from_db()
+        assert self.subscription_cost.monthly_subscription_cost == decimal.Decimal("1234.00")
+        assert self.subscription_cost.engineer_avg_hourly_rate == decimal.Decimal("50.00")
+        assert self.subscription_cost.include_template_creation_time_in_costs is True
+
+    def test_update_rejects_negative_monthly_subscription_cost(self) -> None:
+        """Test updating monthly_subscription_cost with a negative value returns 400."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        data = {
+            "monthly_subscription_cost": "-100.00",
+            "engineer_avg_hourly_rate": "50.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_rejects_negative_engineer_avg_hourly_rate(self) -> None:
+        """Test updating engineer_avg_hourly_rate with a negative value returns 400."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        data = {
+            "monthly_subscription_cost": "100.00",
+            "engineer_avg_hourly_rate": "-50.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_update_response_includes_id(self) -> None:
+        """Test the update response includes the id field."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        data = {
+            "monthly_subscription_cost": "300.00",
+            "engineer_avg_hourly_rate": "40.00",
+            "include_template_creation_time_in_costs": False,
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "id" in response.data
+        assert response.data["id"] == self.subscription_cost.pk
+
+    # ------------------------------------------------------------------
+    # ViewSet introspection
+    # ------------------------------------------------------------------
+
+    def test_get_serializer_class_for_list_action(self) -> None:
+        """Test get_serializer_class returns SubscriptionCostSerializer for list."""
+        viewset = SubscriptionCostViewSet()
+        viewset.action = "list"
+        assert viewset.get_serializer_class() == SubscriptionCostSerializer
+
+    def test_get_queryset_returns_all_subscription_costs(self) -> None:
+        """Test get_queryset returns all SubscriptionCost objects."""
+        viewset = SubscriptionCostViewSet()
+        qs = viewset.get_queryset()
+        assert qs.model == SubscriptionCost
+
+
+# =============================================================================
+# Permission Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSubscriptionCostPermissions(APITestCase):
+    """Test permission enforcement on the SubscriptionCost endpoints."""
+
+    def setUp(self) -> None:
+        self.user = User.objects.create_superuser(
+            username="admin", email="admin@example.com", password=get_test_password()
+        )
+        self.subscription_cost = SubscriptionCost.get()
+        self._original_monthly = self.subscription_cost.monthly_subscription_cost
+        self._original_rate = self.subscription_cost.engineer_avg_hourly_rate
+        self._original_include = self.subscription_cost.include_template_creation_time_in_costs
+
+    def tearDown(self) -> None:
+        self.subscription_cost.monthly_subscription_cost = self._original_monthly
+        self.subscription_cost.engineer_avg_hourly_rate = self._original_rate
+        self.subscription_cost.include_template_creation_time_in_costs = self._original_include
+        self.subscription_cost.save()
+
+    @override_settings(MODE="production")
+    def test_list_denied_in_production_mode(self) -> None:
+        """Test list is forbidden when MODE is not development."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-list")
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @override_settings(MODE="production")
+    def test_update_denied_in_production_mode(self) -> None:
+        """Test update is forbidden when MODE is not development."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        data = {
+            "monthly_subscription_cost": "100.00",
+            "engineer_avg_hourly_rate": "50.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @override_settings(MODE="development")
+    def test_list_accessible_in_development_mode(self) -> None:
+        """Test list is accessible when MODE=development."""
+        self.client.force_authenticate(user=self.user)
+
+        url = reverse("dashboard_reports:subscription_costs-list")
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+
+
+# =============================================================================
+# Serializer Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSubscriptionCostSerializer(TestCase):
+    """Test SubscriptionCostSerializer field validation."""
+
+    def setUp(self) -> None:
+        self.instance = SubscriptionCost.get()
+        self._original_monthly = self.instance.monthly_subscription_cost
+        self._original_rate = self.instance.engineer_avg_hourly_rate
+        self._original_include = self.instance.include_template_creation_time_in_costs
+
+    def tearDown(self) -> None:
+        self.instance.monthly_subscription_cost = self._original_monthly
+        self.instance.engineer_avg_hourly_rate = self._original_rate
+        self.instance.include_template_creation_time_in_costs = self._original_include
+        self.instance.save()
+
+    def test_valid_data_is_accepted(self) -> None:
+        """Test serializer accepts a fully valid payload."""
+        data = {
+            "monthly_subscription_cost": "1200.00",
+            "engineer_avg_hourly_rate": "60.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        serializer = SubscriptionCostSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors
+
+    def test_negative_monthly_subscription_cost_is_rejected(self) -> None:
+        """Test serializer rejects negative monthly_subscription_cost."""
+        data = {
+            "monthly_subscription_cost": "-1.00",
+            "engineer_avg_hourly_rate": "60.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        serializer = SubscriptionCostSerializer(data=data)
+        assert not serializer.is_valid()
+        assert "monthly_subscription_cost" in serializer.errors
+
+    def test_negative_engineer_avg_hourly_rate_is_rejected(self) -> None:
+        """Test serializer rejects negative engineer_avg_hourly_rate."""
+        data = {
+            "monthly_subscription_cost": "500.00",
+            "engineer_avg_hourly_rate": "-10.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        serializer = SubscriptionCostSerializer(data=data)
+        assert not serializer.is_valid()
+        assert "engineer_avg_hourly_rate" in serializer.errors
+
+    def test_zero_values_are_accepted(self) -> None:
+        """Test serializer accepts 0.00 for cost fields (boundary value)."""
+        data = {
+            "monthly_subscription_cost": "0.00",
+            "engineer_avg_hourly_rate": "0.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        serializer = SubscriptionCostSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors
+
+    def test_include_template_creation_time_defaults_to_true(self) -> None:
+        """Test include_template_creation_time_in_costs defaults to True when omitted."""
+        data = {
+            "monthly_subscription_cost": "100.00",
+            "engineer_avg_hourly_rate": "50.00",
+            # include_template_creation_time_in_costs omitted
+        }
+        serializer = SubscriptionCostSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["include_template_creation_time_in_costs"] is True
+
+    def test_update_method_persists_changes(self) -> None:
+        """Test serializer update() saves all fields to the instance."""
+        data = {
+            "monthly_subscription_cost": "750.00",
+            "engineer_avg_hourly_rate": "85.00",
+            "include_template_creation_time_in_costs": False,
+        }
+        serializer = SubscriptionCostSerializer(instance=self.instance, data=data)
+        assert serializer.is_valid(), serializer.errors
+
+        updated = serializer.save()
+
+        assert updated.monthly_subscription_cost == decimal.Decimal("750.00")
+        assert updated.engineer_avg_hourly_rate == decimal.Decimal("85.00")
+        assert updated.include_template_creation_time_in_costs is False
+
+    def test_id_field_is_read_only(self) -> None:
+        """Test the id field is read-only and cannot be set via input."""
+        serializer = SubscriptionCostSerializer(instance=self.instance)
+        assert serializer.fields["id"].read_only is True
+
+    def test_serializer_exposes_expected_fields(self) -> None:
+        """Test serializer data contains all expected fields."""
+        serializer = SubscriptionCostSerializer(instance=self.instance)
+        data = serializer.data
+        expected_fields = {
+            "id",
+            "monthly_subscription_cost",
+            "engineer_avg_hourly_rate",
+            "include_template_creation_time_in_costs",
+        }
+        assert expected_fields == set(data.keys())
+
+
+# =============================================================================
+# Import Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSubscriptionCostImports(TestCase):
+    """Smoke tests: verify all new symbols can be imported."""
+
+    def test_viewset_is_importable(self) -> None:
+        """Test SubscriptionCostViewSet can be imported."""
+        assert callable(SubscriptionCostViewSet)
+
+    def test_serializer_is_importable(self) -> None:
+        """Test SubscriptionCostSerializer can be imported."""
+        assert callable(SubscriptionCostSerializer)


### PR DESCRIPTION
# [[AAP-70359](https://redhat.atlassian.net/browse/AAP-70359)] Implement subscription cost API endpoint

Requires: https://github.com/ansible/metrics-service/pull/177

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
    * GET /api/v1/dashboard_reports/subscription_costs/ - get currently set cost
    * PUT /api/v1/dashboard_reports/subscription_costs/{id} - update the cost by id
- Why is this change needed?
    * We want subscription cost calculation be configurable depending on the admin's needs 
- How does this change address the issue?
    * We added endpoints that enable editing subscription costs

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
See README for setting up development environment.

Other requierements:
- running metrics service DB (with migrations)
- running awx DB (with migrations)

### Steps to Test
1. start metrics service - `python manage.py metrics_service run`
2. go to swagger docs - `http://localhost:8000/api/v1/docs/#/dashboard_reports`
3. test the GET and PUT methods of subscription_costs endpoint

Another way to test:
- run all unit tests: `pytest -m unit`
- run unit tests just for subscription costs: `pytest -m unit tests/unit/dashboard_reports/test_subscription_cost.py`

### Expected Results
<!-- Describe what should happen after following the steps -->
- For the GET endpoint, you should be able to see a list of all subscription cost entries (should be just one)
- For the PUT endpoint, you should be able to see and a response of the subscription cost entry you just updated but with updated values
- Unit tests should pass

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new API endpoint for managing subscription costs with list and update operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->