### PR TITLE
[AAP-69250] Implement template metadata API endpoints

### DIFF
--- a/apps/dashboard_reports/serializers.py
+++ b/apps/dashboard_reports/serializers.py
@@ -3,7 +3,7 @@ from typing import Any
 from dateutil.relativedelta import relativedelta
 from rest_framework import serializers
 
-from apps.dashboard_reports.models import JobData
+from apps.dashboard_reports.models import JobData, TemplateMetadata
 
 
 def sec2time(sec: int) -> str:
@@ -210,3 +210,21 @@ class ReportDetailSerializer(serializers.Serializer):
 
     def get_total_time_saving(self, obj: dict[str, Any]) -> float:
         return self._get_rounded_value(obj, "total_time_savings", divisor=3600)
+
+
+class TemplateMetadataSerializer(serializers.ModelSerializer):
+    template_id = serializers.IntegerField(read_only=True, help_text="ID of the associated job template")
+    time_taken_manually_execute_minutes = serializers.IntegerField(
+        allow_null=True, min_value=0, help_text="User override: Estimated time to perform this task manually (minutes)"
+    )
+    time_taken_create_automation_minutes = serializers.IntegerField(
+        allow_null=True, min_value=0, help_text="User override: Estimated time spent creating this automation (minutes)"
+    )
+
+    class Meta:
+        model = TemplateMetadata
+        fields = [
+            "template_id",
+            "time_taken_manually_execute_minutes",
+            "time_taken_create_automation_minutes",
+        ]

--- a/apps/dashboard_reports/urls.py
+++ b/apps/dashboard_reports/urls.py
@@ -7,6 +7,7 @@ from apps.dashboard_reports.viewsets import (
     LabelsViewSet,
     OrganizationsViewSet,
     ProjectsViewSet,
+    TemplateMetadataViewSet,
 )
 
 app_name = "dashboard_reports"
@@ -18,7 +19,20 @@ router.register(r"projects", ProjectsViewSet, basename="projects")
 router.register(r"labels", LabelsViewSet, basename="labels")
 router.register(r"report", DashboardReportViewSet, basename="report")
 
+# TemplateMetadataViewSet doesn't fit the standard router pattern, so we define its URL separately
+#   * standard router pattern example: /api/v1/dashboard_reports/templates/metadata/{id}/
+#   * what we want is: /api/v1/dashboard_reports/templates/{id}/metadata/
+metadata_view = TemplateMetadataViewSet.as_view(
+    {
+        "get": "retrieve",
+        "put": "update",
+        "patch": "partial_update",
+        "delete": "destroy",
+    }
+)
+
 urlpatterns = [
     # Dashboard report endpoints at /api/v1/
+    path("api/v1/dashboard_reports/templates/<int:pk>/metadata/", metadata_view, name="template-metadata"),
     path("api/v1/dashboard_reports/", include(router.urls)),
 ]

--- a/apps/dashboard_reports/viewsets/__init__.py
+++ b/apps/dashboard_reports/viewsets/__init__.py
@@ -4,6 +4,7 @@ from .job_templates import JobTemplatesViewSet
 from .labels import LabelsViewSet
 from .organizations import OrganizationsViewSet
 from .projects import ProjectsViewSet
