### PR TITLE
Enhance feature flag management and URL routing

### DIFF
--- a/apps/dashboard/urls.py
+++ b/apps/dashboard/urls.py
@@ -19,5 +19,5 @@ from . import views
 app_name = "dashboard"
 
 urlpatterns = [
-    path("dashboard/", views.dashboard_view, name="dashboard"),
+    path("api/dashboard/", views.dashboard_view, name="dashboard"),
 ]

--- a/apps/tasks/apps.py
+++ b/apps/tasks/apps.py
@@ -2,7 +2,57 @@
 Django app configuration for tasks app.
 """
 
+import logging
+from pathlib import Path
+
+import yaml
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+
+logger = logging.getLogger(__name__)
+
+_FEATURE_FLAGS_FILE = Path(__file__).parent / "feature_flags.yaml"
+
+
+def load_task_feature_flags(**kwargs):
+    """
+    Upsert tasks feature flags into AAPFlag after each DAB purge cycle.
+
+    Connected to the dab_feature_flags app post_migrate signal so it runs after
+    purge_feature_flags() + load_feature_flags() in create_initial_data(). This
+    ensures task-level feature flags survive every DAB migration without requiring
+    a change to the django-ansible-base feature_flags.yaml.
+    """
+    try:
+        from ansible_base.resource_registry.signals.handlers import no_reverse_sync
+        from django.apps import apps as django_apps
+
+        AAPFlag = django_apps.get_model("dab_feature_flags", "AAPFlag")
+
+        with _FEATURE_FLAGS_FILE.open() as f:
+            flags = yaml.safe_load(f) or []
+
+        for flag_def in flags:
+            existing = AAPFlag.objects.filter(name=flag_def["name"], condition=flag_def["condition"]).first()
+            if existing:
+                existing.support_level = flag_def.get("support_level", "TECHNOLOGY_PREVIEW")
+                existing.visibility = flag_def.get("visibility", True)
+                existing.ui_name = flag_def.get("ui_name", flag_def["name"])
+                existing.description = flag_def.get("description", "")
+                existing.labels = flag_def.get("labels", [])
+                existing.toggle_type = flag_def.get("toggle_type", "run-time")
+                existing.support_url = flag_def.get("support_url", "")
+                existing.full_clean(exclude=["resource"])
+                with no_reverse_sync():
+                    existing.save()
+            else:
+                flag = AAPFlag(**flag_def)
+                flag.full_clean(exclude=["resource"])
+                with no_reverse_sync():
+                    flag.save()
+            logger.debug("Loaded task feature flag: %s", flag_def["name"])
+    except Exception:
+        logger.exception("Failed to load tasks feature flags into AAPFlag")
 
 
 class TasksConfig(AppConfig):
@@ -12,3 +62,12 @@ class TasksConfig(AppConfig):
     name = "apps.tasks"
     label = "tasks"
     verbose_name = "Task Management"
+
+    def ready(self):
+        # Connect to the dab_feature_flags app post_migrate so task feature flags
+        # are (re)loaded after every DAB purge_feature_flags() + load_feature_flags()
+        # cycle. INSTALLED_APPS order ensures ansible_base.feature_flags connects its
+        # handler first, so DAB's purge runs before ours adds the flags back.
+        from ansible_base.feature_flags.apps import FeatureFlagsConfig
+
+        post_migrate.connect(load_task_feature_flags, sender=FeatureFlagsConfig)

--- a/apps/tasks/feature_flags.yaml
+++ b/apps/tasks/feature_flags.yaml
@@ -1,0 +1,29 @@
+- name: FEATURE_ANONYMIZED_DATA_COLLECTION_ENABLED
+  ui_name: Anonymized Data Collection
+  visibility: true
+  condition: boolean
+  value: 'True'
+  support_level: TECHNOLOGY_PREVIEW
+  description: >-
+    Enable anonymization and transmission of metrics data to Red Hat.
+    When enabled, collected job data is anonymized and sent to Segment
+    for platform analytics. Disabling this stops the anonymization and
+    sending tasks but does not affect metrics collection or rollup.
+  support_url: ''
+  toggle_type: run-time
+  labels:
+    - metrics
+- name: FEATURE_DASHBOARD_COLLECTION_ENABLED
+  ui_name: Dashboard Reports Collection
+  visibility: true
+  condition: boolean
+  value: 'False'
+  support_level: TECHNOLOGY_PREVIEW
+  description: >-
+    Enable data collection for the automation-reports dashboard integration.
+    When enabled, AWX job data is collected and stored to power the
+    dashboard_reports API and automation-reports UI.
+  support_url: ''
+  toggle_type: run-time
+  labels:
+    - metrics

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -52,8 +52,8 @@ def get_feature_enabled_from_db(setting_name: str, default: bool = False) -> boo
             flag = AAPFlag.objects.filter(name=f"FEATURE_{setting_name}_ENABLED", condition="boolean").first()
             if flag is not None:
                 return flag.value.lower() in ("true", "1", "yes", "on")
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Error reading feature enabled setting {setting_name} from AAPFlag: {e}")
 
         # Fallback to Django settings
         feature_enabled = getattr(settings, "FEATURE_ENABLED", {})

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -45,6 +45,16 @@ def get_feature_enabled_from_db(setting_name: str, default: bool = False) -> boo
                 # If not valid JSON, treat as string boolean
                 return setting.current_value.lower() in ("true", "1", "yes", "on")
 
+        # Check AAPFlag value (seeded from feature_flags.yaml)
+        try:
+            from ansible_base.feature_flags.models import AAPFlag
+
+            flag = AAPFlag.objects.filter(name=f"FEATURE_{setting_name}_ENABLED", condition="boolean").first()
+            if flag is not None:
+                return flag.value.lower() in ("true", "1", "yes", "on")
+        except Exception:
+            pass
+
         # Fallback to Django settings
         feature_enabled = getattr(settings, "FEATURE_ENABLED", {})
         return feature_enabled.get(setting_name, default)

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -23,8 +23,11 @@ This file loads at step 3 in the URL loading order, before individual apps
 """
 
 from django.urls import include, path
