### PR TITLE
[AAP-71480] Minor code changes to accomodate connecting the metrics service with the UI

### DIFF
--- a/apps/dashboard_reports/serializers.py
+++ b/apps/dashboard_reports/serializers.py
@@ -45,7 +45,10 @@ class PaginatedFilterOptionsSerializer(serializers.Serializer):
 
 
 class ReportSerializer(serializers.ModelSerializer[JobData]):
-    id = serializers.IntegerField(source="template_id", read_only=True)
+    # NOTE: id must be sourced from template_metadata_id (which cannot be null), because we
+    # link the logic of changing times for manually execute and time taken to create
+    # automation, and if template_id can be null then the GUI also gives an error.
+    id = serializers.IntegerField(source="template_metadata_id", read_only=True)
     time_taken_manually_execute_minutes = serializers.IntegerField(
         read_only=True, help_text="Estimated time to perform this task manually (minutes)"
     )

--- a/apps/dashboard_reports/urls.py
+++ b/apps/dashboard_reports/urls.py
@@ -20,21 +20,8 @@ router.register(r"projects", ProjectsViewSet, basename="projects")
 router.register(r"labels", LabelsViewSet, basename="labels")
 router.register(r"report", DashboardReportViewSet, basename="report")
 router.register(r"subscription_costs", SubscriptionCostViewSet, basename="subscription_costs")
-
-# TemplateMetadataViewSet doesn't fit the standard router pattern, so we define its URL separately
-#   * standard router pattern example: /api/v1/dashboard_reports/templates/metadata/{id}/
-#   * what we want is: /api/v1/dashboard_reports/templates/{id}/metadata/
-metadata_view = TemplateMetadataViewSet.as_view(
-    {
-        "get": "retrieve",
-        "put": "update",
-        "patch": "partial_update",
-        "delete": "destroy",
-    }
-)
+router.register(r"template_metadata", TemplateMetadataViewSet, basename="template_metadata")
 
 urlpatterns = [
-    # Dashboard report endpoints at /api/v1/
-    path("api/v1/dashboard_reports/templates/<int:pk>/metadata/", metadata_view, name="template-metadata"),
     path("api/v1/dashboard_reports/", include(router.urls)),
 ]

