### PR TITLE
[AAP-69218] Segment send failures are silent

### DIFF
--- a/apps/core/views/health.py
+++ b/apps/core/views/health.py
@@ -26,6 +26,18 @@ class HealthView(AnsibleBaseView):
             health_status["status"] = "unhealthy"
             health_status["checks"]["database"] = f"error: {str(e)}"
 
+        # Segment send check
+        try:
+            from apps.tasks.models import AnonymizedMetricsPayload
+            recent_failed = AnonymizedMetricsPayload.objects.filter(status="failed").exists()
+            if recent_failed:
+                health_status["status"] = "unhealthy"
+                health_status["checks"]["segment_send"] = "failed"
+            else:
+                health_status["checks"]["segment_send"] = "ok"
+        except Exception as e:
+            health_status["checks"]["segment_send"] = f"error: {str(e)}"
+
         http_status = (
             status.HTTP_200_OK if health_status["status"] == "healthy" else status.HTTP_503_SERVICE_UNAVAILABLE
         )

--- a/apps/tasks/collectors/send_anonymized_to_segment.py
+++ b/apps/tasks/collectors/send_anonymized_to_segment.py
@@ -67,18 +67,36 @@ def _handle_successful_send(payload, results: dict) -> None:
         logger.warning(f"Failed to update daily_summary for payload {payload.id}: {summary_error}")
 
 
-def _handle_failed_send(payload, segment_status: str, results: dict) -> None:
+def _handle_failed_send(payload, segment_result: dict, results: dict) -> None:
     """
     Handle failed payload send to Segment.
 
     Args:
         payload: AnonymizedMetricsPayload object
-        segment_status: Status returned from send_to_segment
+        segment_result: Result dict from send_to_segment
         results: Results dictionary to update
     """
-    payload.status = "retry"
+    error_category = segment_result.get("data", {}).get("error_category", "unknown_error")
+    error_detail = segment_result.get("data", {}).get("error_detail", "Unknown error")
+
     payload.retry_count += 1
-    payload.error_message = f"Send failed: {segment_status}"
+    payload.error_message = f"Send failed: {error_detail}"
+
+    details = f"payload_id: {payload.id}, summary_date: {payload.summary_date}, " + \
+        f"retry_count: {payload.retry_count}, error_category: {error_category}, error_detail: {error_detail}"
+
+    if payload.retry_count >= payload.max_retries:
+        # Log an error if we are past the maximum retry limit, else, log a warning about the retry
+        payload.status = "failed"
+        logger.error(
+            f"Segment send failed, not retrying, details:\n {details}"
+        )
+    else:
+        payload.status = "retry"
+        logger.warning(
+            f"Segment send failed, retrying, details:\n {details}"
+        )
+
     payload.save()
     results["failed"] += 1
 
@@ -118,7 +136,7 @@ def _process_single_payload(payload, results: dict) -> None:
         # hashed on the other side, with chunk index
         message_id = str(payload.created)
 
-        segment_status = send_to_segment(
+        segment_result = send_to_segment(
             user_id=payload.segment_user_id,
             event_name=event_name,
             segment_data=payload.anonymized_data,
@@ -128,21 +146,21 @@ def _process_single_payload(payload, results: dict) -> None:
             },
         )
 
-        if segment_status == "success":
+        if segment_result["status"] == "success":
             _handle_successful_send(payload, results)
         else:
-            _handle_failed_send(payload, segment_status, results)
+            _handle_failed_send(payload, segment_result, results)
 
     except Exception as e:
         logger.error(f"Error sending payload {payload.id}: {str(e)}")
-        payload.status = "retry"
-        payload.retry_count += 1
-        payload.error_message = str(e)
-        payload.save()
-        results["failed"] += 1
+        error_result = create_task_result(
+            "error",
+            data={"error_category": "unknown_error", "error_detail": str(e)}
+        )
+        _handle_failed_send(payload, error_result, results)
 
 
-def send_to_segment(user_id: str, event_name: str, segment_data: dict, segment_meta: dict = None) -> str:
+def send_to_segment(user_id: str, event_name: str, segment_data: dict, segment_meta: dict = None) -> dict:
     """
     Send data to Segment.com using metrics-utility StorageSegment.
 
@@ -152,17 +170,22 @@ def send_to_segment(user_id: str, event_name: str, segment_data: dict, segment_m
         segment_data: Dictionary of data to send
 
     Returns:
-        str: "success" if sent, "segment_not_available" if Segment is not configured,
-             or "error: <message>" if sending failed.
+        dict: Task result with status, error_category, and error_detail
     """
     try:
         from metrics_utility.library.storage.segment import SEGMENT_AVAILABLE, StorageSegment
     except ImportError:
         logger.warning("metrics-utility segment integration not available")
-        return "segment_not_available"
+        return create_task_result(
+            "error",
+            data={"error_category": "segment_unavailable", "error_detail": "segment_not_available"}
+        )
 
     if not SEGMENT_AVAILABLE or StorageSegment is None:
