### PR TITLE
[AAP-68897] add jenkins pipeline benchmark

### DIFF
--- a/metrics_service/tools/performance_tests/BENCHMARK_JENKINS.md
+++ b/metrics_service/tools/performance_tests/BENCHMARK_JENKINS.md
@@ -1,0 +1,181 @@
+# Running Performance Benchmarks Against Jenkins Pipeline
+
+**Jenkins pipeline:** AAPQA/AAPQA Provisioner/AAPQA-ATF-Test-Suite-Yolo
+
+## Prerequisites
+
+- Jenkins pipeline has completed and the TSD file is available
+- `metrics-utility` is checked out locally
+- `metrics-service` is checked out locally
+
+## Step 1 — Get IPs and credentials from the TSD file
+
+The TSD file provides:
+
+- `<controller-ip>` — Controller host (source DB for `fill_perf_db_data.py`)
+- `<metrics-service-ip>` — metrics-service host (where the container runs)
+- `<controller-db-user>` and `<controller-db-password>` — AWX DB credentials
+
+> **Note:** `benchmark_api.py` does not work against Jenkins deployments.
+> Production metrics-service sets `ALLOWED_HOSTS=[]`, which causes Django to reject
+> all HTTP requests with 400. Use `benchmark_manage.py` instead, which runs the
+> collectors directly via `manage.py shell` inside the container.
+
+## Step 2 — Copy the benchmark script into the container
+
+```bash
+# From your local machine — copy to the host
+scp metrics_service/tools/performance_tests/benchmark_manage.py \
+    ansible@<metrics-service-ip>:/tmp/benchmark_manage.py
+
+# On the metrics-service host — copy into the container
+podman cp /tmp/benchmark_manage.py \
+    automation-metrics-service:/tmp/benchmark_manage.py
+```
+
+## Step 3 — Run the benchmarks at each scale
+
+Repeat the following block for **small**, **medium**, and **large**.
+Each time: generate data (cumulative — do not clean between scales) → run benchmark.
+
+> **Note:** Cleaning the AWX DB between scales is not reliable on Jenkins deployments
+> due to FK constraints on internal AWX jobs. Data is accumulated across scales instead.
+
+---
+
+### Small (100 jobs, 50 tasks, 16 hosts)
+
+**Generate data:**
+
+```bash
+cd <path-to-metrics-utility>
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --job-count=100 --task-count=50 --host-count=16 --no-events
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --date=2024-01-24 --job-count=100 --task-count=50 --host-count=16 --no-events
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --date=2024-01-25 --job-count=100 --task-count=50 --host-count=16 --no-events
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --date=2024-01-26 --job-count=100 --task-count=50 --host-count=16 --no-events
+```
+
+**Run benchmark (on the metrics-service host):**
+
+```bash
+podman exec automation-metrics-service \
+  python3.12 manage.py shell -c "exec(open('/tmp/benchmark_manage.py').read())" \
+  | tee /home/ansible/results_small_jenkins.txt
+```
+
+---
+
+### Medium (1000 jobs, 50 tasks, 20 hosts)
+
+**Generate data:**
+
+```bash
+cd <path-to-metrics-utility>
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --job-count=1000 --task-count=50 --host-count=20 --no-events
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --date=2024-01-24 --job-count=1000 --task-count=50 --host-count=20 --no-events
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --date=2024-01-25 --job-count=1000 --task-count=50 --host-count=20 --no-events
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --date=2024-01-26 --job-count=1000 --task-count=50 --host-count=20 --no-events
+```
+
+**Run benchmark (on the metrics-service host):**
+
+```bash
+podman exec automation-metrics-service \
+  python3.12 manage.py shell -c "exec(open('/tmp/benchmark_manage.py').read())" \
+  | tee /home/ansible/results_medium_jenkins.txt
+```
+
+---
+
+### Large (2000 jobs, 100 tasks, 40 hosts)
+
+**Generate data:**
+
+```bash
+cd <path-to-metrics-utility>
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --job-count=2000 --task-count=100 --host-count=40 --no-events
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --date=2024-01-24 --job-count=2000 --task-count=100 --host-count=40 --no-events
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --date=2024-01-25 --job-count=2000 --task-count=100 --host-count=40 --no-events
+
+METRICS_UTILITY_DB_HOST=<controller-ip> \
+METRICS_UTILITY_DB_USER=<controller-db-user> \
+METRICS_UTILITY_DB_PASSWORD=<controller-db-password> \
+  .venv/bin/python tools/anonymized_db_perf_data/fill_perf_db_data.py \
+  --date=2024-01-26 --job-count=2000 --task-count=100 --host-count=40 --no-events
+```
+
+**Run benchmark (on the metrics-service host):**
+
+```bash
+podman exec automation-metrics-service \
+  python3.12 manage.py shell -c "exec(open('/tmp/benchmark_manage.py').read())" \
+  | tee /home/ansible/results_large_jenkins.txt
+```
+
+---
+
+## Results
+
+Collected 2026-04-07 on a Jenkins pipeline AIO (containerized) deployment.
+Data is cumulative — each scale builds on top of the previous (no clean between scales).
+
+| Scale | Snapshot | Hourly | Daily rollup | Total |
+|-------|----------|--------|--------------|-------|
+| Small (100 jobs, 50 tasks, 16 hosts) | 2.51s | 3.2s | 0.07s | 5.8s |
+| Medium (1000 jobs, 50 tasks, 20 hosts) | 1.64s | 8.3s | 2.32s | 12.2s |
+| Large (2000 jobs, 100 tasks, 40 hosts) | 1.49s | 15.7s | 3.32s | 20.5s |