+from .template_metadata import TemplateMetadataViewSet
 
 __all__ = [
     "FilterOptionsViewSet",
@@ -12,4 +13,5 @@ __all__ = [
     "ProjectsViewSet",
     "LabelsViewSet",
     "DashboardReportViewSet",
+    "TemplateMetadataViewSet",
 ]

--- a/apps/dashboard_reports/viewsets/template_metadata.py
+++ b/apps/dashboard_reports/viewsets/template_metadata.py
@@ -1,0 +1,42 @@
+from django.db.models import QuerySet
+from rest_framework.mixins import DestroyModelMixin, RetrieveModelMixin, UpdateModelMixin
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import GenericViewSet
+
+from apps.core.permissions import DeveloperModeRequired
+from apps.dashboard_reports.models import TemplateMetadata
+from apps.dashboard_reports.serializers import TemplateMetadataSerializer
+
+
+class TemplateMetadataViewSet(RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin, GenericViewSet):
+    """
+    ViewSet for retrieving template metadata from metrics service database.
+
+    Endpoints:
+        GET    api/metrics/v1/automation-dashboard/templates/{id}/metadata/ - Get template metadata
+        PUT    api/metrics/v1/automation-dashboard/templates/{id}/metadata/ - Update template metadata
+        PATCH    api/metrics/v1/automation-dashboard/templates/{id}/metadata/ - Partially update template metadata
+        DELETE api/metrics/v1/automation-dashboard/templates/{id}/metadata/ - Template reverts to system defaults
+    """
+
+    permission_classes = [IsAuthenticated, DeveloperModeRequired]
+    versioning_class = None
+    pagination_class = None
+    serializer_class = TemplateMetadataSerializer
+    lookup_field = "template_id"
+    lookup_url_kwarg = "pk"
+
+    def get_queryset(self) -> QuerySet[TemplateMetadata]:
+        return TemplateMetadata.objects.all()
+
+    def perform_destroy(self, instance: TemplateMetadata) -> None:
+        """Clear user overrides, reverting the template to system defaults."""
+
+        instance.time_taken_manually_execute_minutes = None
+        instance.time_taken_create_automation_minutes = None
+        instance.save(
+            update_fields=[
+                "time_taken_manually_execute_minutes",
+                "time_taken_create_automation_minutes",
+            ]
+        )

--- a/tests/integration/dashboard_reports/test_template_metadata_db.py
+++ b/tests/integration/dashboard_reports/test_template_metadata_db.py
@@ -1,0 +1,190 @@
+"""
+DB-backed tests for TemplateMetadataViewSet.
+
+These tests verify the full round-trip: the viewset actually persists changes
+and reverts to system defaults correctly. No mocking of ORM calls.
+"""
+
+import pytest
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.core.models import User
+from apps.dashboard_reports.models import TemplateMetadata
+
+
+def _create_metadata(
+    template_id: int = 42,
+    template_name: str = "Test Template",
+    time_taken_manually_execute_minutes: int | None = 30,
+    time_taken_create_automation_minutes: int | None = 60,
+) -> TemplateMetadata:
+    return TemplateMetadata.objects.create(
+        template_id=template_id,
+        template_name=template_name,
+        time_taken_manually_execute_minutes=time_taken_manually_execute_minutes,
+        time_taken_create_automation_minutes=time_taken_create_automation_minutes,
+    )
+
+
+def _url(pk: int) -> str:
+    return reverse("dashboard_reports:template-metadata", kwargs={"pk": pk})
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+@override_settings(MODE="development")
+class TestTemplateMetadataPutPatchDb(TestCase):
+    """Verify PUT actually persists updated values to the DB."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="testuser", password="pass")
+        self.client.force_authenticate(user=self.user)
+        self.instance = _create_metadata()
+
+    def test_put_updates_time_fields_in_db(self):
+        response = self.client.put(
+            _url(self.instance.template_id),
+            data={
+                "time_taken_manually_execute_minutes": 99,
+                "time_taken_create_automation_minutes": 199,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        self.instance.refresh_from_db()
+        assert self.instance.time_taken_manually_execute_minutes == 99
+        assert self.instance.time_taken_create_automation_minutes == 199
+
+    def test_put_response_reflects_updated_values(self):
+        response = self.client.put(
+            _url(self.instance.template_id),
+            data={
+                "time_taken_manually_execute_minutes": 55,
+                "time_taken_create_automation_minutes": 110,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["time_taken_manually_execute_minutes"] == 55
+        assert response.data["time_taken_create_automation_minutes"] == 110
+
+    def test_put_with_null_sets_fields_to_null_in_db(self):
+        response = self.client.put(
+            _url(self.instance.template_id),
+            data={
+                "time_taken_manually_execute_minutes": None,
+                "time_taken_create_automation_minutes": None,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        self.instance.refresh_from_db()
+        assert self.instance.time_taken_manually_execute_minutes is None
+        assert self.instance.time_taken_create_automation_minutes is None
+
+    def test_put_does_not_change_template_id(self):
+        original_template_id = self.instance.template_id
+
+        self.client.put(
+            _url(self.instance.template_id),
+            data={
+                "template_id": 999,
+                "time_taken_manually_execute_minutes": 10,
+                "time_taken_create_automation_minutes": 20,
+            },
+            format="json",
+        )
+
+        self.instance.refresh_from_db()
+        assert self.instance.template_id == original_template_id
+
+    def test_put_returns_404_for_nonexistent_pk(self):
+        response = self.client.put(
+            _url(99999),
+            data={
+                "time_taken_manually_execute_minutes": 10,
+                "time_taken_create_automation_minutes": 20,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_patch_updates_only_provided_field(self):
+        response = self.client.patch(
+            _url(self.instance.template_id),
+            data={
+                "time_taken_manually_execute_minutes": 77,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        self.instance.refresh_from_db()
+        assert self.instance.time_taken_manually_execute_minutes == 77
+        assert self.instance.time_taken_create_automation_minutes == 60  # unchanged
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+@override_settings(MODE="development")
+class TestTemplateMetadataDeleteDb(TestCase):
+    """Verify DELETE reverts overrides to NULL (system defaults) without deleting the record."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(username="testuser", password="pass")
+        self.client.force_authenticate(user=self.user)
+        self.instance = _create_metadata(
+            time_taken_manually_execute_minutes=30,
+            time_taken_create_automation_minutes=60,
+        )
+
+    def test_delete_sets_time_fields_to_null_in_db(self):
+        response = self.client.delete(_url(self.instance.template_id))
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        self.instance.refresh_from_db()
+        assert self.instance.time_taken_manually_execute_minutes is None
+        assert self.instance.time_taken_create_automation_minutes is None
+
+    def test_delete_does_not_remove_the_record(self):
+        pk = self.instance.pk
+        self.client.delete(_url(pk))
+
+        assert TemplateMetadata.objects.filter(pk=pk).exists()
+
+    def test_delete_preserves_template_id_and_name(self):
+        original_template_id = self.instance.template_id
+        original_template_name = self.instance.template_name
+
+        self.client.delete(_url(self.instance.template_id))
+
+        self.instance.refresh_from_db()
+        assert self.instance.template_id == original_template_id
+        assert self.instance.template_name == original_template_name
+
+    def test_get_after_delete_reflects_null_overrides(self):
+        self.client.delete(_url(self.instance.template_id))
+
+        response = self.client.get(_url(self.instance.template_id))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["time_taken_manually_execute_minutes"] is None
+        assert response.data["time_taken_create_automation_minutes"] is None
+
+    def test_delete_returns_404_for_nonexistent_pk(self):
+        response = self.client.delete(_url(99999))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/unit/dashboard_reports/test_template_metadata.py
+++ b/tests/unit/dashboard_reports/test_template_metadata.py
@@ -1,0 +1,363 @@
+"""
+Unit tests for TemplateMetadata viewset, serializer, and URL routing.
+All DB interaction is mocked — no real writes occur.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import TestCase, override_settings
+from django.urls import resolve, reverse
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+
+from apps.dashboard_reports.models import TemplateMetadata
+from apps.dashboard_reports.serializers import TemplateMetadataSerializer
+from apps.dashboard_reports.viewsets.template_metadata import TemplateMetadataViewSet
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_mock_instance(
+    pk: int = 1,
+    template_id: int = 42,
+    time_taken_manually_execute_minutes: int | None = 30,
+    time_taken_create_automation_minutes: int | None = 60,
+) -> MagicMock:
+    instance = MagicMock(spec=TemplateMetadata)
+    instance.pk = pk
+    instance.template_id = template_id
+    instance.time_taken_manually_execute_minutes = time_taken_manually_execute_minutes
+    instance.time_taken_create_automation_minutes = time_taken_create_automation_minutes
+    return instance
+
+
+def _make_request_user(is_authenticated: bool = True) -> MagicMock:
+    user = MagicMock()
+    user.is_authenticated = is_authenticated
+    return user
+
+
+# =============================================================================
+# Serializer tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestTemplateMetadataSerializer(TestCase):
+    def _serializer_data(self, **kwargs) -> dict:
+        return TemplateMetadataSerializer(_make_mock_instance(**kwargs)).data
+
+    def test_contains_expected_fields(self):
+        assert set(self._serializer_data().keys()) == {
+            "template_id",
+            "time_taken_manually_execute_minutes",
+            "time_taken_create_automation_minutes",
+        }
+
+    def test_maps_values_correctly(self):
+        data = self._serializer_data(
+            template_id=99,
+            time_taken_manually_execute_minutes=15,
+            time_taken_create_automation_minutes=45,
+        )
+        assert data["template_id"] == 99
+        assert data["time_taken_manually_execute_minutes"] == 15
+        assert data["time_taken_create_automation_minutes"] == 45
+
+    def test_allows_null_time_fields(self):
+        data = self._serializer_data(
+            time_taken_manually_execute_minutes=None,
+            time_taken_create_automation_minutes=None,
+        )
+        assert data["time_taken_manually_execute_minutes"] is None
+        assert data["time_taken_create_automation_minutes"] is None
+
+    def test_template_id_is_read_only(self):
+        assert TemplateMetadataSerializer().fields["template_id"].read_only is True
+
+    def test_put_payload_cannot_change_template_id(self):
+        payload = {
+            "template_id": 999,
+            "time_taken_manually_execute_minutes": 20,
+            "time_taken_create_automation_minutes": 40,
+        }
+        serializer = TemplateMetadataSerializer(data=payload)
+        assert serializer.is_valid(), serializer.errors
+        assert "template_id" not in serializer.validated_data
+
+    def test_valid_with_complete_payload(self):
+        serializer = TemplateMetadataSerializer(
+            data={
+                "time_taken_manually_execute_minutes": 30,
+                "time_taken_create_automation_minutes": 60,
+            }
+        )
+        assert serializer.is_valid(), serializer.errors
+
+    def test_valid_with_null_time_fields(self):
+        serializer = TemplateMetadataSerializer(
+            data={
+                "time_taken_manually_execute_minutes": None,
+                "time_taken_create_automation_minutes": None,
+            }
+        )
+        assert serializer.is_valid(), serializer.errors
+
+    def test_meta_model(self):
+        assert TemplateMetadataSerializer.Meta.model is TemplateMetadata
+
+    def test_meta_fields(self):
+        assert set(TemplateMetadataSerializer.Meta.fields) == {
+            "template_id",
+            "time_taken_manually_execute_minutes",
+            "time_taken_create_automation_minutes",
+        }
+
+
+# =============================================================================
+# ViewSet configuration tests
+# =============================================================================
+
+
+@pytest.mark.unit
+@override_settings(MODE="development")
+class TestTemplateMetadataViewSetConfig(TestCase):
+    def test_uses_correct_serializer_class(self):
+        assert TemplateMetadataViewSet.serializer_class is TemplateMetadataSerializer
+
+    def test_versioning_class_is_none(self):
+        assert TemplateMetadataViewSet.versioning_class is None
+
+    def test_pagination_class_is_none(self):
+        assert TemplateMetadataViewSet.pagination_class is None
+
+    def test_has_developer_mode_permission(self):
+        from apps.core.permissions import DeveloperModeRequired
+
+        assert DeveloperModeRequired in TemplateMetadataViewSet.permission_classes
+
+    def test_has_retrieve_mixin(self):
+        from rest_framework.mixins import RetrieveModelMixin
+
+        assert issubclass(TemplateMetadataViewSet, RetrieveModelMixin)
+
+    def test_has_update_mixin(self):
+        from rest_framework.mixins import UpdateModelMixin
+
+        assert issubclass(TemplateMetadataViewSet, UpdateModelMixin)
+
+    def test_has_destroy_mixin(self):
+        from rest_framework.mixins import DestroyModelMixin
+
+        assert issubclass(TemplateMetadataViewSet, DestroyModelMixin)
+
+    def test_does_not_have_list_mixin(self):
+        from rest_framework.mixins import ListModelMixin
+
+        assert not issubclass(TemplateMetadataViewSet, ListModelMixin)
+
+    def test_does_not_have_create_mixin(self):
+        from rest_framework.mixins import CreateModelMixin
+
+        assert not issubclass(TemplateMetadataViewSet, CreateModelMixin)
+
+    @patch("apps.dashboard_reports.viewsets.template_metadata.TemplateMetadata")
+    def test_get_queryset_calls_objects_all(self, mock_model):
+        mock_qs = MagicMock()
+        mock_model.objects.all.return_value = mock_qs
+        viewset = TemplateMetadataViewSet()
+        viewset.request = MagicMock()
+        viewset.kwargs = {}
+        viewset.format_kwarg = None
+        assert viewset.get_queryset() is mock_qs
+        mock_model.objects.all.assert_called_once()
+
+
+# =============================================================================
+# ViewSet action tests  (get_object + perform_* mocked — no DB)
+# =============================================================================
+
+
+@pytest.mark.unit
+@override_settings(MODE="development")
+class TestTemplateMetadataViewSetActions(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.instance = _make_mock_instance()
+        self.none_qs = TemplateMetadata.objects.none()
+
+    def _view(self, method_map: dict):
+        return TemplateMetadataViewSet.as_view(method_map)
+
+    def _call(self, view, request, pk: int = 1):
+        with patch.object(TemplateMetadataViewSet, "get_queryset", return_value=self.none_qs):
+            return view(request, pk=pk)
+
+    # ---- GET (retrieve) ----
+
+    @patch.object(TemplateMetadataViewSet, "get_object")
+    def test_retrieve_returns_200(self, mock_get_object):
+        mock_get_object.return_value = self.instance
+        request = self.factory.get("/fake/")
+        request.user = _make_request_user()
+        response = self._call(self._view({"get": "retrieve"}), request)
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch.object(TemplateMetadataViewSet, "get_object")
+    def test_retrieve_calls_get_object_once(self, mock_get_object):
+        mock_get_object.return_value = self.instance
+        request = self.factory.get("/fake/")
+        request.user = _make_request_user()
+        self._call(self._view({"get": "retrieve"}), request)
+        mock_get_object.assert_called_once()
+
+    # ---- PUT (update) ----
+
+    @patch.object(TemplateMetadataViewSet, "get_object")
+    @patch.object(TemplateMetadataViewSet, "perform_update")
+    def test_update_returns_200(self, mock_perform_update, mock_get_object):
+        mock_get_object.return_value = self.instance
+        self.instance.template_id = 42
+        request = self.factory.put(
+            "/fake/",
+            data={
+                "time_taken_manually_execute_minutes": 20,
+                "time_taken_create_automation_minutes": 50,
+            },
+            format="json",
+        )
+        request.user = _make_request_user()
+        response = self._call(self._view({"put": "update"}), request)
+        assert response.status_code == status.HTTP_200_OK
+
+    @patch.object(TemplateMetadataViewSet, "get_object")
+    @patch.object(TemplateMetadataViewSet, "perform_update")
+    def test_update_calls_perform_update_once(self, mock_perform_update, mock_get_object):
+        mock_get_object.return_value = self.instance
+        self.instance.template_id = 42
+        request = self.factory.put(
+            "/fake/",
+            data={
+                "time_taken_manually_execute_minutes": 20,
+                "time_taken_create_automation_minutes": 50,
+            },
+            format="json",
+        )
+        request.user = _make_request_user()
+        self._call(self._view({"put": "update"}), request)
+        mock_perform_update.assert_called_once()
+
+    @patch.object(TemplateMetadataViewSet, "get_object")
+    @patch.object(TemplateMetadataViewSet, "perform_update")
+    def test_update_with_null_time_fields(self, mock_perform_update, mock_get_object):
+        mock_get_object.return_value = self.instance
+        self.instance.template_id = 42
+        request = self.factory.put(
+            "/fake/",
+            data={
+                "time_taken_manually_execute_minutes": None,
+                "time_taken_create_automation_minutes": None,
+            },
+            format="json",
+        )
+        request.user = _make_request_user()
+        response = self._call(self._view({"put": "update"}), request)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_patch_mapped_to_partial_update(self):
+        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        assert match.func.actions.get("patch") == "partial_update"
+
+    # ---- DELETE (destroy) ----
+
+    @patch.object(TemplateMetadataViewSet, "get_object")
+    def test_destroy_returns_204(self, mock_get_object):
+        mock_get_object.return_value = self.instance
+        request = self.factory.delete("/fake/")
+        request.user = _make_request_user()
+        response = self._call(self._view({"delete": "destroy"}), request)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    @patch.object(TemplateMetadataViewSet, "get_object")
+    def test_destroy_clears_override_fields(self, mock_get_object):
+        mock_get_object.return_value = self.instance
+        request = self.factory.delete("/fake/")
+        request.user = _make_request_user()
+        self._call(self._view({"delete": "destroy"}), request)
+        assert self.instance.time_taken_manually_execute_minutes is None
+        assert self.instance.time_taken_create_automation_minutes is None
+
+    @patch.object(TemplateMetadataViewSet, "get_object")
+    def test_destroy_saves_with_correct_update_fields(self, mock_get_object):
+        mock_get_object.return_value = self.instance
+        request = self.factory.delete("/fake/")
+        request.user = _make_request_user()
+        self._call(self._view({"delete": "destroy"}), request)
+        self.instance.save.assert_called_once_with(
+            update_fields=[
+                "time_taken_manually_execute_minutes",
+                "time_taken_create_automation_minutes",
+            ]
+        )
+
+    @patch.object(TemplateMetadataViewSet, "get_object")
+    def test_destroy_does_not_delete_the_record(self, mock_get_object):
+        mock_get_object.return_value = self.instance
+        request = self.factory.delete("/fake/")
+        request.user = _make_request_user()
+        self._call(self._view({"delete": "destroy"}), request)
+        self.instance.delete.assert_not_called()
+
+    # ---- developer mode gate ----
+
+    @override_settings(MODE="production")
+    def test_all_methods_return_403_when_not_in_development_mode(self):
+        for method, factory_fn, map_ in [
+            ("GET", self.factory.get, {"get": "retrieve"}),
+            ("PUT", lambda u, **k: self.factory.put(u, data={}, format="json", **k), {"put": "update"}),
+            ("DELETE", self.factory.delete, {"delete": "destroy"}),
+        ]:
+            with self.subTest(method=method):
+                request = factory_fn("/fake/")
+                request.user = _make_request_user()
+                response = self._call(self._view(map_), request)
+                assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+# =============================================================================
+# URL routing tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestTemplateMetadataUrls(TestCase):
+    def test_url_resolves_to_metadata_viewset(self):
+        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        assert match.func.cls is TemplateMetadataViewSet
+
+    def test_url_captures_pk(self):
+        match = resolve("/api/v1/dashboard_reports/templates/99/metadata/")
+        assert match.kwargs["pk"] == 99
+
+    def test_named_url_reverse(self):
+        url = reverse("dashboard_reports:template-metadata", kwargs={"pk": 1})
+        assert url == "/api/v1/dashboard_reports/templates/1/metadata/"
+
+    def test_get_mapped_to_retrieve(self):
+        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        assert match.func.actions.get("get") == "retrieve"
+
+    def test_put_mapped_to_update(self):
+        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        assert match.func.actions.get("put") == "update"
+
+    def test_delete_mapped_to_destroy(self):
+        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        assert match.func.actions.get("delete") == "destroy"
+
+    def test_post_not_mapped(self):
+        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        assert "post" not in match.func.actions


### PR DESCRIPTION
# [[AAP-69250](https://redhat.atlassian.net/browse/AAP-69250)] Implement template metadata API endpoint

Requires: https://github.com/ansible/metrics-service/pull/177

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
    * ViewSet for retrieving template metadata from metrics service database.
    * Endpoints:
        * GET /api/v1/dashboard_reports/templates/{id}/metadata - Get specific template
        * PUT /api/v1/dashboard_reports/templates/{id}/metadata - Update specific template
        * DELETE /api/v1/dashboard_reports/templates/{id}/metadata - Delete specific template
- Why is this change needed?
    * We want users (with correct permissions) to be able to edit specific template metadata to suit their needs
- How does this change address the issue?
    * By adding the viewset and endpoints mentioned above

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
See README for setting up development environment.

Other requierements:
- running metrics service DB (with migrations)
- running awx DB (with migrations)

### Steps to Test
1. start metrics service - `python manage.py metrics_service run`
2. go to swagger docs - `http://localhost:8000/api/v1/docs/#/dashboard_reports`
3. test the GET, PUT and DELETE methods of template_metadata endpoint

Another way to test:
- run all unit tests: `pytest -m unit`
- run unit tests just for template metadata: `pytest -m unit tests/unit/dashboard_reports/test_template_metadata.py`
- run unit tests just for template metadata: `pytest -m unit tests/unit/dashboard_reports/test_template_metadata_db.py`

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for retrieving and managing template metadata overrides, allowing users to view and update estimated execution times for templates in developer mode.
  * Endpoint supports clearing time overrides via deletion, which resets values without removing the template record.

* **Tests**
  * Added comprehensive unit tests for the new template metadata endpoint and serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->