+from django.views.generic import RedirectView
 
 urlpatterns = [
     # Prometheus metrics endpoint
     path("", include("django_prometheus.urls")),
+    # Redirect bare feature_flags/ to the canonical states list
+    path("api/v1/feature_flags/", RedirectView.as_view(url="/api/v1/feature_flags/states/", permanent=True)),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ exclude = ["tests*"]
 
 [tool.setuptools.package-data]
 "apps.settings" = ["*.yaml"]
+"apps.dashboard" = ["templates/*.html"]
+"apps.tasks" = ["feature_flags.yaml"]
 
 
 [dependency-groups]

--- a/tests/unit/core/test_development_mode_permissions.py
+++ b/tests/unit/core/test_development_mode_permissions.py
@@ -37,6 +37,6 @@ class TestDevelopmentModeDisabled(TestCase):
         """Test that dashboard returns 403 when development mode is disabled."""
         self.client.force_authenticate(user=self.user)
 
-        response = self.client.get("/dashboard/")
+        response = self.client.get("/api/dashboard/")
 
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/unit/tasks/test_feature_enabled_db.py
+++ b/tests/unit/tasks/test_feature_enabled_db.py
@@ -123,7 +123,10 @@ class TestFeatureEnabledAAPFlagFallback(TestCase):
 
     def _patch_aap_flag(self, flag_instance):
         """Patch AAPFlag at its source module so the local import inside the function picks it up."""
-        return patch("ansible_base.feature_flags.models.AAPFlag", **{"objects.filter.return_value.first.return_value": flag_instance})
+        return patch(
+            "ansible_base.feature_flags.models.AAPFlag",
+            **{"objects.filter.return_value.first.return_value": flag_instance},
+        )
 
     # ------------------------------------------------------------------
     # AAPFlag fallback — basic true / false
@@ -171,8 +174,9 @@ class TestFeatureEnabledAAPFlagFallback(TestCase):
 
     def test_dynamic_setting_takes_precedence_over_aap_flag(self):
         """A dynamic_settings.Setting overrides the AAPFlag value."""
-        from apps.dynamic_settings.models import Setting
         from django.contrib.auth import get_user_model
+
+        from apps.dynamic_settings.models import Setting
 
         user = get_user_model().objects.create_user(username="prio_test", password="x")  # noqa: S106
         Setting.objects.create(setting_key="PRIO_FLAG", current_value=json.dumps(True), last_modified_by=user)
@@ -215,8 +219,9 @@ class TestFeatureEnabledAAPFlagFallback(TestCase):
         mock_aap_flag_class = MagicMock()
         mock_aap_flag_class.objects.filter.side_effect = Exception("registry unavailable")
 
-        with patch("ansible_base.feature_flags.models.AAPFlag", mock_aap_flag_class), override_settings(
-            FEATURE_ENABLED={"ERR_FLAG": True}
+        with (
+            patch("ansible_base.feature_flags.models.AAPFlag", mock_aap_flag_class),
+            override_settings(FEATURE_ENABLED={"ERR_FLAG": True}),
         ):
             result = get_feature_enabled_from_db("ERR_FLAG", default=False)
 

--- a/tests/unit/tasks/test_feature_enabled_db.py
+++ b/tests/unit/tasks/test_feature_enabled_db.py
@@ -6,7 +6,7 @@ with fallback to Django settings and defaults.
 """
 
 import json
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
@@ -104,3 +104,120 @@ class TestFeatureEnabledDB(TestCase):
             result = get_feature_enabled_from_db("ERROR_SETTING", default=True)
             assert result is True
             mock_logger.warning.assert_called_once()
+
+
+class TestFeatureEnabledAAPFlagFallback(TestCase):
+    """Test AAPFlag is used as the second fallback in get_feature_enabled_from_db.
+
+    Priority chain:
+      1. dynamic_settings.Setting  (runtime DB override)
+      2. AAPFlag.value             (YAML-seeded default)
+      3. settings.FEATURE_ENABLED  (Django settings)
+      4. default argument
+    """
+
+    def _make_mock_flag(self, value: str) -> MagicMock:
+        flag = MagicMock()
+        flag.value = value
+        return flag
+
+    def _patch_aap_flag(self, flag_instance):
+        """Patch AAPFlag at its source module so the local import inside the function picks it up."""
+        return patch("ansible_base.feature_flags.models.AAPFlag", **{"objects.filter.return_value.first.return_value": flag_instance})
+
+    # ------------------------------------------------------------------
+    # AAPFlag fallback — basic true / false
+    # ------------------------------------------------------------------
+
+    def test_aap_flag_true_returns_true(self):
+        """Returns True when AAPFlag.value is 'True' and no Setting exists."""
+        with self._patch_aap_flag(self._make_mock_flag("True")):
+            assert get_feature_enabled_from_db("MY_FLAG", default=False) is True
+
+    def test_aap_flag_false_returns_false(self):
+        """Returns False when AAPFlag.value is 'False' and no Setting exists."""
+        with self._patch_aap_flag(self._make_mock_flag("False")):
+            assert get_feature_enabled_from_db("MY_FLAG", default=True) is False
+
+    def test_aap_flag_string_variants(self):
+        """AAPFlag.value truthy strings are all accepted."""
+        for truthy in ("true", "True", "TRUE", "1", "yes", "on"):
+            with self._patch_aap_flag(self._make_mock_flag(truthy)):
+                assert get_feature_enabled_from_db("MY_FLAG", default=False) is True, truthy
+
+        for falsy in ("false", "False", "0", "no", "off"):
+            with self._patch_aap_flag(self._make_mock_flag(falsy)):
+                assert get_feature_enabled_from_db("MY_FLAG", default=True) is False, falsy
+
+    # ------------------------------------------------------------------
+    # Name mapping: setting_name → FEATURE_<setting_name>_ENABLED
+    # ------------------------------------------------------------------
+
+    def test_aap_flag_queried_with_correct_name(self):
+        """AAPFlag is looked up using the FEATURE_<setting_name>_ENABLED convention."""
+        mock_aap_flag_class = MagicMock()
+        mock_aap_flag_class.objects.filter.return_value.first.return_value = None
+
+        with patch("ansible_base.feature_flags.models.AAPFlag", mock_aap_flag_class):
+            get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=False)
+
+        mock_aap_flag_class.objects.filter.assert_called_once_with(
+            name="FEATURE_DASHBOARD_COLLECTION_ENABLED", condition="boolean"
+        )
+
+    # ------------------------------------------------------------------
+    # Priority: Setting > AAPFlag > FEATURE_ENABLED > default
+    # ------------------------------------------------------------------
+
+    def test_dynamic_setting_takes_precedence_over_aap_flag(self):
+        """A dynamic_settings.Setting overrides the AAPFlag value."""
+        from apps.dynamic_settings.models import Setting
+        from django.contrib.auth import get_user_model
+
+        user = get_user_model().objects.create_user(username="prio_test", password="x")  # noqa: S106
+        Setting.objects.create(setting_key="PRIO_FLAG", current_value=json.dumps(True), last_modified_by=user)
+
+        # AAPFlag disagrees — says False
+        with self._patch_aap_flag(self._make_mock_flag("False")):
+            result = get_feature_enabled_from_db("PRIO_FLAG", default=False)
+
+        assert result is True  # Setting wins
+
+    @override_settings(FEATURE_ENABLED={"FALLBACK_FLAG": True})
+    def test_aap_flag_takes_precedence_over_feature_enabled_settings(self):
+        """AAPFlag value takes priority over settings.FEATURE_ENABLED."""
+        # AAPFlag says False; settings says True — AAPFlag wins
+        with self._patch_aap_flag(self._make_mock_flag("False")):
+            result = get_feature_enabled_from_db("FALLBACK_FLAG", default=True)
+
+        assert result is False
+
+    @override_settings(FEATURE_ENABLED={"SETTINGS_FLAG": True})
+    def test_feature_enabled_settings_used_when_no_aap_flag(self):
+        """settings.FEATURE_ENABLED is used when AAPFlag returns None."""
+        with self._patch_aap_flag(None):
+            result = get_feature_enabled_from_db("SETTINGS_FLAG", default=False)
+
+        assert result is True
+
+    def test_default_used_when_nothing_found(self):
+        """default argument is returned when Setting, AAPFlag, and FEATURE_ENABLED all miss."""
+        with self._patch_aap_flag(None), override_settings(FEATURE_ENABLED={}):
+            assert get_feature_enabled_from_db("NONEXISTENT", default=True) is True
+            assert get_feature_enabled_from_db("NONEXISTENT", default=False) is False
+
+    # ------------------------------------------------------------------
+    # Exception resilience
+    # ------------------------------------------------------------------
+
+    def test_aap_flag_exception_falls_through_to_settings(self):
+        """An exception inside the AAPFlag block falls through to FEATURE_ENABLED."""
+        mock_aap_flag_class = MagicMock()
+        mock_aap_flag_class.objects.filter.side_effect = Exception("registry unavailable")
+
+        with patch("ansible_base.feature_flags.models.AAPFlag", mock_aap_flag_class), override_settings(
+            FEATURE_ENABLED={"ERR_FLAG": True}
+        ):
+            result = get_feature_enabled_from_db("ERR_FLAG", default=False)
+
+        assert result is True

--- a/tests/unit/tasks/test_tasks_apps.py
+++ b/tests/unit/tasks/test_tasks_apps.py
@@ -1,0 +1,242 @@
+"""
+Unit tests for apps.tasks.apps — TasksConfig and load_task_feature_flags.
+"""
+
+import io
+from contextlib import nullcontext
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+import yaml
+from django.test import TestCase
+
+from apps.tasks.apps import load_task_feature_flags
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_FLAGS = [
+    {
+        "name": "FEATURE_ANONYMIZED_DATA_COLLECTION_ENABLED",
+        "ui_name": "Anonymized Data Collection",
+        "visibility": True,
+        "condition": "boolean",
+        "value": "True",
+        "support_level": "TECHNOLOGY_PREVIEW",
+        "description": "A test flag.",
+        "support_url": "",
+        "toggle_type": "run-time",
+        "labels": ["metrics"],
+    },
+    {
+        "name": "FEATURE_DASHBOARD_COLLECTION_ENABLED",
+        "ui_name": "Dashboard Reports Collection",
+        "visibility": True,
+        "condition": "boolean",
+        "value": "False",
+        "support_level": "TECHNOLOGY_PREVIEW",
+        "description": "Another test flag.",
+        "support_url": "",
+        "toggle_type": "run-time",
+        "labels": ["metrics"],
+    },
+]
+
+
+def _make_patches(flags=_SAMPLE_FLAGS, existing_flag=None):
+    """Return (mock_aap_flag_class, list-of-active-patches) ready to start."""
+    yaml_content = yaml.dump(flags)
+
+    mock_file_path = MagicMock()
+    mock_file_path.open.return_value.__enter__ = lambda s: io.StringIO(yaml_content)
+    mock_file_path.open.return_value.__exit__ = MagicMock(return_value=False)
+
+    mock_aap_flag_class = MagicMock()
+    mock_aap_flag_class.objects.filter.return_value.first.return_value = existing_flag
+
+    return mock_file_path, mock_aap_flag_class
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestLoadTaskFeatureFlags(TestCase):
+    """Tests for load_task_feature_flags signal handler."""
+
+    # ------------------------------------------------------------------
+    # Create path — flag does not exist yet
+    # ------------------------------------------------------------------
+
+    def test_creates_new_flags_when_none_exist(self):
+        """Creates an AAPFlag instance for every entry in the YAML when none exist."""
+        mock_file_path, mock_aap_flag_class = _make_patches(existing_flag=None)
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+            patch(
+                "ansible_base.resource_registry.signals.handlers.no_reverse_sync",
+                return_value=nullcontext(),
+            ),
+        ):
+            load_task_feature_flags()
+
+        # One AAPFlag(**flag_def) call per flag in the YAML
+        assert mock_aap_flag_class.call_count == len(_SAMPLE_FLAGS)
+        for flag_def in _SAMPLE_FLAGS:
+            mock_aap_flag_class.assert_any_call(**flag_def)
+
+        # full_clean and save called for each new instance
+        new_instance = mock_aap_flag_class.return_value
+        assert new_instance.full_clean.call_count == len(_SAMPLE_FLAGS)
+        new_instance.full_clean.assert_called_with(exclude=["resource"])
+        assert new_instance.save.call_count == len(_SAMPLE_FLAGS)
+
+    def test_new_flag_full_clean_excludes_resource(self):
+        """full_clean(exclude=['resource']) is called to skip the reverse FK check."""
+        mock_file_path, mock_aap_flag_class = _make_patches(flags=[_SAMPLE_FLAGS[0]], existing_flag=None)
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+            patch(
+                "ansible_base.resource_registry.signals.handlers.no_reverse_sync",
+                return_value=nullcontext(),
+            ),
+        ):
+            load_task_feature_flags()
+
+        mock_aap_flag_class.return_value.full_clean.assert_called_once_with(exclude=["resource"])
+
+    # ------------------------------------------------------------------
+    # Update path — flag already exists
+    # ------------------------------------------------------------------
+
+    def test_updates_existing_flag_fields(self):
+        """Updates metadata fields on an existing AAPFlag without recreating it."""
+        existing = MagicMock()
+        flag_def = _SAMPLE_FLAGS[0]
+        mock_file_path, mock_aap_flag_class = _make_patches(flags=[flag_def], existing_flag=existing)
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+            patch(
+                "ansible_base.resource_registry.signals.handlers.no_reverse_sync",
+                return_value=nullcontext(),
+            ),
+        ):
+            load_task_feature_flags()
+
+        # No new AAPFlag(**) call — existing instance is mutated instead
+        mock_aap_flag_class.assert_not_called()
+
+        assert existing.support_level == flag_def["support_level"]
+        assert existing.visibility == flag_def["visibility"]
+        assert existing.ui_name == flag_def["ui_name"]
+        assert existing.description == flag_def["description"]
+        assert existing.labels == flag_def["labels"]
+        assert existing.toggle_type == flag_def["toggle_type"]
+        assert existing.support_url == flag_def["support_url"]
+
+        existing.full_clean.assert_called_once_with(exclude=["resource"])
+        existing.save.assert_called_once()
+
+    def test_existing_flag_full_clean_excludes_resource(self):
+        """full_clean(exclude=['resource']) is also used on the update path."""
+        existing = MagicMock()
+        mock_file_path, mock_aap_flag_class = _make_patches(flags=[_SAMPLE_FLAGS[0]], existing_flag=existing)
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+            patch(
+                "ansible_base.resource_registry.signals.handlers.no_reverse_sync",
+                return_value=nullcontext(),
+            ),
+        ):
+            load_task_feature_flags()
+
+        existing.full_clean.assert_called_once_with(exclude=["resource"])
+
+    # ------------------------------------------------------------------
+    # AAPFlag lookup uses correct name + condition filter
+    # ------------------------------------------------------------------
+
+    def test_filters_by_name_and_condition(self):
+        """AAPFlag is looked up by (name, condition) for each flag in the YAML."""
+        mock_file_path, mock_aap_flag_class = _make_patches(existing_flag=None)
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+            patch(
+                "ansible_base.resource_registry.signals.handlers.no_reverse_sync",
+                return_value=nullcontext(),
+            ),
+        ):
+            load_task_feature_flags()
+
+        expected_calls = [
+            call(name=f["name"], condition=f["condition"]) for f in _SAMPLE_FLAGS
+        ]
+        assert mock_aap_flag_class.objects.filter.call_args_list == expected_calls
+
+    # ------------------------------------------------------------------
+    # Exception resilience
+    # ------------------------------------------------------------------
+
+    @patch("apps.tasks.apps.logger")
+    def test_logs_exception_and_does_not_raise(self, mock_logger):
+        """An unexpected exception is caught and logged; the function never raises."""
+        mock_file_path = MagicMock()
+        mock_file_path.open.side_effect = OSError("file not found")
+
+        mock_aap_flag_class = MagicMock()
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+        ):
+            load_task_feature_flags()  # must not raise
+
+        mock_logger.exception.assert_called_once_with("Failed to load tasks feature flags into AAPFlag")
+
+    @patch("apps.tasks.apps.logger")
+    def test_empty_yaml_is_a_no_op(self, mock_logger):
+        """An empty YAML file results in no AAPFlag interactions."""
+        mock_file_path, mock_aap_flag_class = _make_patches(flags=[], existing_flag=None)
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+            patch(
+                "ansible_base.resource_registry.signals.handlers.no_reverse_sync",
+                return_value=nullcontext(),
+            ),
+        ):
+            load_task_feature_flags()
+
+        mock_aap_flag_class.objects.filter.assert_not_called()
+        mock_logger.exception.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # TasksConfig.ready wires up the signal
+    # ------------------------------------------------------------------
+
+    def test_ready_connects_signal_to_feature_flags_app(self):
+        """TasksConfig.ready() connects load_task_feature_flags to FeatureFlagsConfig post_migrate."""
+        from ansible_base.feature_flags.apps import FeatureFlagsConfig
+        from django.db.models.signals import post_migrate
+
+        from apps.tasks.apps import TasksConfig, load_task_feature_flags
+
+        config = TasksConfig("apps.tasks", __import__("apps.tasks"))
+        with patch.object(post_migrate, "connect") as mock_connect:
+            config.ready()
+
+        mock_connect.assert_called_once_with(load_task_feature_flags, sender=FeatureFlagsConfig)

--- a/tests/unit/tasks/test_tasks_apps.py
+++ b/tests/unit/tasks/test_tasks_apps.py
@@ -181,9 +181,7 @@ class TestLoadTaskFeatureFlags(TestCase):
         ):
             load_task_feature_flags()
 
-        expected_calls = [
-            call(name=f["name"], condition=f["condition"]) for f in _SAMPLE_FLAGS
-        ]
+        expected_calls = [call(name=f["name"], condition=f["condition"]) for f in _SAMPLE_FLAGS]
         assert mock_aap_flag_class.objects.filter.call_args_list == expected_calls
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
- Added support for loading task feature flags from a new YAML file in the tasks app, ensuring feature flags persist through migrations.
- Updated URL routing for the dashboard to use a more RESTful structure, changing the dashboard path to "api/dashboard/".
- Introduced a redirect for the feature flags API endpoint to point to the canonical states list.
- Included new template files for the dashboard and tasks in the package data configuration.

This commit improves the organization of feature flags and enhances the API structure for better usability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes feature-flag persistence by hooking `post_migrate` to upsert `AAPFlag` records and updates public URL paths/redirects, which can affect migrations and client integrations if misconfigured.
> 
> **Overview**
> Adds tasks-owned feature flags that are (re)seeded into `dab_feature_flags.AAPFlag` from a new `apps/tasks/feature_flags.yaml` on `post_migrate`, ensuring they survive DAB’s purge/load cycle and are used as a fallback in `get_feature_enabled_from_db`.
> 
> Updates routing by moving the dashboard endpoint from `/dashboard/` to `/api/dashboard/` and adds a permanent redirect from `/api/v1/feature_flags/` to `/api/v1/feature_flags/states/`; packaging is adjusted to ship the dashboard templates and the new tasks YAML, with unit tests expanded to cover the new flag-loading and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56603cce5a30f2b4a11500b2e1d53e06a56bc928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->