--- a/metrics_service/tools/performance_tests/RESULTS_JENKINS.md
+++ b/metrics_service/tools/performance_tests/RESULTS_JENKINS.md
@@ -1,0 +1,104 @@
+# Metrics-Service Jenkins Pipeline Benchmark Results
+
+Tests the full collection + rollup pipeline on a containerized AIO Jenkins
+deployment, using `benchmark_manage.py` via `podman exec` (direct Python calls
+inside the container). Duration is wall-clock time measured by `time.perf_counter()`.
+
+> **Note:** `benchmark_api.py` cannot be used against Jenkins deployments —
+> production metrics-service sets `ALLOWED_HOSTS=[]`, which causes Django to
+> reject all HTTP requests with 400.
+>
+> **Note:** Data is cumulative across scales (no clean between runs due to FK
+> constraints on internal AWX jobs). Each scale's AWX DB contains data from all
+> prior scales as well.
+
+## Scaling Summary
+
+| Scale  | Generator params    | Snapshot | Hourly | Daily rollup | Total  |
+|--------|---------------------|----------|--------|--------------|--------|
+| Small  | J=100, T=50, H=16   | 1.29s    | 3.5s   | 1.09s        | 5.9s   |
+| Medium | J=1000, T=50, H=20  | 0.89s    | 8.3s   | 2.83s        | 12.1s  |
+| Large  | J=2000, T=100, H=40 | 0.87s    | 15.8s  | 3.33s        | 20.0s  |
+
+---
+
+## Small Scale Detail
+
+**Date of test run:** 2026-04-07
+**Scale:** J=100, T=50, H=16 (no events)
+**Environment:** AIO containerized Jenkins deployment
+**Test date:** 2024-01-25
+
+### AWX DB counts at time of benchmark (total rows in DB, not per hour)
+
+| Table               | Total rows |
+|---------------------|------------|
+| main_host           | 78         |
+| main_job            | 423        |
+| main_jobhostsummary | 6,710      |
+| main_jobevent       | 729        |
+
+### Summary
+
+| Phase               | Duration  |
+|---------------------|-----------|
+| Snapshot collectors | 1.29s     |
+| Hourly collection   | 3.5s      |
+| Daily rollup        | 1.09s     |
+| **Total**           | **5.9s**  |
+
+---
+
+## Medium Scale Detail
+
+**Date of test run:** 2026-04-07
+**Scale:** J=1000, T=50, H=20 (cumulative on top of small; no events)
+**Environment:** AIO containerized Jenkins deployment
+**Test date:** 2024-01-25
+
+### AWX DB counts at time of benchmark (total rows in DB, not per hour)
+
+| Table               | Total rows |
+|---------------------|------------|
+| main_host           | 158        |
+| main_job            | 4,423      |
+| main_jobhostsummary | 86,710     |
+| main_jobevent       | 729        |
+
+### Summary
+
+| Phase               | Duration   |
+|---------------------|------------|
+| Snapshot collectors | 0.89s      |
+| Hourly collection   | 8.3s       |
+| Daily rollup        | 2.83s      |
+| **Total**           | **12.1s**  |
+
+---
+
+## Large Scale Detail
+
+**Date of test run:** 2026-04-07
+**Scale:** J=2000, T=100, H=40 (cumulative on top of medium; no events)
+**Environment:** AIO containerized Jenkins deployment
+**Test date:** 2024-01-25
+
+### AWX DB counts at time of benchmark (total rows in DB, not per hour)
+
+| Table               | Total rows |
+|---------------------|------------|
+| main_host           | 338        |
+| main_job            | 13,423     |
+| main_jobhostsummary | 426,710    |
+| main_jobevent       | 729        |
+
+### Summary
+
+| Phase               | Duration   |
+|---------------------|------------|
+| Snapshot collectors | 0.87s      |
+| Hourly collection   | 15.8s      |
+| Daily rollup        | 3.33s      |
+| **Total**           | **20.0s**  |
+
+---

