### PR TITLE
Refactor task feature flag handling and enhance initialization logic

### DIFF
--- a/apps/tasks/apps.py
+++ b/apps/tasks/apps.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 _FEATURE_FLAGS_FILE = Path(__file__).parent / "feature_flags.yaml"
 
 
-def load_task_feature_flags(**kwargs):
+def load_task_feature_flags(**kwargs) -> bool:
     """
     Upsert tasks feature flags into AAPFlag after each DAB purge cycle.
 
@@ -22,6 +22,10 @@ def load_task_feature_flags(**kwargs):
     purge_feature_flags() + load_feature_flags() in create_initial_data(). This
     ensures task-level feature flags survive every DAB migration without requiring
     a change to the django-ansible-base feature_flags.yaml.
+
+    Returns True if flags were loaded successfully. On failure, logs at WARNING
+    (with exception context) and returns False without re-raising, so migrate and
+    other callers are not aborted by optional flag seeding.
     """
     try:
         from ansible_base.resource_registry.signals.handlers import no_reverse_sync
@@ -52,7 +56,12 @@ def load_task_feature_flags(**kwargs):
                     flag.save()
             logger.debug("Loaded task feature flag: %s", flag_def["name"])
     except Exception:
-        logger.exception("Failed to load tasks feature flags into AAPFlag")
+        logger.warning(
+            "Failed to load tasks feature flags into AAPFlag",
+            exc_info=True,
+        )
+        return False
+    return True
 
 
 class TasksConfig(AppConfig):

--- a/apps/tasks/apps.py
+++ b/apps/tasks/apps.py
@@ -68,6 +68,14 @@ class TasksConfig(AppConfig):
         # are (re)loaded after every DAB purge_feature_flags() + load_feature_flags()
         # cycle. INSTALLED_APPS order ensures ansible_base.feature_flags connects its
         # handler first, so DAB's purge runs before ours adds the flags back.
-        from ansible_base.feature_flags.apps import FeatureFlagsConfig
+        #
+        # post_migrate dispatches with sender=<AppConfig instance>, not the class,
+        # so we must pass the live instance here — id(class) != id(instance) and
+        # Django's signal dispatch matches by id(), so using the class would mean
+        # load_task_feature_flags is never called.
+        from django.apps import apps as django_apps
 
-        post_migrate.connect(load_task_feature_flags, sender=FeatureFlagsConfig)
+        post_migrate.connect(
+            load_task_feature_flags,
+            sender=django_apps.get_app_config("dab_feature_flags"),
+        )

--- a/apps/tasks/management/commands/metrics_service.py
+++ b/apps/tasks/management/commands/metrics_service.py
@@ -228,9 +228,15 @@ class Command(BaseCommand):
         """Handle the init-default-settings command."""
         try:
             from apps.dynamic_settings.utils import initialize_default_settings
+            from apps.tasks.apps import load_task_feature_flags
 
             overwrite = options.get("overwrite", False) if options else False
             initialize_default_settings(overwrite=overwrite)
+            # Seed metrics-specific AAPFlags from feature_flags.yaml. This
+            # mirrors what the post_migrate signal does during `migrate`, but
+            # must also run here because init-default-settings is called in
+            # production without a preceding migrate (DB is pre-migrated).
+            load_task_feature_flags()
             self.output.success("Initialized default settings")
         except Exception as e:
             raise CommandError(f"Failed to initialize default settings: {e}") from e

--- a/apps/tasks/management/commands/metrics_service.py
+++ b/apps/tasks/management/commands/metrics_service.py
@@ -236,8 +236,12 @@ class Command(BaseCommand):
             # mirrors what the post_migrate signal does during `migrate`, but
             # must also run here because init-default-settings is called in
             # production without a preceding migrate (DB is pre-migrated).
-            load_task_feature_flags()
-            self.output.success("Initialized default settings")
+            if load_task_feature_flags():
+                self.output.success("Initialized default settings")
+            else:
+                self.output.warning(
+                    "Initialized default settings in the database, but task feature flags could not be seeded; see logs.",
+                )
         except Exception as e:
             raise CommandError(f"Failed to initialize default settings: {e}") from e
 

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -72,9 +72,7 @@ def get_feature_enabled_from_db(setting_name: str, default: bool = False) -> boo
     except Exception as e:
         logger.warning(f"Error reading feature enabled setting {setting_name} from database: {e}")
         feature_enabled = getattr(settings, "FEATURE_ENABLED", {})
-        if setting_name in feature_enabled:
-            return bool(feature_enabled[setting_name])
-        return default
+        return bool(feature_enabled[setting_name]) if setting_name in feature_enabled else default
 
 
 class TaskGroup:

--- a/tests/unit/core/test_metrics_service_command.py
+++ b/tests/unit/core/test_metrics_service_command.py
@@ -373,6 +373,20 @@ class TestInitDefaultSettingsCommand(BaseCommandTestCase):
         output = self.out.getvalue()
         assert "Initialized default settings" in output
 
+    @patch("apps.tasks.apps.load_task_feature_flags")
+    @patch("apps.dynamic_settings.utils.initialize_default_settings")
+    def test_handle_init_default_settings_seeds_aap_flags(self, mock_initialize, mock_load_flags):
+        """init-default-settings also calls load_task_feature_flags to seed AAPFlags.
+
+        In production the DB is pre-migrated before the service starts, so the
+        post_migrate signal that normally seeds AAPFlags during `migrate` never fires.
+        init-default-settings must therefore call load_task_feature_flags() directly.
+        """
+        self.setup_command_output()
+        self.command._handle_init_default_settings_command()
+
+        mock_load_flags.assert_called_once()
+
     @patch("apps.dynamic_settings.utils.initialize_default_settings")
     def test_handle_init_default_settings_error_handling(self, mock_initialize):
         """Test error handling in _handle_init_default_settings_command."""