--- a/apps/dashboard_reports/viewsets/dashboard_report.py
+++ b/apps/dashboard_reports/viewsets/dashboard_report.py
@@ -273,7 +273,7 @@ class DashboardReportViewSet(ReadOnlyModelViewSet):
 
         qs = JobData.objects.values(
             "template_name",
-            "template_id",
+            "template_metadata_id",
             time_taken_manually_execute_minutes=F("template_metadata__time_taken_manually_execute_minutes"),
             time_taken_create_automation_minutes=F("template_metadata__time_taken_create_automation_minutes"),
         ).annotate(

--- a/apps/dashboard_reports/viewsets/template_metadata.py
+++ b/apps/dashboard_reports/viewsets/template_metadata.py
@@ -1,5 +1,5 @@
 from django.db.models import QuerySet
-from rest_framework.mixins import DestroyModelMixin, RetrieveModelMixin, UpdateModelMixin
+from rest_framework.mixins import RetrieveModelMixin, UpdateModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
 
@@ -7,35 +7,20 @@ from apps.dashboard_reports.models import TemplateMetadata
 from apps.dashboard_reports.serializers import TemplateMetadataSerializer
 
 
-class TemplateMetadataViewSet(RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin, GenericViewSet):
+class TemplateMetadataViewSet(RetrieveModelMixin, UpdateModelMixin, GenericViewSet):
     """
     ViewSet for retrieving template metadata from metrics service database.
 
     Endpoints:
-        GET    api/v1/dashboard_reports/templates/{id}/metadata/ - Get template metadata
-        PUT    api/v1/dashboard_reports/templates/{id}/metadata/ - Update template metadata
-        PATCH  api/v1/dashboard_reports/templates/{id}/metadata/ - Partially update template metadata
-        DELETE api/v1/dashboard_reports/templates/{id}/metadata/ - Template reverts to system defaults
+        GET    api/v1/dashboard_reports/template_metadata/{id}/ - Get template metadata
+        PUT    api/v1/dashboard_reports/template_metadata/{id}/ - Update template metadata
+        PATCH  api/v1/dashboard_reports/template_metadata/{id}/ - Partially update template metadata
     """
 
     permission_classes = [IsAuthenticated]
     versioning_class = None
     pagination_class = None
     serializer_class = TemplateMetadataSerializer
-    lookup_field = "template_id"
-    lookup_url_kwarg = "pk"
 
     def get_queryset(self) -> QuerySet[TemplateMetadata]:
         return TemplateMetadata.objects.all()
-
-    def perform_destroy(self, instance: TemplateMetadata) -> None:
-        """Clear user overrides, reverting the template to system defaults."""
-
-        instance.time_taken_manually_execute_minutes = None
-        instance.time_taken_create_automation_minutes = None
-        instance.save(
-            update_fields=[
-                "time_taken_manually_execute_minutes",
-                "time_taken_create_automation_minutes",
-            ]
-        )

--- a/tests/integration/dashboard_reports/test_template_metadata_db.py
+++ b/tests/integration/dashboard_reports/test_template_metadata_db.py
@@ -7,7 +7,6 @@ and reverts to system defaults correctly. No mocking of ORM calls.
 
 import pytest
 from django.test import TestCase
-from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -31,7 +30,7 @@ def _create_metadata(
 
 
 def _url(pk: int) -> str:
-    return reverse("dashboard_reports:template-metadata", kwargs={"pk": pk})
+    return f"/api/v1/dashboard_reports/template_metadata/{pk}/"
 
 
 @pytest.mark.integration
@@ -41,13 +40,15 @@ class TestTemplateMetadataPutPatchDb(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.user = User.objects.create_user(username="admin", email="admin@example.com", password=get_test_password())
+        self.user = User.objects.create_user(
+            username="admin", email="admin@example.com", password=get_test_password(), is_superuser=True
+        )
         self.client.force_authenticate(user=self.user)
         self.instance = _create_metadata()
 
     def test_put_updates_time_fields_in_db(self):
         response = self.client.put(
-            _url(self.instance.template_id),
+            _url(self.instance.pk),
             data={
                 "time_taken_manually_execute_minutes": 99,
                 "time_taken_create_automation_minutes": 199,
@@ -63,7 +64,7 @@ class TestTemplateMetadataPutPatchDb(TestCase):
 
     def test_put_response_reflects_updated_values(self):
         response = self.client.put(
-            _url(self.instance.template_id),
+            _url(self.instance.pk),
             data={
                 "time_taken_manually_execute_minutes": 55,
                 "time_taken_create_automation_minutes": 110,
@@ -77,7 +78,7 @@ class TestTemplateMetadataPutPatchDb(TestCase):
 
     def test_put_with_null_sets_fields_to_null_in_db(self):
         response = self.client.put(
-            _url(self.instance.template_id),
+            _url(self.instance.pk),
             data={
                 "time_taken_manually_execute_minutes": None,
                 "time_taken_create_automation_minutes": None,
@@ -92,10 +93,10 @@ class TestTemplateMetadataPutPatchDb(TestCase):
         assert self.instance.time_taken_create_automation_minutes is None
 
     def test_put_does_not_change_template_id(self):
-        original_template_id = self.instance.template_id
+        original_template_id = self.instance.pk
 
         self.client.put(
-            _url(self.instance.template_id),
+            _url(self.instance.pk),
             data={
                 "template_id": 999,
                 "time_taken_manually_execute_minutes": 10,
@@ -105,7 +106,7 @@ class TestTemplateMetadataPutPatchDb(TestCase):
         )
 
         self.instance.refresh_from_db()
-        assert self.instance.template_id == original_template_id
+        assert self.instance.pk == original_template_id
 
     def test_put_returns_404_for_nonexistent_pk(self):
         response = self.client.put(
@@ -121,7 +122,7 @@ class TestTemplateMetadataPutPatchDb(TestCase):
 
     def test_patch_updates_only_provided_field(self):
         response = self.client.patch(
-            _url(self.instance.template_id),
+            _url(self.instance.pk),
             data={
                 "time_taken_manually_execute_minutes": 77,
             },
@@ -133,57 +134,3 @@ class TestTemplateMetadataPutPatchDb(TestCase):
         self.instance.refresh_from_db()
         assert self.instance.time_taken_manually_execute_minutes == 77
         assert self.instance.time_taken_create_automation_minutes == 60  # unchanged
-
-
-@pytest.mark.integration
-@pytest.mark.django_db
-class TestTemplateMetadataDeleteDb(TestCase):
-    """Verify DELETE reverts overrides to NULL (system defaults) without deleting the record."""
-
-    def setUp(self):
-        self.client = APIClient()
-        self.user = User.objects.create_user(username="testuser", password="pass")
-        self.client.force_authenticate(user=self.user)
-        self.instance = _create_metadata(
-            time_taken_manually_execute_minutes=30,
-            time_taken_create_automation_minutes=60,
-        )
-
-    def test_delete_sets_time_fields_to_null_in_db(self):
-        response = self.client.delete(_url(self.instance.template_id))
-
-        assert response.status_code == status.HTTP_204_NO_CONTENT
-
-        self.instance.refresh_from_db()
-        assert self.instance.time_taken_manually_execute_minutes is None
-        assert self.instance.time_taken_create_automation_minutes is None
-
-    def test_delete_does_not_remove_the_record(self):
-        pk = self.instance.pk
-        self.client.delete(_url(pk))
-
-        assert TemplateMetadata.objects.filter(pk=pk).exists()
-
-    def test_delete_preserves_template_id_and_name(self):
-        original_template_id = self.instance.template_id
-        original_template_name = self.instance.template_name
-
-        self.client.delete(_url(self.instance.template_id))
-
-        self.instance.refresh_from_db()
-        assert self.instance.template_id == original_template_id
-        assert self.instance.template_name == original_template_name
-
-    def test_get_after_delete_reflects_null_overrides(self):
-        self.client.delete(_url(self.instance.template_id))
-
-        response = self.client.get(_url(self.instance.template_id))
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["time_taken_manually_execute_minutes"] is None
-        assert response.data["time_taken_create_automation_minutes"] is None
-
-    def test_delete_returns_404_for_nonexistent_pk(self):
-        response = self.client.delete(_url(99999))
-
-        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/integration/dashboard_reports/test_urls.py
+++ b/tests/integration/dashboard_reports/test_urls.py
@@ -33,6 +33,7 @@ class TestDashboardReportsURLs(TestCase):
         self.user = User.objects.create_user(
             username="testuser", email="test@example.com", password=get_test_password()
         )
+        self.api_client.force_authenticate(user=self.user)
 
     def test_dashboard_reports_endpoint_resolution(self):
         """Test that all dashboard_reports endpoints resolve correctly."""

--- a/tests/unit/dashboard_reports/test_serializers.py
+++ b/tests/unit/dashboard_reports/test_serializers.py
@@ -96,7 +96,7 @@ class TestReportSerializer:
         # Mock JobData-like dict for serializer
         return {
             "template_name": "Test Template",
-            "template_id": 123,
+            "template_metadata_id": 123,
             "time_taken_manually_execute_minutes": 30,
             "time_taken_create_automation_minutes": 60,
             "runs": 10,

--- a/tests/unit/dashboard_reports/test_template_metadata.py
+++ b/tests/unit/dashboard_reports/test_template_metadata.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import TestCase
-from django.urls import resolve, reverse
+from django.urls import resolve
 from rest_framework import status
 from rest_framework.test import APIRequestFactory
 
@@ -148,11 +148,6 @@ class TestTemplateMetadataViewSetConfig(TestCase):
 
         assert issubclass(TemplateMetadataViewSet, UpdateModelMixin)
 
-    def test_has_destroy_mixin(self):
-        from rest_framework.mixins import DestroyModelMixin
-
-        assert issubclass(TemplateMetadataViewSet, DestroyModelMixin)
-
     def test_does_not_have_list_mixin(self):
         from rest_framework.mixins import ListModelMixin
 
@@ -266,48 +261,8 @@ class TestTemplateMetadataViewSetActions(TestCase):
         assert response.status_code == status.HTTP_200_OK
 
     def test_patch_mapped_to_partial_update(self):
-        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        match = resolve("/api/v1/dashboard_reports/template_metadata/1/")
         assert match.func.actions.get("patch") == "partial_update"
-
-    # ---- DELETE (destroy) ----
-
-    @patch.object(TemplateMetadataViewSet, "get_object")
-    def test_destroy_returns_204(self, mock_get_object):
-        mock_get_object.return_value = self.instance
-        request = self.factory.delete("/fake/")
-        request.user = _make_request_user()
-        response = self._call(self._view({"delete": "destroy"}), request)
-        assert response.status_code == status.HTTP_204_NO_CONTENT
-
-    @patch.object(TemplateMetadataViewSet, "get_object")
-    def test_destroy_clears_override_fields(self, mock_get_object):
-        mock_get_object.return_value = self.instance
-        request = self.factory.delete("/fake/")
-        request.user = _make_request_user()
-        self._call(self._view({"delete": "destroy"}), request)
-        assert self.instance.time_taken_manually_execute_minutes is None
-        assert self.instance.time_taken_create_automation_minutes is None
-
-    @patch.object(TemplateMetadataViewSet, "get_object")
-    def test_destroy_saves_with_correct_update_fields(self, mock_get_object):
-        mock_get_object.return_value = self.instance
-        request = self.factory.delete("/fake/")
-        request.user = _make_request_user()
-        self._call(self._view({"delete": "destroy"}), request)
-        self.instance.save.assert_called_once_with(
-            update_fields=[
-                "time_taken_manually_execute_minutes",
-                "time_taken_create_automation_minutes",
-            ]
-        )
-
-    @patch.object(TemplateMetadataViewSet, "get_object")
-    def test_destroy_does_not_delete_the_record(self, mock_get_object):
-        mock_get_object.return_value = self.instance
-        request = self.factory.delete("/fake/")
-        request.user = _make_request_user()
-        self._call(self._view({"delete": "destroy"}), request)
-        self.instance.delete.assert_not_called()
 
     # ---- permission gate ----
 
@@ -317,7 +272,6 @@ class TestTemplateMetadataViewSetActions(TestCase):
         for method, factory_fn, map_ in [
             ("GET", self.factory.get, {"get": "retrieve"}),
             ("PUT", lambda u, **k: self.factory.put(u, data={}, format="json", **k), {"put": "update"}),
-            ("DELETE", self.factory.delete, {"delete": "destroy"}),
         ]:
             with self.subTest(method=method):
                 request = factory_fn("/fake/")
@@ -334,29 +288,21 @@ class TestTemplateMetadataViewSetActions(TestCase):
 @pytest.mark.unit
 class TestTemplateMetadataUrls(TestCase):
     def test_url_resolves_to_metadata_viewset(self):
-        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        match = resolve("/api/v1/dashboard_reports/template_metadata/1/")
         assert match.func.cls is TemplateMetadataViewSet
 
-    def test_url_captures_pk(self):
-        match = resolve("/api/v1/dashboard_reports/templates/99/metadata/")
-        assert match.kwargs["pk"] == 99
-
-    def test_named_url_reverse(self):
-        url = reverse("dashboard_reports:template-metadata", kwargs={"pk": 1})
-        assert url == "/api/v1/dashboard_reports/templates/1/metadata/"
-
     def test_get_mapped_to_retrieve(self):
-        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        match = resolve("/api/v1/dashboard_reports/template_metadata/1/")
         assert match.func.actions.get("get") == "retrieve"
 
     def test_put_mapped_to_update(self):
-        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        match = resolve("/api/v1/dashboard_reports/template_metadata/1/")
         assert match.func.actions.get("put") == "update"
 
-    def test_delete_mapped_to_destroy(self):
-        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
-        assert match.func.actions.get("delete") == "destroy"
+    def test_delete_not_mapped(self):
+        match = resolve("/api/v1/dashboard_reports/template_metadata/1/")
+        assert "delete" not in match.func.actions
 
     def test_post_not_mapped(self):
-        match = resolve("/api/v1/dashboard_reports/templates/1/metadata/")
+        match = resolve("/api/v1/dashboard_reports/template_metadata/1/")
         assert "post" not in match.func.actions


### PR DESCRIPTION
# [[AAP-71480](https://redhat.atlassian.net/browse/AAP-71480)] Minor code changes to accomodate connecting the metrics service with the UI

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
    * Changed base url of tampleate metadata endpoints to: api/v1/dashboard_reports/template_metadata/{id}
    * Removed DELETE endpoint from template metadata endpoints
        * template metadata should not be allowed deletion
    * Fixed ReportSerializer id source to be "template_metadata_id" instead of "template_id"
        * id must be sourced from template_metadata_id (which cannot be null), because we link the logic of changing times for manually execute and time taken to create automation, and if template_id can be null then the GUI also gives an error.
    * Fixed DashboardReports viewset to take into account ReportSerializer change
    * Fixed tests to reflect these changes
- Why is this change needed?
    * There were issues found when trying to link frontend and backend
- How does this change address the issue?
    * See above

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->