--- a/metrics_service/tools/performance_tests/benchmark_manage.py
+++ b/metrics_service/tools/performance_tests/benchmark_manage.py
@@ -1,0 +1,82 @@
+# ruff: noqa: T201
+import time
+
+from apps.tasks.collectors import collect_hourly_metrics, collect_snapshot_metrics, daily_metrics_rollup
+
+TEST_DATE = "2024-01-25"
+
+SNAPSHOT_COLLECTORS = [
+    "execution_environments",
+    "config",
+    "controller_version_service",
+    "table_metadata",
+]
+
+HOURLY_COLLECTORS = [
+    "job_host_summary_service",
+    "unified_jobs",
+    "credentials_service",
+    "main_jobevent_service",
+]
+
+print("=" * 70)
+print("Metrics Service Pipeline Benchmark (manage.py)")
+print("=" * 70)
+print(f"  Test date : {TEST_DATE}")
+
+# Phase 1 — Snapshot collectors
+print("\n" + "=" * 70)
+print("Phase 1: Snapshot collectors (run once each)")
+print("=" * 70)
+print(f"  {'Collector':<35} {'Duration':>10}")
+print(f"  {'---------':<35} {'--------':>10}")
+
+snapshot_start = time.perf_counter()
+for collector in SNAPSHOT_COLLECTORS:
+    start = time.perf_counter()
+    collect_snapshot_metrics(collector_type=collector)
+    elapsed = time.perf_counter() - start
+    print(f"  {collector:<35} {elapsed:>8.2f}s")
+
+snapshot_elapsed = time.perf_counter() - snapshot_start
+print(f"\n  Total: {snapshot_elapsed:.1f}s")
+
+# Phase 2 — Hourly collection
+print("\n" + "=" * 70)
+print("Phase 2: Hourly collectors (24 hours x 4 collectors)")
+print("=" * 70)
+print(f"  {'Hour':<6} {'Collector':<35} {'Duration':>10}")
+print(f"  {'----':<6} {'---------':<35} {'--------':>10}")
+
+hourly_start = time.perf_counter()
+for hour in range(24):
+    hour_ts = f"{TEST_DATE}T{hour:02d}:00:00Z"
+    for collector in HOURLY_COLLECTORS:
+        start = time.perf_counter()
+        collect_hourly_metrics(collector_type=collector, hour_timestamp=hour_ts)
+        elapsed = time.perf_counter() - start
+        print(f"  {hour:<6} {collector:<35} {elapsed:>8.2f}s")
+
+hourly_elapsed = time.perf_counter() - hourly_start
+print(f"\n  Total: {hourly_elapsed:.1f}s ({hourly_elapsed / 60:.1f} min)")
+
+# Phase 3 — Daily rollup
+print("\n" + "=" * 70)
+print("Phase 3: Daily rollup")
+print("=" * 70)
+start = time.perf_counter()
+daily_metrics_rollup(summary_date=TEST_DATE)
+rollup_elapsed = time.perf_counter() - start
+print(f"  Duration: {rollup_elapsed:.2f}s")
+
+total_elapsed = snapshot_elapsed + hourly_elapsed + rollup_elapsed
+
+# Summary
+print("\n" + "=" * 70)
+print("Summary")
+print("=" * 70)
+print(f"  Snapshot collectors: {snapshot_elapsed:>8.2f}s")
+print(f"  Hourly collection  : {hourly_elapsed:>8.1f}s ({hourly_elapsed / 60:.1f} min)")
+print(f"  Daily rollup       : {rollup_elapsed:>8.2f}s")
+print(f"  Total              : {total_elapsed:>8.1f}s ({total_elapsed / 60:.1f} min)")
+print()

