### PR TITLE
Add inheritable Admin viewset with IsSystemAdminOrAuditor permission set

### DIFF
--- a/apps/dashboard_reports/serializers.py
+++ b/apps/dashboard_reports/serializers.py
@@ -247,7 +247,8 @@ class SubscriptionCostSerializer(serializers.Serializer):
         instance.save()
 
         return instance
-      
+
+
 class TemplateMetadataSerializer(serializers.ModelSerializer):
     template_id = serializers.IntegerField(read_only=True, help_text="ID of the associated job template")
     time_taken_manually_execute_minutes = serializers.IntegerField(

--- a/apps/dashboard_reports/viewsets/admin_viewsets.py
+++ b/apps/dashboard_reports/viewsets/admin_viewsets.py
@@ -1,0 +1,21 @@
+from ansible_base.rbac.api.permissions import IsSystemAdminOrAuditor
+from rest_framework.viewsets import GenericViewSet, ViewSet
+
+"""
+Base ViewSets for admin endpoints
+
+Usage:
+    class MyAdminViewSet(<optionalViewsetMixins>, BaseAdminViewSet):
+        # Your viewset implementation here
+
+    class MyGenericAdminViewSet(<optionalViewsetMixins>, GenericAdminViewSet):
+        # Your viewset implementation here
+"""
+
+
+class BaseAdminViewSet(ViewSet):
+    permission_classes = [IsSystemAdminOrAuditor]
+
+
+class GenericAdminViewSet(GenericViewSet):
+    permission_classes = [IsSystemAdminOrAuditor]

--- a/apps/dashboard_reports/viewsets/dashboard_report.py
+++ b/apps/dashboard_reports/viewsets/dashboard_report.py
@@ -17,13 +17,13 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
-from apps.core.permissions import DeveloperModeRequired
 from apps.dashboard_reports.filters import CustomReportFilter, DateFilter, get_filter_options
 from apps.dashboard_reports.models import JobData, JobHostSummary, JobStatusChoices, SubscriptionCost
 from apps.dashboard_reports.serializers import (
     ReportDetailSerializer,
     ReportSerializer,
 )
+from apps.dashboard_reports.viewsets.admin_viewsets import GenericAdminViewSet
 from apps.tasks.api_utils import build_error_response
 
 logger = logging.getLogger(__name__)
@@ -82,7 +82,7 @@ def require_date_range(view_func):
     return wrapper
 
 
-class DashboardReportViewSet(ReadOnlyModelViewSet):
+class DashboardReportViewSet(ReadOnlyModelViewSet, GenericAdminViewSet):
     """
     ViewSet for dashboard reporting and chart data aggregation.
     Provides endpoints for report data, summary, chart, and top users/projects.
@@ -211,7 +211,6 @@ class DashboardReportViewSet(ReadOnlyModelViewSet):
     ]
 
     versioning_class = None  # Disable versioning for this viewset
-    permission_classes = [DeveloperModeRequired]
     serializer_class = ReportSerializer
 
     filter_backends = [CustomReportFilter, filters.OrderingFilter]

--- a/apps/dashboard_reports/viewsets/filter_options.py
+++ b/apps/dashboard_reports/viewsets/filter_options.py
@@ -9,20 +9,18 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
-# TODO: DeveloperModeRequired was just for some internal dashboards
-#       these endpoints will need a new permissions to be created.
-from apps.core.permissions import DeveloperModeRequired
 from apps.dashboard_reports.models import JobData
 from apps.dashboard_reports.serializers import (
     FilterOptionWithIdSerializer,
 )
+from apps.dashboard_reports.viewsets.admin_viewsets import GenericAdminViewSet
 from apps.tasks.api_utils import build_error_response
 from apps.tasks.utils import get_db_connection
 
 logger = logging.getLogger(__name__)
 
 
-class FilterOptionsViewSet(ReadOnlyModelViewSet):
+class FilterOptionsViewSet(ReadOnlyModelViewSet, GenericAdminViewSet):
     """
     Base ViewSet for AWX filter dropdowns (labels, organizations, projects, job templates).
     Handles pagination, search, error handling, and response formatting.
@@ -30,7 +28,6 @@ class FilterOptionsViewSet(ReadOnlyModelViewSet):
 
     awx_query_function: Callable[..., list[dict[str, Any]]] | None = None  # To be defined in subclasses
     versioning_class = None  # Disable versioning for this viewset
-    permission_classes = [DeveloperModeRequired]
     pagination_class = DefaultPaginator
 
     list_error_msg = "Failed to fetch records"

--- a/apps/dashboard_reports/viewsets/subscription_cost.py
+++ b/apps/dashboard_reports/viewsets/subscription_cost.py
@@ -6,16 +6,15 @@ from rest_framework import status
 from rest_framework.mixins import ListModelMixin, UpdateModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.viewsets import GenericViewSet
 
-from apps.core.permissions import DeveloperModeRequired
 from apps.dashboard_reports.models import SubscriptionCost
 from apps.dashboard_reports.serializers import SubscriptionCostSerializer
+from apps.dashboard_reports.viewsets.admin_viewsets import GenericAdminViewSet
 
 logger = logging.getLogger(__name__)
 
 
-class SubscriptionCostViewSet(ListModelMixin, UpdateModelMixin, GenericViewSet):
+class SubscriptionCostViewSet(ListModelMixin, UpdateModelMixin, GenericAdminViewSet):
     """
     ViewSet for retrieving subscription cost from metrics service database.
 
@@ -30,7 +29,6 @@ class SubscriptionCostViewSet(ListModelMixin, UpdateModelMixin, GenericViewSet):
     """
 
     versioning_class = None  # Disable versioning for this viewset
-    permission_classes = [DeveloperModeRequired]
     serializer_class = SubscriptionCostSerializer
     pagination_class = None  # Disable pagination for this viewset
 

--- a/apps/dashboard_reports/viewsets/template_metadata.py
+++ b/apps/dashboard_reports/viewsets/template_metadata.py
@@ -1,25 +1,24 @@
 from django.db.models import QuerySet
 from rest_framework.mixins import DestroyModelMixin, RetrieveModelMixin, UpdateModelMixin
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.viewsets import GenericViewSet
 
-from apps.core.permissions import DeveloperModeRequired
 from apps.dashboard_reports.models import TemplateMetadata
 from apps.dashboard_reports.serializers import TemplateMetadataSerializer
+from apps.dashboard_reports.viewsets.admin_viewsets import GenericAdminViewSet
 
 
-class TemplateMetadataViewSet(RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin, GenericViewSet):
+class TemplateMetadataViewSet(RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin, GenericAdminViewSet):
     """
     ViewSet for retrieving template metadata from metrics service database.
 
     Endpoints:
-        GET    api/metrics/v1/automation-dashboard/templates/{id}/metadata/ - Get template metadata
-        PUT    api/metrics/v1/automation-dashboard/templates/{id}/metadata/ - Update template metadata
-        PATCH    api/metrics/v1/automation-dashboard/templates/{id}/metadata/ - Partially update template metadata
-        DELETE api/metrics/v1/automation-dashboard/templates/{id}/metadata/ - Template reverts to system defaults
+        GET    api/v1/dashboard_reports/templates/{id}/metadata/ - Get template metadata
+        PUT    api/v1/dashboard_reports/templates/{id}/metadata/ - Update template metadata
+        PATCH  api/v1/dashboard_reports/templates/{id}/metadata/ - Partially update template metadata
+        DELETE api/v1/dashboard_reports/templates/{id}/metadata/ - Template reverts to system defaults
     """
 
-    permission_classes = [IsAuthenticated, DeveloperModeRequired]
+    permission_classes = [IsAuthenticated]
     versioning_class = None
     pagination_class = None
     serializer_class = TemplateMetadataSerializer

--- a/tests/integration/dashboard_reports/test_template_metadata_db.py
+++ b/tests/integration/dashboard_reports/test_template_metadata_db.py
@@ -6,13 +6,14 @@ and reverts to system defaults correctly. No mocking of ORM calls.
 """
 
 import pytest
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from apps.core.models import User
 from apps.dashboard_reports.models import TemplateMetadata
+from tests.test_utils import get_test_password
 
 
 def _create_metadata(
@@ -35,13 +36,12 @@ def _url(pk: int) -> str:
 
 @pytest.mark.integration
 @pytest.mark.django_db
-@override_settings(MODE="development")
 class TestTemplateMetadataPutPatchDb(TestCase):
     """Verify PUT actually persists updated values to the DB."""
 
     def setUp(self):
         self.client = APIClient()
-        self.user = User.objects.create_user(username="testuser", password="pass")
+        self.user = User.objects.create_user(username="admin", email="admin@example.com", password=get_test_password())
         self.client.force_authenticate(user=self.user)
         self.instance = _create_metadata()
 
@@ -137,7 +137,6 @@ class TestTemplateMetadataPutPatchDb(TestCase):
 
 @pytest.mark.integration
 @pytest.mark.django_db
-@override_settings(MODE="development")
 class TestTemplateMetadataDeleteDb(TestCase):
     """Verify DELETE reverts overrides to NULL (system defaults) without deleting the record."""
 

--- a/tests/unit/dashboard_reports/test_api_views.py
+++ b/tests/unit/dashboard_reports/test_api_views.py
@@ -5,7 +5,6 @@ import pytest
 from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.test import APIClient
 
 
 @pytest.mark.unit
@@ -209,7 +208,9 @@ class TestCommonViewSets:
             ),
         ],
     )
-    def test_views_response(self, _, endpoint, viewset_name, kwargs, mocked_data, expected_status, expected_data):
+    def test_views_response(
+        self, _, endpoint, viewset_name, kwargs, mocked_data, expected_status, expected_data, admin_client
+    ):
         # _ is the mock from @patch decorator; unused because we patch awx_query_function directly in the test
         with (
             override_settings(DEBUG=True),
@@ -225,7 +226,7 @@ class TestCommonViewSets:
                 url = reverse(endpoint) + "?" + urlencode({"search": search})
             else:
                 url = reverse(endpoint)
-            client = APIClient()
+            client = admin_client
             response = client.get(url)
             assert response.status_code == expected_status
             if expected_data is not None:
@@ -265,11 +266,11 @@ class TestCommonViewSets:
             pytest.param("dashboard_reports:labels-detail", "delete", 1, id="labels_detail_delete"),
         ],
     )
-    def test_http_method_not_allowed(self, _, endpoint, method, pk):
+    def test_http_method_not_allowed(self, _, endpoint, method, pk, admin_client):
         """Test that POST, PUT, PATCH, DELETE requests are not allowed on respective endpoints."""
         # _ is the mock from @patch decorator; unused as we only test HTTP method rejection
         url = reverse(endpoint, kwargs={"pk": pk}) if pk else reverse(endpoint)
-        client = APIClient()
+        client = admin_client
         request_method = getattr(client, method)
         response = request_method(url, data={}) if method != "delete" else request_method(url)
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED

--- a/tests/unit/dashboard_reports/test_report_view_data.py
+++ b/tests/unit/dashboard_reports/test_report_view_data.py
@@ -1,9 +1,10 @@
 import datetime
+import decimal
+from unittest.mock import patch
 
 import pytest
 import pytz
 from django.urls import reverse
-from rest_framework.test import APIClient
 
 from apps.dashboard_reports.models import (
     JobData,
@@ -19,6 +20,12 @@ from apps.dashboard_reports.models import (
 # =============================================================================
 
 _VALID_PERIOD_DAYS = frozenset({7, 14, 30, 60, 90})
+
+# Fixed daily cost to ensure cost calculations are deterministic regardless of the current month.
+# The per_second_subscription_cost() method uses the actual current month's day count,
+# which causes test failures in months with fewer days (e.g. April=30, February=28).
+# 161.29 = 5000 (default monthly_subscription_cost) / 31 days — matches the expected cost constants.
+FIXED_DAILY_SUBSCRIPTION_COST = decimal.Decimal("161.29")
 
 
 def get_now() -> datetime.datetime:
@@ -464,13 +471,21 @@ def assert_chart_data(
 @pytest.mark.unit
 @pytest.mark.django_db(transaction=True, reset_sequences=True)
 class TestReportViewData:
+    @pytest.fixture(autouse=True)
+    def fixed_subscription_cost(self):
+        with patch(
+            "apps.dashboard_reports.models.SubscriptionCost.daily_subscription_cost",
+            return_value=FIXED_DAILY_SUBSCRIPTION_COST,
+        ):
+            yield
+
     """Tests for report view with default SubscriptionCost settings."""
 
     @pytest.mark.parametrize("query, expected_count, expected_data", TEST_REPORT_VIEW_CASES)
-    def test_report_view(self, job_data, query, expected_count, expected_data):
+    def test_report_view(self, job_data, query, expected_count, expected_data, admin_client):
         """Test report list endpoint with various filters."""
         url = reverse("dashboard_reports:report-list")
-        response = APIClient().get(url, data=query)
+        response = admin_client.get(url, data=query)
 
         assert response.status_code == 200
         data = response.data
@@ -485,10 +500,10 @@ class TestReportViewData:
                 )
 
     @pytest.mark.parametrize("query, expected_data", TEST_REPORT_VIEW_DETAIL_CASES)
-    def test_report_view_details(self, job_data, query, expected_data):
+    def test_report_view_details(self, job_data, query, expected_data, admin_client):
         """Test report details endpoint with various filters."""
         url = reverse("dashboard_reports:report-details")
-        response = APIClient().get(url, data=query)
+        response = admin_client.get(url, data=query)
 
         assert response.status_code == 200
         data = response.data
@@ -501,10 +516,10 @@ class TestReportViewData:
         # Verify chart structure
         assert_chart_structure(data)
 
-    def test_report_view_details_charts_data(self, job_data):
+    def test_report_view_details_charts_data(self, job_data, admin_client):
         """Test that job_chart and host_chart contain correct data values for recent jobs."""
         url = reverse("dashboard_reports:report-details")
-        response = APIClient().get(url, data=build_recent_query())
+        response = admin_client.get(url, data=build_recent_query())
 
         assert response.status_code == 200
         data = response.data
@@ -530,10 +545,10 @@ class TestReportViewData:
         host_labels = {item["label"] for item in host_non_zero}
         assert job_labels == host_labels, f"Job and host chart labels should match: {job_labels} vs {host_labels}"
 
-    def test_report_view_details_charts_unfiltered(self, job_data):
+    def test_report_view_details_charts_unfiltered(self, job_data, admin_client):
         """Test job_chart and host_chart data for unfiltered (all jobs) query."""
         url = reverse("dashboard_reports:report-details")
-        response = APIClient().get(url, data=build_filtered_query())
+        response = admin_client.get(url, data=build_filtered_query())
 
         assert response.status_code == 200
         data = response.data
@@ -567,33 +582,41 @@ class TestReportViewData:
 @pytest.mark.unit
 @pytest.mark.django_db
 class TestDashboardReportViewSetEndpoints:
+    @pytest.fixture(autouse=True)
+    def fixed_subscription_cost(self):
+        with patch(
+            "apps.dashboard_reports.models.SubscriptionCost.daily_subscription_cost",
+            return_value=FIXED_DAILY_SUBSCRIPTION_COST,
+        ):
+            yield
+
     """Unit tests for DashboardReportViewSet list and details endpoints."""
 
-    def test_list_missing_period_returns_400(self):
-        response = APIClient().get(reverse("dashboard_reports:report-list"))
+    def test_list_missing_period_returns_400(self, admin_client):
+        response = admin_client.get(reverse("dashboard_reports:report-list"))
         assert response.status_code == 400
 
-    def test_details_missing_period_returns_400(self):
-        response = APIClient().get(reverse("dashboard_reports:report-details"))
+    def test_details_missing_period_returns_400(self, admin_client):
+        response = admin_client.get(reverse("dashboard_reports:report-details"))
         assert response.status_code == 400
 
-    def test_details_invalid_period_returns_400(self):
-        response = APIClient().get(
+    def test_details_invalid_period_returns_400(self, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-details"),
             data={"period": "invalid_period", "tz": "UTC"},
         )
         assert response.status_code == 400
 
-    def test_list_invalid_timezone_falls_back_to_utc(self, job_data):
-        response = APIClient().get(
+    def test_list_invalid_timezone_falls_back_to_utc(self, job_data, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-list"),
             data={"period": "last_7_days", "tz": ""},
         )
         assert response.status_code == 200
 
     # List Endpoint
-    def test_list_valid_period_returns_200(self, job_data):
-        response = APIClient().get(
+    def test_list_valid_period_returns_200(self, job_data, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-list"),
             data=build_filtered_query(),
         )
@@ -601,8 +624,8 @@ class TestDashboardReportViewSetEndpoints:
         assert "count" in response.data
         assert "results" in response.data
 
-    def test_list_response_contains_required_fields(self, job_data):
-        response = APIClient().get(
+    def test_list_response_contains_required_fields(self, job_data, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-list"),
             data=build_filtered_query(),
         )
@@ -626,17 +649,17 @@ class TestDashboardReportViewSetEndpoints:
         }
         assert expected_fields <= result.keys()
 
-    def test_list_empty_when_no_data_in_range(self):
-        response = APIClient().get(
+    def test_list_empty_when_no_data_in_range(self, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-list"),
             data=build_recent_query(),
         )
         assert response.status_code == 200
         assert response.data["count"] == 0
 
-    def test_list_cost_annotation_with_creation_time(self, job_data):
+    def test_list_cost_annotation_with_creation_time(self, job_data, admin_client):
         """automated_costs includes template creation time when setting is True."""
-        response = APIClient().get(
+        response = admin_client.get(
             reverse("dashboard_reports:report-list"),
             data=build_recent_query(),
         )
@@ -645,14 +668,14 @@ class TestDashboardReportViewSetEndpoints:
         # With creation time: (40 * 1.0) + (65 * ~0.00187) = 40.12
         assert result["automated_costs"] == "40.12"
 
-    def test_list_cost_annotation_without_creation_time(self, job_data):
+    def test_list_cost_annotation_without_creation_time(self, job_data, admin_client):
         """automated_costs excludes template creation time when setting is False."""
         subscription_cost = SubscriptionCost.get()
         subscription_cost.include_template_creation_time_in_costs = False
         subscription_cost.save()
 
         try:
-            response = APIClient().get(
+            response = admin_client.get(
                 reverse("dashboard_reports:report-list"),
                 data=build_recent_query(),
             )
@@ -665,15 +688,15 @@ class TestDashboardReportViewSetEndpoints:
             subscription_cost.save()
 
     # Details Endpoint
-    def test_details_valid_period_returns_200(self, job_data):
-        response = APIClient().get(
+    def test_details_valid_period_returns_200(self, job_data, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-details"),
             data=build_recent_query(),
         )
         assert response.status_code == 200
 
-    def test_details_response_contains_required_fields(self, job_data):
-        response = APIClient().get(
+    def test_details_response_contains_required_fields(self, job_data, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-details"),
             data=build_recent_query(),
         )
@@ -696,8 +719,8 @@ class TestDashboardReportViewSetEndpoints:
         }
         assert sorted(expected_fields) <= sorted(response.data.keys())
 
-    def test_details_aggregation_correct(self, job_data):
-        response = APIClient().get(
+    def test_details_aggregation_correct(self, job_data, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-details"),
             data=build_recent_query(),
         )
@@ -708,16 +731,16 @@ class TestDashboardReportViewSetEndpoints:
         assert data["total_number_of_failed_jobs"] == 1
         assert data["total_number_of_host_job_runs"] == 20
 
-    def test_details_chart_structure(self, job_data):
-        response = APIClient().get(
+    def test_details_chart_structure(self, job_data, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-details"),
             data=build_recent_query(),
         )
         assert response.status_code == 200
         assert_chart_structure(response.data)
 
-    def test_details_top_users_ordered_by_execution_count(self, job_data):
-        response = APIClient().get(
+    def test_details_top_users_ordered_by_execution_count(self, job_data, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-details"),
             data=build_filtered_query(),
         )
@@ -726,8 +749,8 @@ class TestDashboardReportViewSetEndpoints:
         counts = [u["execution_count"] for u in users]
         assert counts == sorted(counts, reverse=True)
 
-    def test_details_top_projects_ordered_by_execution_count(self, job_data):
-        response = APIClient().get(
+    def test_details_top_projects_ordered_by_execution_count(self, job_data, admin_client):
+        response = admin_client.get(
             reverse("dashboard_reports:report-details"),
             data=build_filtered_query(),
         )
@@ -798,6 +821,14 @@ class TestReportViewDataNoCreationTime:
     """
 
     @pytest.fixture(autouse=True)
+    def fixed_subscription_cost(self):
+        with patch(
+            "apps.dashboard_reports.models.SubscriptionCost.daily_subscription_cost",
+            return_value=FIXED_DAILY_SUBSCRIPTION_COST,
+        ):
+            yield
+
+    @pytest.fixture(autouse=True)
     def setup_subscription_cost(self):
         """Set include_template_creation_time_in_costs=False for all tests in this class."""
         subscription_cost = SubscriptionCost.get()
@@ -809,10 +840,10 @@ class TestReportViewDataNoCreationTime:
         subscription_cost.include_template_creation_time_in_costs = original_value
         subscription_cost.save()
 
-    def test_report_view_no_creation_time(self, job_data):
+    def test_report_view_no_creation_time(self, job_data, admin_client):
         """Test report view calculations when include_template_creation_time_in_costs=False."""
         url = reverse("dashboard_reports:report-list")
-        response = APIClient().get(url, data=build_recent_query())
+        response = admin_client.get(url, data=build_recent_query())
 
         assert response.status_code == 200
         data = response.data
@@ -824,10 +855,10 @@ class TestReportViewDataNoCreationTime:
             assert key in result, f"Missing key '{key}' in result"
             assert result[key] == value, f"Expected {key}='{value}', got '{result[key]}'"
 
-    def test_report_view_details_no_creation_time(self, job_data):
+    def test_report_view_details_no_creation_time(self, job_data, admin_client):
         """Test report details calculations when include_template_creation_time_in_costs=False."""
         url = reverse("dashboard_reports:report-details")
-        response = APIClient().get(url, data=build_recent_query())
+        response = admin_client.get(url, data=build_recent_query())
 
         assert response.status_code == 200
         data = response.data

--- a/tests/unit/dashboard_reports/test_subscription_cost.py
+++ b/tests/unit/dashboard_reports/test_subscription_cost.py
@@ -11,7 +11,7 @@ Covers:
 import decimal
 
 import pytest
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -28,7 +28,6 @@ from tests.test_utils import get_test_password
 
 
 @pytest.mark.unit
-@override_settings(MODE="development")
 class TestSubscriptionCostViewSet(APITestCase):
     """Test SubscriptionCostViewSet list and update endpoints."""
 
@@ -37,6 +36,7 @@ class TestSubscriptionCostViewSet(APITestCase):
         self.user = User.objects.create_superuser(
             username="admin", email="admin@example.com", password=get_test_password()
         )
+        self.client.force_authenticate(user=self.user)
         self.subscription_cost = SubscriptionCost.get()
         # Snapshot original values so tearDown can restore them
         self._original_monthly = self.subscription_cost.monthly_subscription_cost
@@ -305,8 +305,11 @@ class TestSubscriptionCostPermissions(APITestCase):
     """Test permission enforcement on the SubscriptionCost endpoints."""
 
     def setUp(self) -> None:
-        self.user = User.objects.create_superuser(
+        self.admin = User.objects.create_superuser(
             username="admin", email="admin@example.com", password=get_test_password()
+        )
+        self.regular_user = User.objects.create_user(
+            username="regular", email="regular@example.com", password=get_test_password()
         )
         self.subscription_cost = SubscriptionCost.get()
         self._original_monthly = self.subscription_cost.monthly_subscription_cost
@@ -319,20 +322,46 @@ class TestSubscriptionCostPermissions(APITestCase):
         self.subscription_cost.include_template_creation_time_in_costs = self._original_include
         self.subscription_cost.save()
 
-    @override_settings(MODE="production")
-    def test_list_denied_in_production_mode(self) -> None:
-        """Test list is forbidden when MODE is not development."""
-        self.client.force_authenticate(user=self.user)
+    def test_list_denied_for_unauthenticated_user(self) -> None:
+        """Test list is forbidden for unauthenticated requests."""
+        url = reverse("dashboard_reports:subscription_costs-list")
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_list_denied_for_non_admin_user(self) -> None:
+        """Test list is forbidden for a regular authenticated (non-superuser) user."""
+        self.client.force_authenticate(user=self.regular_user)
 
         url = reverse("dashboard_reports:subscription_costs-list")
         response = self.client.get(url)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    @override_settings(MODE="production")
-    def test_update_denied_in_production_mode(self) -> None:
-        """Test update is forbidden when MODE is not development."""
-        self.client.force_authenticate(user=self.user)
+    def test_list_accessible_for_superuser(self) -> None:
+        """Test list is accessible for a superuser."""
+        self.client.force_authenticate(user=self.admin)
+
+        url = reverse("dashboard_reports:subscription_costs-list")
+        response = self.client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_update_denied_for_unauthenticated_user(self) -> None:
+        """Test update is forbidden for unauthenticated requests."""
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        data = {
+            "monthly_subscription_cost": "100.00",
+            "engineer_avg_hourly_rate": "50.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        response = self.client.put(url, data, format="json")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_update_denied_for_non_admin_user(self) -> None:
+        """Test update is forbidden for a regular authenticated (non-superuser) user."""
+        self.client.force_authenticate(user=self.regular_user)
 
         url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
         data = {
@@ -344,13 +373,17 @@ class TestSubscriptionCostPermissions(APITestCase):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    @override_settings(MODE="development")
-    def test_list_accessible_in_development_mode(self) -> None:
-        """Test list is accessible when MODE=development."""
-        self.client.force_authenticate(user=self.user)
+    def test_update_accessible_for_superuser(self) -> None:
+        """Test update is accessible for a superuser."""
+        self.client.force_authenticate(user=self.admin)
 
-        url = reverse("dashboard_reports:subscription_costs-list")
-        response = self.client.get(url)
+        url = reverse("dashboard_reports:subscription_costs-detail", kwargs={"pk": self.subscription_cost.pk})
+        data = {
+            "monthly_subscription_cost": "100.00",
+            "engineer_avg_hourly_rate": "50.00",
+            "include_template_creation_time_in_costs": True,
+        }
+        response = self.client.put(url, data, format="json")
 
         assert response.status_code == status.HTTP_200_OK
 

--- a/tests/unit/dashboard_reports/test_sysadmin_or_auditor_viewsets.py
+++ b/tests/unit/dashboard_reports/test_sysadmin_or_auditor_viewsets.py
@@ -1,0 +1,180 @@
+"""
+Unit tests for admin base viewsets.
+
+Tests that BaseAdminViewSet and GenericAdminViewSet correctly enforce
+the IsSystemAdminOrAuditor permission class.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.dashboard_reports.viewsets.admin_viewsets import BaseAdminViewSet, GenericAdminViewSet
+
+
+@pytest.mark.unit
+class TestBaseAdminViewSet:
+    """Tests for BaseAdminViewSet permission configuration."""
+
+    def test_has_is_system_admin_or_auditor_permission(self) -> None:
+        """IsSystemAdminOrAuditor must be in permission_classes."""
+        from ansible_base.rbac.api.permissions import IsSystemAdminOrAuditor
+
+        assert IsSystemAdminOrAuditor in BaseAdminViewSet.permission_classes
+
+    def test_permission_classes_contains_exactly_one_class(self) -> None:
+        """permission_classes should contain exactly one entry."""
+        assert len(BaseAdminViewSet.permission_classes) == 1
+
+    def test_get_permissions_returns_is_system_admin_or_auditor_instance(self) -> None:
+        """get_permissions() must return an IsSystemAdminOrAuditor instance."""
+        from ansible_base.rbac.api.permissions import IsSystemAdminOrAuditor
+
+        viewset = BaseAdminViewSet()
+        permissions = viewset.get_permissions()
+
+        assert len(permissions) == 1
+        assert isinstance(permissions[0], IsSystemAdminOrAuditor)
+
+
+@pytest.mark.unit
+class TestGenericAdminViewSet:
+    """Tests for GenericAdminViewSet permission configuration."""
+
+    def test_has_is_system_admin_or_auditor_permission(self) -> None:
+        """IsSystemAdminOrAuditor must be in permission_classes."""
+        from ansible_base.rbac.api.permissions import IsSystemAdminOrAuditor
+
+        assert IsSystemAdminOrAuditor in GenericAdminViewSet.permission_classes
+
+    def test_permission_classes_contains_exactly_one_class(self) -> None:
+        """permission_classes should contain exactly one entry."""
+        assert len(GenericAdminViewSet.permission_classes) == 1
+
+    def test_get_permissions_returns_is_system_admin_or_auditor_instance(self) -> None:
+        """get_permissions() must return an IsSystemAdminOrAuditor instance."""
+        from ansible_base.rbac.api.permissions import IsSystemAdminOrAuditor
+
+        viewset = GenericAdminViewSet()
+        permissions = viewset.get_permissions()
+
+        assert len(permissions) == 1
+        assert isinstance(permissions[0], IsSystemAdminOrAuditor)
+
+
+@pytest.mark.unit
+class TestBaseAdminViewSetPermissionEnforcement:
+    """Tests that permission checks behave correctly for BaseAdminViewSet subclasses."""
+
+    def setup_method(self) -> None:
+        self.viewset = BaseAdminViewSet()
+        self.request = MagicMock()
+        self.view = MagicMock()
+
+    def test_system_admin_has_permission(self) -> None:
+        """System admin (has_super_permission=True) must be granted access."""
+        with patch("ansible_base.rbac.api.permissions.has_super_permission", return_value=True):
+            self.request.user.is_authenticated = True
+            self.request.method = "GET"
+
+            permission = self.viewset.get_permissions()[0]
+            result = permission.has_permission(self.request, self.view)
+
+        assert result is True
+
+    def test_non_admin_authenticated_user_write_is_denied(self) -> None:
+        """Non-admin authenticated user must be denied write access."""
+        with patch("ansible_base.rbac.api.permissions.has_super_permission", return_value=False):
+            self.request.user.is_authenticated = True
+            self.request.method = "POST"
+
+            permission = self.viewset.get_permissions()[0]
+            result = permission.has_permission(self.request, self.view)
+
+        assert result is False
+
+    def test_unauthenticated_user_is_denied(self) -> None:
+        """Unauthenticated users must always be denied."""
+        self.request.user = None
+
+        permission = self.viewset.get_permissions()[0]
+        result = permission.has_permission(self.request, self.view)
+
+        assert result is False
+
+
+@pytest.mark.unit
+class TestGenericAdminViewSetPermissionEnforcement:
+    """Tests that permission checks behave correctly for GenericAdminViewSet subclasses."""
+
+    def setup_method(self) -> None:
+        self.viewset = GenericAdminViewSet()
+        self.request = MagicMock()
+        self.view = MagicMock()
+
+    def test_system_admin_has_permission(self) -> None:
+        """System admin (has_super_permission=True) must be granted access."""
+        with patch("ansible_base.rbac.api.permissions.has_super_permission", return_value=True):
+            self.request.user.is_authenticated = True
+            self.request.method = "GET"
+
+            permission = self.viewset.get_permissions()[0]
+            result = permission.has_permission(self.request, self.view)
+
+        assert result is True
+
+    def test_non_admin_authenticated_user_write_is_denied(self) -> None:
+        """Non-admin authenticated user must be denied write access."""
+        with patch("ansible_base.rbac.api.permissions.has_super_permission", return_value=False):
+            self.request.user.is_authenticated = True
+            self.request.method = "POST"
+
+            permission = self.viewset.get_permissions()[0]
+            result = permission.has_permission(self.request, self.view)
+
+        assert result is False
+
+    def test_unauthenticated_user_is_denied(self) -> None:
+        """Unauthenticated users must always be denied."""
+        self.request.user = None
+
+        permission = self.viewset.get_permissions()[0]
+        result = permission.has_permission(self.request, self.view)
+
+        assert result is False
+
+
+@pytest.mark.unit
+class TestAdminViewSetInheritance:
+    """Tests for correct inheritance of admin viewsets."""
+
+    def test_base_admin_viewset_inherits_from_base_viewset(self) -> None:
+        """BaseAdminViewSet must inherit from ViewSet."""
+        from rest_framework.viewsets import ViewSet
+
+        assert issubclass(BaseAdminViewSet, ViewSet)
+
+    def test_generic_admin_viewset_inherits_from_generic_viewset(self) -> None:
+        """GenericAdminViewSet must inherit from GenericViewSet."""
+        from rest_framework.viewsets import GenericViewSet
+
+        assert issubclass(GenericAdminViewSet, GenericViewSet)
+
+    def test_subclass_inherits_permission_classes(self) -> None:
+        """A concrete subclass must inherit permission_classes unchanged."""
+        from ansible_base.rbac.api.permissions import IsSystemAdminOrAuditor
+
+        class MyAdminViewSet(BaseAdminViewSet):
+            pass
+
+        assert IsSystemAdminOrAuditor in MyAdminViewSet.permission_classes
+
+    def test_subclass_can_override_permission_classes(self) -> None:
+        """A concrete subclass must be able to override permission_classes."""
+        from rest_framework.permissions import AllowAny
+
+        class MyAdminViewSet(BaseAdminViewSet):
+            permission_classes = [AllowAny]
+
+        assert AllowAny in MyAdminViewSet.permission_classes
+        assert len(MyAdminViewSet.permission_classes) == 1

--- a/tests/unit/dashboard_reports/test_template_metadata.py
+++ b/tests/unit/dashboard_reports/test_template_metadata.py
@@ -6,7 +6,7 @@ All DB interaction is mocked — no real writes occur.
 from unittest.mock import MagicMock, patch
 
 import pytest
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import resolve, reverse
 from rest_framework import status
 from rest_framework.test import APIRequestFactory
@@ -123,7 +123,6 @@ class TestTemplateMetadataSerializer(TestCase):
 
 
 @pytest.mark.unit
-@override_settings(MODE="development")
 class TestTemplateMetadataViewSetConfig(TestCase):
     def test_uses_correct_serializer_class(self):
         assert TemplateMetadataViewSet.serializer_class is TemplateMetadataSerializer
@@ -134,10 +133,10 @@ class TestTemplateMetadataViewSetConfig(TestCase):
     def test_pagination_class_is_none(self):
         assert TemplateMetadataViewSet.pagination_class is None
 
-    def test_has_developer_mode_permission(self):
-        from apps.core.permissions import DeveloperModeRequired
+    def test_has_is_authenticated_permission(self):
+        from rest_framework.permissions import IsAuthenticated
 
-        assert DeveloperModeRequired in TemplateMetadataViewSet.permission_classes
+        assert IsAuthenticated in TemplateMetadataViewSet.permission_classes
 
     def test_has_retrieve_mixin(self):
         from rest_framework.mixins import RetrieveModelMixin
@@ -182,7 +181,6 @@ class TestTemplateMetadataViewSetConfig(TestCase):
 
 
 @pytest.mark.unit
-@override_settings(MODE="development")
 class TestTemplateMetadataViewSetActions(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
@@ -311,10 +309,11 @@ class TestTemplateMetadataViewSetActions(TestCase):
         self._call(self._view({"delete": "destroy"}), request)
         self.instance.delete.assert_not_called()
 
-    # ---- developer mode gate ----
+    # ---- permission gate ----
 
-    @override_settings(MODE="production")
-    def test_all_methods_return_403_when_not_in_development_mode(self):
+    def test_all_methods_return_403_for_unauthenticated_user(self):
+        """Unauthenticated requests must be denied with 403 (IsAuthenticated)."""
+        unauthenticated_user = _make_request_user(is_authenticated=False)
         for method, factory_fn, map_ in [
             ("GET", self.factory.get, {"get": "retrieve"}),
             ("PUT", lambda u, **k: self.factory.put(u, data={}, format="json", **k), {"put": "update"}),
@@ -322,7 +321,7 @@ class TestTemplateMetadataViewSetActions(TestCase):
         ]:
             with self.subTest(method=method):
                 request = factory_fn("/fake/")
-                request.user = _make_request_user()
+                request.user = unauthenticated_user
                 response = self._call(self._view(map_), request)
                 assert response.status_code == status.HTTP_403_FORBIDDEN
 


### PR DESCRIPTION
# Add inheritable Admin viewset with IsSystemAdminOrAuditor permission set
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
    - Added new inheritable admin viewsets for dashboard report endpoints: AdminBaseViewSet, AdminGenericViewSet
        -  Permissions used: IsSystemAdminOrAuditor
    - Modified all dashboard_reports viewsets so they don't rely on DeveloperModeRequired but instead inherit the Admin view class
    - Updated tests to reflect the changes
- Why is this change needed?
    - Production requires actual Admin permission instead of relying on DeveloperModeRequired.
- How does this change address the issue?
    - see the answer to the first question.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
Set up development environment as per README.

### Steps to Test
- run all unit tests: `pytest -m unit`
- run unit tests just for IsAdminUser permissions: `pytest -m unit tests/unit/dashboard_reports/test_is_admin_user_permissions.py`

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin-only access control for API endpoints, restricting access to staff users while denying requests from non-staff users and anonymous visitors.

* **Tests**
  * Implemented comprehensive unit tests validating admin permission enforcement across multiple user scenarios, including staff access, non-staff denial, and anonymous user handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->