### PR TITLE
AAP-65336 fixes for test in aap-dev

### DIFF
--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -2,31 +2,10 @@
 Dashboard views for task management and monitoring.
 """
 
-from functools import wraps
-
 from django.conf import settings
-from django.http import HttpRequest, HttpResponse, HttpResponseForbidden
+from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_safe
-
-
-def require_development_mode(view_func):
-    """
-    Decorator that restricts access to views when development mode is disabled.
-
-    Returns 403 Forbidden with a descriptive message when METRICS_SERVICE_MODE=development
-    """
-
-    @wraps(view_func)
-    def wrapper(request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        if settings.MODE != "development":
-            return HttpResponseForbidden(
-                "The dashboard is only available when development mode is enabled. "
-                "Set METRICS_SERVICE_MODE=development to enable."
-            )
-        return view_func(request, *args, **kwargs)
-
-    return wrapper
 
 
 def url_for(path):
@@ -45,7 +24,6 @@ def url_for(path):
 
 
 @require_safe
-@require_development_mode
 def dashboard_view(request: HttpRequest) -> HttpResponse:
     """
     Main dashboard view for task management.

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -312,10 +312,10 @@ DASHBOARD_COLLECTION_GROUP = TaskGroup(
         {
             "task_id": "daily_dashboard_collection",
             "function": "collect_dashboard_reports_data",
-            "cron": "0 */6 * * *",  # Runs every 6 hours (at minute 0)
+            "cron": settings.DASHBOARD_COLLECTION["COLLECTION_SCHEDULE_CRON"],
             "args": {"incremental": True},  # Uses incremental collection by default to minimize load
             "enabled": False,
-            "description": "Dashboard report collection every 6 hours",
+            "description": "Dashboard report collection (default every 6 hours)",
             "category": "dashboard_collection",
         },
         {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       METRICS_SERVICE_DATABASES__default__HOST: postgres
       METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
       METRICS_SERVICE_MODE: development
+      METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION: "true"
+      METRICS_SERVICE_DASHBOARD_COLLECTION__COLLECTION_SCHEDULE_CRON: "*/5 * * * *"
     networks:
       - metrics-service
 
@@ -70,6 +72,8 @@ services:
       # Development-only password. In production, override with secrets management.
       METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
       METRICS_SERVICE_MODE: development
+      METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION: "true"
+      METRICS_SERVICE_DASHBOARD_COLLECTION__COLLECTION_SCHEDULE_CRON: "*/5 * * * *"
     networks:
       - metrics-service
 
@@ -99,6 +103,8 @@ services:
       METRICS_SERVICE_DATABASES__default__HOST: postgres
       METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
       METRICS_SERVICE_MODE: development
+      METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION: "true"
+      METRICS_SERVICE_DASHBOARD_COLLECTION__COLLECTION_SCHEDULE_CRON: "*/5 * * * *"
     networks:
       - metrics-service
 
@@ -125,6 +131,8 @@ services:
       METRICS_SERVICE_DATABASES__default__HOST: postgres
       METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
       METRICS_SERVICE_MODE: development
+      METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION: "true"
+      METRICS_SERVICE_DASHBOARD_COLLECTION__COLLECTION_SCHEDULE_CRON: "*/5 * * * *"
     networks:
       - metrics-service
 

--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -264,6 +264,12 @@ IS_RUNNING_TESTS = "test" in sys.argv or "PYTEST_VERSION" in os.environ
 LOADED_APPS = []
 """List of apps loaded by the Ansible Services Framework dynamically set at runtime."""
 
+DASHBOARD_COLLECTION = {
+    "COLLECTION_SCHEDULE_CRON": "0 */6 * * *",
+}
+"""Dashboard collection settings.
+Override cron via METRICS_SERVICE_DASHBOARD_COLLECTION__COLLECTION_SCHEDULE_CRON env var."""
+
 default_variables = {k: v for k, v in locals().items() if k.isupper()}
 """Variables from this module locals that will be passed to Dynaconf"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "pip>=25.2",
     "packaging>=20.0",  # Required for setuptools-scm during source builds
     "django-generate-series>=2026.2.1", # Required for generating time series data for dashboard report charts
+    "pytz",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -779,6 +779,7 @@ dependencies = [
     { name = "pip" },
     { name = "psycopg", extra = ["binary"] },
     { name = "psycopg2-binary" },
+    { name = "pytz" },
     { name = "whitenoise" },
 ]
 
@@ -849,6 +850,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1" },
     { name = "pytest-django", marker = "extra == 'test'", specifier = ">=4.5" },
     { name = "python-ldap", marker = "extra == 'ldap'", specifier = ">=3.4.0" },
+    { name = "pytz" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.1" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=1.24" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=1.3" },


### PR DESCRIPTION
# [AAP-65336] Test automation-dashboard in aap-dev

## Description

While tesitng in aap-dev, a few errors were found
- pytz library was missing
- testing is difficult if you need to wait 6 hours on 1st sync to happen. Make sync schedule configurable via environ, even if only for testing/developers.
- do not require development mode. Here I assume api endpoint are already decorated to require admin or auditior role.