--- a/metrics_service/tools/performance_tests/results_large_jenkins.txt
+++ b/metrics_service/tools/performance_tests/results_large_jenkins.txt
@@ -1,0 +1,136 @@
+28 objects imported automatically (use -v 2 for details).
+
+======================================================================
+Metrics Service Pipeline Benchmark (manage.py)
+======================================================================
+  Test date : 2024-01-25
+
+======================================================================
+Phase 1: Snapshot collectors (run once each)
+======================================================================
+  Collector                             Duration
+  ---------                             --------
+  execution_environments                  0.59s
+  config                                  0.01s
+  controller_version_service              0.00s
+  table_metadata                          0.27s
+
+  Total: 0.9s
+
+======================================================================
+Phase 2: Hourly collectors (24 hours x 4 collectors)
+======================================================================
+  Hour   Collector                             Duration
+  ----   ---------                             --------
+  0      job_host_summary_service                0.08s
+  0      unified_jobs                            0.17s
+  0      credentials_service                     0.01s
+  0      main_jobevent_service                   0.04s
+  1      job_host_summary_service                0.14s
+  1      unified_jobs                            0.39s
+  1      credentials_service                     0.01s
+  1      main_jobevent_service                   0.04s
+  2      job_host_summary_service                0.20s
+  2      unified_jobs                            0.49s
+  2      credentials_service                     0.01s
+  2      main_jobevent_service                   0.04s
+  3      job_host_summary_service                0.24s
+  3      unified_jobs                            0.55s
+  3      credentials_service                     0.01s
+  3      main_jobevent_service                   0.04s
+  4      job_host_summary_service                0.20s
+  4      unified_jobs                            0.50s
+  4      credentials_service                     0.01s
+  4      main_jobevent_service                   0.04s
+  5      job_host_summary_service                0.20s
+  5      unified_jobs                            0.39s
+  5      credentials_service                     0.01s
+  5      main_jobevent_service                   0.04s
+  6      job_host_summary_service                0.23s
+  6      unified_jobs                            0.50s
+  6      credentials_service                     0.01s
+  6      main_jobevent_service                   0.04s
+  7      job_host_summary_service                0.17s
+  7      unified_jobs                            0.46s
+  7      credentials_service                     0.01s
+  7      main_jobevent_service                   0.04s
+  8      job_host_summary_service                0.19s
+  8      unified_jobs                            0.48s
+  8      credentials_service                     0.01s
+  8      main_jobevent_service                   0.04s
+  9      job_host_summary_service                0.15s
+  9      unified_jobs                            0.40s
+  9      credentials_service                     0.01s
+  9      main_jobevent_service                   0.04s
+  10     job_host_summary_service                0.19s
+  10     unified_jobs                            0.47s
+  10     credentials_service                     0.01s
+  10     main_jobevent_service                   0.04s
+  11     job_host_summary_service                0.18s
+  11     unified_jobs                            0.45s
+  11     credentials_service                     0.01s
+  11     main_jobevent_service                   0.04s
+  12     job_host_summary_service                0.21s
+  12     unified_jobs                            0.50s
+  12     credentials_service                     0.01s
+  12     main_jobevent_service                   0.04s
+  13     job_host_summary_service                0.16s
+  13     unified_jobs                            0.41s
+  13     credentials_service                     0.01s
+  13     main_jobevent_service                   0.04s
+  14     job_host_summary_service                0.19s
+  14     unified_jobs                            0.49s
+  14     credentials_service                     0.01s
+  14     main_jobevent_service                   0.04s
+  15     job_host_summary_service                0.19s
+  15     unified_jobs                            0.48s
+  15     credentials_service                     0.01s
+  15     main_jobevent_service                   0.04s
+  16     job_host_summary_service                0.16s
+  16     unified_jobs                            0.41s
+  16     credentials_service                     0.01s
+  16     main_jobevent_service                   0.04s
+  17     job_host_summary_service                0.19s
+  17     unified_jobs                            0.47s
+  17     credentials_service                     0.01s
+  17     main_jobevent_service                   0.04s
+  18     job_host_summary_service                0.19s
+  18     unified_jobs                            0.51s
+  18     credentials_service                     0.01s
+  18     main_jobevent_service                   0.04s
+  19     job_host_summary_service                0.21s
+  19     unified_jobs                            0.51s
+  19     credentials_service                     0.01s
+  19     main_jobevent_service                   0.04s
+  20     job_host_summary_service                0.20s
+  20     unified_jobs                            0.50s
+  20     credentials_service                     0.01s
+  20     main_jobevent_service                   0.04s
+  21     job_host_summary_service                0.16s
+  21     unified_jobs                            0.43s
+  21     credentials_service                     0.01s
+  21     main_jobevent_service                   0.04s
+  22     job_host_summary_service                0.15s
+  22     unified_jobs                            0.41s
+  22     credentials_service                     0.01s
+  22     main_jobevent_service                   0.04s
+  23     job_host_summary_service                0.06s
+  23     unified_jobs                            0.12s
+  23     credentials_service                     0.01s
+  23     main_jobevent_service                   0.03s
+
+  Total: 15.8s (0.3 min)
+
+======================================================================
+Phase 3: Daily rollup
+======================================================================
+  Duration: 3.33s
+
+======================================================================
+Summary
+======================================================================
+  Snapshot collectors:     0.87s
+  Hourly collection  :     15.8s (0.3 min)
+  Daily rollup       :     3.33s
+  Total              :     20.0s (0.3 min)
+