-        return "segment_not_available"
+        return create_task_result(
+            "error",
+            data={"error_category": "segment_unavailable", "error_detail": "segment_not_available"}
+        )
 
     try:
         import json
@@ -173,7 +196,10 @@ def send_to_segment(user_id: str, event_name: str, segment_data: dict, segment_m
         write_key = getattr(settings, "SEGMENT_WRITE_KEY", None)
         if not write_key:
             logger.warning("SEGMENT_WRITE_KEY not configured in settings")
-            return "segment_not_available"
+            return create_task_result(
+                "error",
+                data={"error_category": "auth_error", "error_detail": "SEGMENT_WRITE_KEY not configured in settings"}
+            )
 
         # Calculate data size for logging
         data_size = len(json.dumps(segment_data).encode("utf-8"))
@@ -201,11 +227,15 @@ def send_to_segment(user_id: str, event_name: str, segment_data: dict, segment_m
         # Log success with chunk information
         chunk_count = len(chunks) if chunks else 1
         logger.info(f"Successfully sent metrics to Segment.com (Size: {data_size} bytes, Chunks: {chunk_count})")
-        return "success"
+        return create_task_result("success", data={"chunks_sent": chunk_count, "data_size_bytes": data_size})
 
     except Exception as e:
         logger.error(f"Error sending data to Segment.com: {str(e)}")
-        return f"error: {str(e)}"
+        error_category = "network_error" if any(term in str(e).lower() for term in ["network", "timeout", "connection"]) else "unknown_error"
+        return create_task_result(
+            "error",
+            data={"error_category": error_category, "error_detail": str(e)}
+        )
 
 
 def send_anonymized_to_segment(**kwargs) -> dict[str, Any]:

--- a/tests/unit/general/test_health_metrics.py
+++ b/tests/unit/general/test_health_metrics.py
@@ -38,6 +38,24 @@ class TestHealthEndpoint:
         assert json_response["status"] == "healthy"
         assert response.status_code == status.HTTP_200_OK
 
+    def test_health_check_includes_segment_send_status_when_no_failures(self, client, db):
+        """Test that health endpoint includes segment_send check when no failed payloads."""
+        response = client.get("/health/")
+        json_response = response.json()
+        assert json_response["status"] == "healthy"
+        assert json_response["checks"]["segment_send"] == "ok"
+
+    def test_health_check_fails_when_segment_payloads_failed(self, client, anonymized_payload_factory):
+        """Test that health endpoint reports unhealthy when failed segment payloads exist."""
+        # Create a failed payload
+        anonymized_payload_factory(status="failed", retry_count=3)
+
+        response = client.get("/health/")
+        json_response = response.json()
+        assert json_response["status"] == "unhealthy"
+        assert json_response["checks"]["segment_send"] == "failed"
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
 
 @pytest.mark.unit
 class TestMetricsEndpoint:

--- a/tests/unit/tasks/collectors/test_send_anonymized_to_segment.py
+++ b/tests/unit/tasks/collectors/test_send_anonymized_to_segment.py
@@ -17,6 +17,7 @@ from apps.tasks.collectors.send_anonymized_to_segment import (
     _handle_successful_send,
     _process_single_payload,
     send_anonymized_to_segment,
+    send_to_segment,
 )
 
 # ---------------------------------------------------------------------------
@@ -45,7 +46,7 @@ class TestSegmentTestMode:
     def test_test_mode_enabled_appends_test_suffix(self, mock_send_to_segment, settings):
         """When SEGMENT_TEST_MODE=True, '_Test' is appended to the event name."""
         settings.SEGMENT_TEST_MODE = True
-        mock_send_to_segment.return_value = "success"
+        mock_send_to_segment.return_value = {"status": "success", "data": {}}
 
         payload = self._make_payload("Controller Metrics Daily Rollup")
         results = {"sent": 0, "failed": 0, "skipped": 0, "recovered": 0}
@@ -61,7 +62,7 @@ class TestSegmentTestMode:
     def test_test_mode_disabled_keeps_original_event_name(self, mock_send_to_segment, settings):
         """When SEGMENT_TEST_MODE=False, the event name is sent unchanged."""
         settings.SEGMENT_TEST_MODE = False
-        mock_send_to_segment.return_value = "success"
+        mock_send_to_segment.return_value = {"status": "success", "data": {}}
 
         payload = self._make_payload("Controller Metrics Daily Rollup")
         results = {"sent": 0, "failed": 0, "skipped": 0, "recovered": 0}
@@ -79,7 +80,7 @@ class TestSegmentTestMode:
         # Remove the attribute if it exists so getattr falls back to the default
         if hasattr(settings, "SEGMENT_TEST_MODE"):
             delattr(settings, "SEGMENT_TEST_MODE")
-        mock_send_to_segment.return_value = "success"
+        mock_send_to_segment.return_value = {"status": "success", "data": {}}
 
         payload = self._make_payload("My Event")
         results = {"sent": 0, "failed": 0, "skipped": 0, "recovered": 0}
@@ -143,13 +144,15 @@ class TestHandleFailedSend:
 
     def test_sets_retry_status_and_increments_retry_count(self):
         payload = MagicMock()
-        payload.retry_count = 2
+        payload.retry_count = 1
+        payload.max_retries = 3
         results = {"sent": 0, "failed": 0, "skipped": 0, "recovered": 0}
 
-        _handle_failed_send(payload, "timeout", results)
+        segment_result = {"status": "error", "data": {"error_category": "network_error", "error_detail": "timeout"}}
+        _handle_failed_send(payload, segment_result, results)
 
         assert payload.status == "retry"
-        assert payload.retry_count == 3
+        assert payload.retry_count == 2
         assert "timeout" in payload.error_message
         payload.save.assert_called_once()
         assert results["failed"] == 1
@@ -190,7 +193,7 @@ class TestSendAnonymizedToSegmentTask:
     def test_processes_each_payload(self, mock_get_payloads, mock_send_to_segment, settings):
         """All payloads in the list are processed and sent."""
         settings.SEGMENT_TEST_MODE = False
-        mock_send_to_segment.return_value = "success"
+        mock_send_to_segment.return_value = {"status": "success", "data": {}}
 
         def make_payload(pid: int) -> MagicMock:
             p = MagicMock()
@@ -211,3 +214,58 @@ class TestSendAnonymizedToSegmentTask:
         assert result["status"] == "success"
         assert result["results"]["sent"] == 2
         assert result["total_processed"] == 2
+
+
+# ---------------------------------------------------------------------------
+# send_to_segment structured results
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSendToSegmentStructured:
+    """Tests for send_to_segment structured error handling."""
+
+    @patch("apps.tasks.collectors.send_anonymized_to_segment.settings")
+    def test_missing_write_key_returns_auth_error(self, mock_settings):
+        """When SEGMENT_WRITE_KEY is missing, returns auth error."""
+        mock_settings.SEGMENT_WRITE_KEY = None
+
+        result = send_to_segment("user-123", "test_event", {"data": "test"})
+
+        assert result["status"] == "error"
+        assert result["error_category"] == "auth_error"
+        assert "SEGMENT_WRITE_KEY not configured" in result["error_detail"]
+
+    @patch("metrics_utility.library.storage.segment.StorageSegment")
+    def test_network_error_categorized_correctly(self, mock_storage_class, settings):
+        """When network error occurs, categorizes as network_error."""
+        settings.SEGMENT_WRITE_KEY = "test-key"
+        mock_storage_instance = MagicMock()
+        mock_storage_class.return_value = mock_storage_instance
+        mock_storage_instance.put.side_effect = Exception("timeout occurred")
+
+        result = send_to_segment("user-123", "test_event", {"data": "test"})
+
+        assert result["status"] == "error"
+        assert result["error_category"] == "network_error"
+        assert "timeout occurred" in result["error_detail"]
+    
+    @patch("apps.tasks.collectors.send_anonymized_to_segment.logger")
+    def test_logs_error_when_retries_exhausted(self, mock_logger):
+        """Logs ERROR with structured fields when max retries reached."""
+        # In an above test, we already test what happens when max retries hasn't been reached
+        payload = MagicMock()
+        payload.id = 123
+        payload.summary_date = "2024-01-01"
+        payload.retry_count = 2
+        payload.max_retries = 3
+        results = {"sent": 0, "failed": 0, "skipped": 0, "recovered": 0}
+
+        segment_result = {"status": "error", "data": {"error_category": "auth_error", "error_detail": "Invalid key"}}
+        _handle_failed_send(payload, segment_result, results)
+
+        mock_logger.error.assert_called_once()
+        log_call = mock_logger.error.call_args[0][0]
+        assert "not retrying" in log_call
+        assert "payload_id: 123" in log_call
+        assert "error_category: auth_error" in log_call


### PR DESCRIPTION
# [AAP-69218] Segment send failures are silent

## AI disclosure: I used an LLM to write the unit tests, which I then modified where I saw fit. The actual code changes were not generated

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - Removed the simple error logging in favor of the `create_task_result` convention other tasks use
  - Add health endpoint check which returns unhealthy status when the latest `send_to_segment` task fails
  - Adds unit tests (majority of changes..) for each of these behaviors, as well as modifies existing tests to match the new changes
- Why is this change needed?
  - We are unable to tell whether or not a Segment failure is due to an actual issue, or, just needs a retry before it works again, we need to be able to tell the difference between failures, and know when there is a fleet-wide issue
- How does this change address the issue?
  - We now return the result of `create_task_result` based on the type of error reached. If there are retries left, based on `max_retries` in the payload, we instead log a warning. This warning is still more verbose than before
  - We now also update the health status depending on the result of the latest `send_to_segment` task result

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