--- a/tests/unit/dashboard_reports/test_urls.py
+++ b/tests/unit/dashboard_reports/test_urls.py
@@ -42,9 +42,7 @@ class TestURLReverse:
         "viewname, endpoint, kwargs",
         [
             pytest.param("v1:organizations-list", "organizations", None, id="organizations_list"),
-            pytest.param(
-                "v1:organizations-detail", "organizations", {"pk": 1}, id="organizations_detail"
-            ),
+            pytest.param("v1:organizations-detail", "organizations", {"pk": 1}, id="organizations_detail"),
             pytest.param("v1:templates-list", "templates", None, id="templates_list"),
             pytest.param("v1:templates-detail", "templates", {"pk": 1}, id="templates_detail"),
             pytest.param("v1:projects-list", "projects", None, id="projects_list"),

--- a/tests/unit/tasks/test_feature_enabled_db.py
+++ b/tests/unit/tasks/test_feature_enabled_db.py
@@ -204,9 +204,8 @@ class TestFeatureEnabledAAPFlagFallback(TestCase):
 
     def test_dashboard_collection_uses_aap_flag_when_omitted_from_feature_enabled(self):
         """When the key is absent from FEATURE_ENABLED, the platform AAPFlag applies."""
-        with self._patch_aap_flag(self._make_mock_flag("True")):
-            with override_settings(FEATURE_ENABLED={}):
-                assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=False) is True
+        with self._patch_aap_flag(self._make_mock_flag("True")), override_settings(FEATURE_ENABLED={}):
+            assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=False) is True
 
     @override_settings(FEATURE_ENABLED={"SETTINGS_FLAG": True})
     def test_feature_enabled_settings_used_when_no_aap_flag(self):

--- a/tests/unit/tasks/test_tasks_apps.py
+++ b/tests/unit/tasks/test_tasks_apps.py
@@ -227,14 +227,23 @@ class TestLoadTaskFeatureFlags(TestCase):
     # ------------------------------------------------------------------
 
     def test_ready_connects_signal_to_feature_flags_app(self):
-        """TasksConfig.ready() connects load_task_feature_flags to FeatureFlagsConfig post_migrate."""
-        from ansible_base.feature_flags.apps import FeatureFlagsConfig
+        """TasksConfig.ready() connects load_task_feature_flags to the dab_feature_flags
+        AppConfig *instance*, not the class.
+
+        post_migrate dispatches with sender=<AppConfig instance>. Django's signal
+        dispatch matches by id(), so id(class) != id(instance) — connecting with the
+        class means the handler is never called. We must pass the live instance from
+        django.apps.apps.get_app_config("dab_feature_flags").
+        """
+        from django.apps import apps as django_apps
         from django.db.models.signals import post_migrate
 
         from apps.tasks.apps import TasksConfig, load_task_feature_flags
+
+        dab_ff_instance = django_apps.get_app_config("dab_feature_flags")
 
         config = TasksConfig("apps.tasks", __import__("apps.tasks"))
         with patch.object(post_migrate, "connect") as mock_connect:
             config.ready()
 
-        mock_connect.assert_called_once_with(load_task_feature_flags, sender=FeatureFlagsConfig)
+        mock_connect.assert_called_once_with(load_task_feature_flags, sender=dab_ff_instance)

--- a/tests/unit/tasks/test_tasks_apps.py
+++ b/tests/unit/tasks/test_tasks_apps.py
@@ -200,9 +200,12 @@ class TestLoadTaskFeatureFlags(TestCase):
             patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
             patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
         ):
-            load_task_feature_flags()  # must not raise
+            assert load_task_feature_flags() is False  # must not raise
 
-        mock_logger.exception.assert_called_once_with("Failed to load tasks feature flags into AAPFlag")
+        mock_logger.warning.assert_called_once_with(
+            "Failed to load tasks feature flags into AAPFlag",
+            exc_info=True,
+        )
 
     @patch("apps.tasks.apps.logger")
     def test_empty_yaml_is_a_no_op(self, mock_logger):


### PR DESCRIPTION
- Updated the connection of the `load_task_feature_flags` function to use the live instance of the `dab_feature_flags` AppConfig instead of the class, ensuring proper signal dispatching during post-migration.
- Modified the `init-default-settings` command to directly call `load_task_feature_flags`, allowing for the seeding of metrics-specific AAPFlags when the database is pre-migrated.
- Added unit tests to verify that `load_task_feature_flags` is called during the initialization of default settings, ensuring correct behavior in production environments.

This commit improves the reliability of feature flag management during application initialization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches migration signal wiring and production init code paths for feature-flag seeding; failures are now non-fatal but could change when/if flags appear in the DB.
> 
> **Overview**
> Fixes task AAPFlag seeding so it actually runs and doesn’t block deployments.
> 
> `TasksConfig.ready()` now connects the `post_migrate` handler using the live `dab_feature_flags` `AppConfig` instance (not the class), and `load_task_feature_flags()` now returns `True/False` while logging failures at WARNING and allowing migrations to continue.
> 
> The `metrics_service init-default-settings` path now also calls `load_task_feature_flags()` to seed flags in pre-migrated production environments, with new/updated unit tests covering the new return value, signal wiring, and init behavior; minor test-only formatting/simplification included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25eb9dabf8c64004924435a5fe24f6843dbaf94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->