--- a/metrics_service/tools/performance_tests/results_medium_jenkins.txt
+++ b/metrics_service/tools/performance_tests/results_medium_jenkins.txt
@@ -1,0 +1,136 @@
+28 objects imported automatically (use -v 2 for details).
+
+======================================================================
+Metrics Service Pipeline Benchmark (manage.py)
+======================================================================
+  Test date : 2024-01-25
+
+======================================================================
+Phase 1: Snapshot collectors (run once each)
+======================================================================
+  Collector                             Duration
+  ---------                             --------
+  execution_environments                  0.61s
+  config                                  0.01s
+  controller_version_service              0.00s
+  table_metadata                          0.27s
+
+  Total: 0.9s
+
+======================================================================
+Phase 2: Hourly collectors (24 hours x 4 collectors)
+======================================================================
+  Hour   Collector                             Duration
+  ----   ---------                             --------
+  0      job_host_summary_service                0.05s
+  0      unified_jobs                            0.11s
+  0      credentials_service                     0.01s
+  0      main_jobevent_service                   0.04s
+  1      job_host_summary_service                0.06s
+  1      unified_jobs                            0.23s
+  1      credentials_service                     0.01s
+  1      main_jobevent_service                   0.05s
+  2      job_host_summary_service                0.08s
+  2      unified_jobs                            0.25s
+  2      credentials_service                     0.01s
+  2      main_jobevent_service                   0.04s
+  3      job_host_summary_service                0.09s
+  3      unified_jobs                            0.31s
+  3      credentials_service                     0.01s
+  3      main_jobevent_service                   0.04s
+  4      job_host_summary_service                0.08s
+  4      unified_jobs                            0.22s
+  4      credentials_service                     0.01s
+  4      main_jobevent_service                   0.04s
+  5      job_host_summary_service                0.06s
+  5      unified_jobs                            0.24s
+  5      credentials_service                     0.01s
+  5      main_jobevent_service                   0.04s
+  6      job_host_summary_service                0.08s
+  6      unified_jobs                            0.24s
+  6      credentials_service                     0.01s
+  6      main_jobevent_service                   0.04s
+  7      job_host_summary_service                0.07s
+  7      unified_jobs                            0.26s
+  7      credentials_service                     0.01s
+  7      main_jobevent_service                   0.04s
+  8      job_host_summary_service                0.07s
+  8      unified_jobs                            0.23s
+  8      credentials_service                     0.01s
+  8      main_jobevent_service                   0.04s
+  9      job_host_summary_service                0.07s
+  9      unified_jobs                            0.24s
+  9      credentials_service                     0.01s
+  9      main_jobevent_service                   0.04s
+  10     job_host_summary_service                0.07s
+  10     unified_jobs                            0.23s
+  10     credentials_service                     0.01s
+  10     main_jobevent_service                   0.04s
+  11     job_host_summary_service                0.07s
+  11     unified_jobs                            0.24s
+  11     credentials_service                     0.01s
+  11     main_jobevent_service                   0.04s
+  12     job_host_summary_service                0.07s
+  12     unified_jobs                            0.22s
+  12     credentials_service                     0.01s
+  12     main_jobevent_service                   0.04s
+  13     job_host_summary_service                0.06s
+  13     unified_jobs                            0.23s
+  13     credentials_service                     0.01s
+  13     main_jobevent_service                   0.04s
+  14     job_host_summary_service                0.08s
+  14     unified_jobs                            0.23s
+  14     credentials_service                     0.01s
+  14     main_jobevent_service                   0.04s
+  15     job_host_summary_service                0.08s
+  15     unified_jobs                            0.30s
+  15     credentials_service                     0.01s
+  15     main_jobevent_service                   0.04s
+  16     job_host_summary_service                0.07s
+  16     unified_jobs                            0.19s
+  16     credentials_service                     0.01s
+  16     main_jobevent_service                   0.04s
+  17     job_host_summary_service                0.07s
+  17     unified_jobs                            0.26s
+  17     credentials_service                     0.01s
+  17     main_jobevent_service                   0.04s
+  18     job_host_summary_service                0.08s
+  18     unified_jobs                            0.23s
+  18     credentials_service                     0.01s
+  18     main_jobevent_service                   0.04s
+  19     job_host_summary_service                0.09s
+  19     unified_jobs                            0.31s
+  19     credentials_service                     0.01s
+  19     main_jobevent_service                   0.04s
+  20     job_host_summary_service                0.08s
+  20     unified_jobs                            0.28s
+  20     credentials_service                     0.01s
+  20     main_jobevent_service                   0.04s
+  21     job_host_summary_service                0.07s
+  21     unified_jobs                            0.19s
+  21     credentials_service                     0.01s
+  21     main_jobevent_service                   0.04s
+  22     job_host_summary_service                0.06s
+  22     unified_jobs                            0.19s
+  22     credentials_service                     0.01s
+  22     main_jobevent_service                   0.04s
+  23     job_host_summary_service                0.08s
+  23     unified_jobs                            0.08s
+  23     credentials_service                     0.01s
+  23     main_jobevent_service                   0.04s
+
+  Total: 8.3s (0.1 min)
+
+======================================================================
+Phase 3: Daily rollup
+======================================================================
+  Duration: 2.83s
+
+======================================================================
+Summary
+======================================================================
+  Snapshot collectors:     0.89s
+  Hourly collection  :      8.3s (0.1 min)
+  Daily rollup       :     2.83s
+  Total              :     12.1s (0.2 min)
+

--- a/metrics_service/tools/performance_tests/results_small_jenkins.txt
+++ b/metrics_service/tools/performance_tests/results_small_jenkins.txt
@@ -1,0 +1,136 @@
+28 objects imported automatically (use -v 2 for details).
+
+======================================================================
+Metrics Service Pipeline Benchmark (manage.py)
+======================================================================
+  Test date : 2024-01-25
+
+======================================================================
+Phase 1: Snapshot collectors (run once each)
+======================================================================
+  Collector                             Duration
+  ---------                             --------
+  execution_environments                  0.93s
+  config                                  0.03s
+  controller_version_service              0.01s
+  table_metadata                          0.32s
+
+  Total: 1.3s
+
+======================================================================
+Phase 2: Hourly collectors (24 hours x 4 collectors)
+======================================================================
+  Hour   Collector                             Duration
+  ----   ---------                             --------
+  0      job_host_summary_service                0.04s
+  0      unified_jobs                            0.06s
+  0      credentials_service                     0.01s
+  0      main_jobevent_service                   0.04s
+  1      job_host_summary_service                0.04s
+  1      unified_jobs                            0.06s
+  1      credentials_service                     0.01s
+  1      main_jobevent_service                   0.04s
+  2      job_host_summary_service                0.04s
+  2      unified_jobs                            0.07s
+  2      credentials_service                     0.01s
+  2      main_jobevent_service                   0.03s
+  3      job_host_summary_service                0.04s
+  3      unified_jobs                            0.08s
+  3      credentials_service                     0.01s
+  3      main_jobevent_service                   0.04s
+  4      job_host_summary_service                0.04s
+  4      unified_jobs                            0.07s
+  4      credentials_service                     0.01s
+  4      main_jobevent_service                   0.03s
+  5      job_host_summary_service                0.03s
+  5      unified_jobs                            0.05s
+  5      credentials_service                     0.01s
+  5      main_jobevent_service                   0.03s
+  6      job_host_summary_service                0.04s
+  6      unified_jobs                            0.07s
+  6      credentials_service                     0.01s
+  6      main_jobevent_service                   0.08s
+  7      job_host_summary_service                0.03s
+  7      unified_jobs                            0.05s
+  7      credentials_service                     0.01s
+  7      main_jobevent_service                   0.03s
+  8      job_host_summary_service                0.04s
+  8      unified_jobs                            0.07s
+  8      credentials_service                     0.01s
+  8      main_jobevent_service                   0.03s
+  9      job_host_summary_service                0.04s
+  9      unified_jobs                            0.07s
+  9      credentials_service                     0.01s
+  9      main_jobevent_service                   0.04s
+  10     job_host_summary_service                0.04s
+  10     unified_jobs                            0.08s
+  10     credentials_service                     0.01s
+  10     main_jobevent_service                   0.04s
+  11     job_host_summary_service                0.04s
+  11     unified_jobs                            0.06s
+  11     credentials_service                     0.01s
+  11     main_jobevent_service                   0.03s
+  12     job_host_summary_service                0.03s
+  12     unified_jobs                            0.05s
+  12     credentials_service                     0.01s
+  12     main_jobevent_service                   0.04s
+  13     job_host_summary_service                0.03s
+  13     unified_jobs                            0.05s
+  13     credentials_service                     0.01s
+  13     main_jobevent_service                   0.04s
+  14     job_host_summary_service                0.04s
+  14     unified_jobs                            0.06s
+  14     credentials_service                     0.01s
+  14     main_jobevent_service                   0.03s
+  15     job_host_summary_service                0.04s
+  15     unified_jobs                            0.07s
+  15     credentials_service                     0.01s
+  15     main_jobevent_service                   0.04s
+  16     job_host_summary_service                0.03s
+  16     unified_jobs                            0.05s
+  16     credentials_service                     0.01s
+  16     main_jobevent_service                   0.03s
+  17     job_host_summary_service                0.03s
+  17     unified_jobs                            0.06s
+  17     credentials_service                     0.01s
+  17     main_jobevent_service                   0.04s
+  18     job_host_summary_service                0.04s
+  18     unified_jobs                            0.07s
+  18     credentials_service                     0.01s
+  18     main_jobevent_service                   0.04s
+  19     job_host_summary_service                0.04s
+  19     unified_jobs                            0.08s
+  19     credentials_service                     0.01s
+  19     main_jobevent_service                   0.04s
+  20     job_host_summary_service                0.04s
+  20     unified_jobs                            0.07s
+  20     credentials_service                     0.01s
+  20     main_jobevent_service                   0.04s
+  21     job_host_summary_service                0.03s
+  21     unified_jobs                            0.06s
+  21     credentials_service                     0.01s
+  21     main_jobevent_service                   0.03s
+  22     job_host_summary_service                0.04s
+  22     unified_jobs                            0.06s
+  22     credentials_service                     0.01s
+  22     main_jobevent_service                   0.04s
+  23     job_host_summary_service                0.03s
+  23     unified_jobs                            0.05s
+  23     credentials_service                     0.01s
+  23     main_jobevent_service                   0.04s
+
+  Total: 3.5s (0.1 min)
+
+======================================================================
+Phase 3: Daily rollup
+======================================================================
+  Duration: 1.09s
+
+======================================================================
+Summary
+======================================================================
+  Snapshot collectors:     1.29s
+  Hourly collection  :      3.5s (0.1 min)
+  Daily rollup       :     1.09s
+  Total              :      5.9s (0.1 min)
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -40,6 +40,6 @@ sonar.issue.ignore.multicriteria.e2.resourceKey=**/tests/**
 sonar.issue.ignore.multicriteria.e3.ruleKey=python:S1192
 sonar.issue.ignore.multicriteria.e3.resourceKey=**/report/**
 
-sonar.cpd.exclusions=**/migrations/*.py,**/tests/**/*.py,**/report/*.py
+sonar.cpd.exclusions=**/migrations/*.py,**/tests/**/*.py,**/report/*.py,**/tools/**/*.py
 sonar.tests.exclusions=tests/**
 sonar.security.hotspots.ignored=**/tests/**


### PR DESCRIPTION
# [AAP-68897] Jenkins pipeline benchmark for collection & rollup

## Description

- Adds `benchmark_manage.py`: runs the full collection + rollup pipeline directly via `manage.py shell` inside the container, for use against Jenkins/production deployments where `ALLOWED_HOSTS=[]` blocks all HTTP API access
- Adds `BENCHMARK_JENKINS.md`: step-by-step instructions for running benchmarks against a Jenkins pipeline AIO deployment
- Adds `RESULTS_JENKINS.md`: results at all three scales

## Results

Collected on a containerized AIO Jenkins deployment (2026-04-07), with data accumulated across scales (no clean between runs due to FK constraints on internal AWX jobs):

| Scale | Generator params | Snapshot | Hourly | Daily rollup | Total |
|-------|-----------------|----------|--------|--------------|-------|
| Small | J=100, T=50, H=16 | 1.29s | 3.5s | 1.09s | 5.9s |
| Medium | J=1000, T=50, H=20 | 0.89s | 8.3s | 2.83s | 12.1s |
| Large | J=2000, T=100, H=40 | 0.87s | 15.8s | 3.33s | 20.0s |

## Test plan

- [x] Small-scale run completed on Jenkins pipeline (2026-04-07)
- [x] Medium-scale run completed on Jenkins pipeline (2026-04-07)
- [x] Large-scale run completed on Jenkins pipeline (2026-04-07)
- Results in `results_small_jenkins.txt`, `results_medium_jenkins.txt`, `results_large_jenkins.txt`, and `RESULTS_JENKINS.md`

