### PR TITLE
Enhance metrics collection feature flag management

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ GET /api/v1/tasks/available_functions/
 - `hello_world` - Simple test task for dispatcherd integration
 - `execute_db_task` - Execute database-defined tasks with lifecycle management
 
-**Metrics Collection Tasks** (always enabled - run regardless of opt-out flag):
+**Metrics Collection Tasks** (controlled by `METRICS_COLLECTION`, default: enabled):
 
 - `collect_hourly_metrics` - Collect time-series metrics every hour (collector type via `collector_type` parameter)
 - `collect_snapshot_metrics` - Collect daily snapshot metrics (collector type via `collector_type` parameter)
@@ -159,18 +159,25 @@ We have these feature flags:
 
 |flag|default|
 |-|-|
+|`METRICS_COLLECTION`|true|
 |`ANONYMIZED_DATA_COLLECTION`|true|
+|`DASHBOARD_COLLECTION`|false (customer opt-in)|
 
-You can change the default value using the `METRICS_SERVICE_FEATURE_ENABLED__` prefixed-environment variables.
+You can change defaults using `METRICS_SERVICE_FEATURE_ENABLED__` prefixed environment variables.
 
 ```sh
-# Enable/disable anonymized data collection (default: true)
+# Pause local collectors, rollup, and metrics cleanup (default: true)
+METRICS_SERVICE_FEATURE_ENABLED__METRICS_COLLECTION=false
+
+# Disable anonymization and Segment transmission (default: true)
 METRICS_SERVICE_FEATURE_ENABLED__ANONYMIZED_DATA_COLLECTION=false
 ```
 
-These environment variables (or their default values) are used to populate the feature flags database tables during `mangage.py metrics_service init-default-settings`. You can also use `python manage.py metrics_service remove-default-settings` to remove these settings from the database.
+These environment variables (or their default values) are used to populate the feature flags database tables during `manage.py metrics_service init-default-settings`. You can also use `python manage.py metrics_service remove-default-settings` to remove these settings from the database.
 
-The feature flag value in the database determines whether the anonymization and transmission tasks run. Collection, rollup, and cleanup tasks always run regardless of this flag. If the value is missing from the database, the environment variable is used as the fallback.
+The feature flag values in the database determine which scheduled tasks run (checked at execution time). If a value is missing from the database, the environment variable or static default is used as the fallback.
+
+After upgrading to a version that adds `METRICS_COLLECTION`, run `python manage.py metrics_service init-system-tasks` once so system tasks include `_feature_flag` for metrics collection templates.
 
 
 ## Development

--- a/apps/dynamic_settings/utils.py
+++ b/apps/dynamic_settings/utils.py
@@ -151,9 +151,13 @@ def rollback_configuration_change(change_id, user):
 # Define default feature flags - same as in initialize_default_settings
 # default_value is the fallback, set the actual default in apps/settings/defaults.py
 DEFAULT_SETTINGS = {
+    "METRICS_COLLECTION": {
+        "default_value": True,
+        "description": "Enable local metrics collection (hourly/daily collectors), daily rollup, and metrics data cleanup",
+    },
     "ANONYMIZED_DATA_COLLECTION": {
         "default_value": True,
-        "description": "Enable anonymized data collection and transmission to Red Hat (includes metrics collection, rollup, anonymization, and sending)",
+        "description": "Enable anonymization of daily rollup and transmission to Red Hat (Segment); does not gate local metrics collection",
     },
 }
 

--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -123,7 +123,10 @@ DATABASES = {
 # and only used when not already changed in the settings DB table
 # also used by tasks - unless set in the db.
 FEATURE_ENABLED = {
-    "ANONYMIZED_DATA_COLLECTION": True,  # Controls all metrics collection, rollup, anonymization, and sending
+    # Local hourly/daily collectors, rollup, cleanup_metrics_data — see METRICS_COLLECTION_GROUP.
+    "METRICS_COLLECTION": True,
+    # Anonymization and Segment transmission only — does not gate METRICS_COLLECTION_GROUP.
+    "ANONYMIZED_DATA_COLLECTION": True,
     # DASHBOARD_COLLECTION is intentionally omitted: set via METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION,
     # DAB AAPFlag FEATURE_DASHBOARD_COLLECTION_ENABLED, or dynamic_settings.Setting — see get_feature_enabled_from_db.
 }

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -154,13 +154,14 @@ SYSTEM_TASKS_GROUP = TaskGroup(
     ],
 )
 
-# Metrics Collection Group - Always enabled, no feature flag.
-# Raw collection, rollup, and cleanup run regardless of the ANONYMIZED_DATA_COLLECTION flag.
-# Operators who opt out of sending data to Red Hat will still collect local metrics
-# to prevent a data gap if sending is enabled later.
+# Metrics Collection Group - Feature flag: METRICS_COLLECTION (default: True).
+# Hourly/daily collectors, rollup, and metrics DB cleanup are gated independently of
+# ANONYMIZED_DATA_COLLECTION (upstream anonymization/Segment). Disabling this stops
+# local scheduled collection; re-enable and run collectors to backfill if needed.
 METRICS_COLLECTION_GROUP = TaskGroup(
     name="metrics_collection",
-    description="Metrics collection, rollup, and cleanup (always enabled)",
+    description="Metrics collection, rollup, and cleanup (METRICS_COLLECTION feature flag)",
+    feature_flag="METRICS_COLLECTION",
     tasks=[
         # Hourly Collection Tasks
         {
@@ -270,8 +271,8 @@ METRICS_COLLECTION_GROUP = TaskGroup(
 )
 
 # Anonymization Group - Controlled by ANONYMIZED_DATA_COLLECTION.
-# Only these two tasks are gated by the flag, disabling it stops data being sent to Red Hat
-# while leaving local collection intact so there is no data gap after enabling again.
+# Disabling the flag stops anonymization / upstream transmission while METRICS_COLLECTION
+# can remain on for local collectors (no data gap when re-enabling anonymization).
 ANONYMIZATION_GROUP = TaskGroup(
     name="anonymization",
     description="Anonymization and transmission of metrics to Red Hat (opt-out via ANONYMIZED_DATA_COLLECTION)",

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -247,7 +247,7 @@ def create_system_tasks() -> dict[str, Any]:
         logger.info(f"Removed {removed_count} existing system tasks")
 
     # Get all task group definitions. Use get_all_tasks_for_init() (not get_all_enabled_tasks())
-    # so that feature-flagged tasks such as daily_anonymize and send_to_segment_daily are always
+    # so that feature-flagged tasks (e.g. daily_anonymize, metrics collectors) are always
     # written to the DB with _feature_flag stored in task_data. The runtime check in
     # cron_scheduler._execute_database_task() then gates execution without requiring re-init
     # when the flag is toggled.

--- a/apps/tasks/tests/test_feature_flag_runtime_check.py
+++ b/apps/tasks/tests/test_feature_flag_runtime_check.py
@@ -74,9 +74,7 @@ class TestFeatureFlagRuntimeCheck:
     @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
     @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
     @patch("apps.tasks.models.Task")
-    def test_recurring_task_skips_when_metrics_collection_disabled(
-        self, mock_task_cls, mock_get_feature, mock_submit
-    ):
+    def test_recurring_task_skips_when_metrics_collection_disabled(self, mock_task_cls, mock_get_feature, mock_submit):
         """Recurring metrics template is not dispatched when METRICS_COLLECTION is false."""
         mock_get_feature.return_value = False
         mock_task = _make_mock_task(
@@ -107,9 +105,7 @@ class TestFeatureFlagRuntimeCheck:
         mock_submit.assert_called_once()
 
     @pytest.mark.django_db
-    @override_settings(
-        FEATURE_ENABLED={"METRICS_COLLECTION": True, "ANONYMIZED_DATA_COLLECTION": True}
-    )
+    @override_settings(FEATURE_ENABLED={"METRICS_COLLECTION": True, "ANONYMIZED_DATA_COLLECTION": True})
     def test_get_all_enabled_tasks_includes_feature_flag(self):
         """get_all_enabled_tasks propagates each group's feature_flag into task configs."""
         from apps.tasks.task_groups import ANONYMIZATION_GROUP, METRICS_COLLECTION_GROUP, get_all_enabled_tasks

--- a/apps/tasks/tests/test_feature_flag_runtime_check.py
+++ b/apps/tasks/tests/test_feature_flag_runtime_check.py
@@ -9,6 +9,7 @@ do not require @pytest.mark.django_db.
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.test import override_settings
 
 from apps.tasks.cron_scheduler import UnifiedTaskScheduler
 
@@ -71,6 +72,28 @@ class TestFeatureFlagRuntimeCheck:
         mock_submit.assert_not_called()
 
     @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
+    @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
+    @patch("apps.tasks.models.Task")
+    def test_recurring_task_skips_when_metrics_collection_disabled(
+        self, mock_task_cls, mock_get_feature, mock_submit
+    ):
+        """Recurring metrics template is not dispatched when METRICS_COLLECTION is false."""
+        mock_get_feature.return_value = False
+        mock_task = _make_mock_task(
+            task_id=7,
+            task_data={"_feature_flag": "METRICS_COLLECTION"},
+            cron_expression="5 * * * *",
+        )
+        mock_task_cls.objects.get.return_value = mock_task
+
+        scheduler = UnifiedTaskScheduler()
+        scheduler._execute_database_task(7)
+
+        mock_get_feature.assert_called_once_with("METRICS_COLLECTION")
+        mock_submit.assert_not_called()
+        mock_task_cls.objects.create.assert_not_called()
+
+    @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")
     @patch("apps.tasks.models.Task")
     def test_task_executes_when_no_feature_flag(self, mock_task_cls, mock_submit):
         """Task executes without a feature flag check when task_data has no _feature_flag."""
@@ -83,9 +106,13 @@ class TestFeatureFlagRuntimeCheck:
 
         mock_submit.assert_called_once()
 
+    @pytest.mark.django_db
+    @override_settings(
+        FEATURE_ENABLED={"METRICS_COLLECTION": True, "ANONYMIZED_DATA_COLLECTION": True}
+    )
     def test_get_all_enabled_tasks_includes_feature_flag(self):
-        """get_all_enabled_tasks propagates the group's feature_flag into each task config."""
-        from apps.tasks.task_groups import METRICS_COLLECTION_GROUP, get_all_enabled_tasks
+        """get_all_enabled_tasks propagates each group's feature_flag into task configs."""
+        from apps.tasks.task_groups import ANONYMIZATION_GROUP, METRICS_COLLECTION_GROUP, get_all_enabled_tasks
 
         all_tasks = get_all_enabled_tasks()
 
@@ -93,6 +120,11 @@ class TestFeatureFlagRuntimeCheck:
             task_id = task["task_id"]
             if task_id in all_tasks:
                 assert "feature_flag" in all_tasks[task_id]
+                assert all_tasks[task_id]["feature_flag"] == "METRICS_COLLECTION"
+
+        for task in ANONYMIZATION_GROUP.tasks:
+            task_id = task["task_id"]
+            if task_id in all_tasks:
                 assert all_tasks[task_id]["feature_flag"] == "ANONYMIZED_DATA_COLLECTION"
 
     @patch("apps.tasks.tasks_system.submit_task_to_dispatcher")

--- a/tests/unit/core/test_metrics_service_command.py
+++ b/tests/unit/core/test_metrics_service_command.py
@@ -304,12 +304,13 @@ class TestInitDefaultSettingsCommand(BaseCommandTestCase):
         # Verify settings were created
         assert Setting.objects.count() > 0
         assert Setting.objects.filter(setting_key="ANONYMIZED_DATA_COLLECTION").exists()
+        assert Setting.objects.filter(setting_key="METRICS_COLLECTION").exists()
 
         # Check output
         output = self.out.getvalue()
         assert "Initialized default settings" in output
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
+    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True, "METRICS_COLLECTION": True})
     def test_handle_init_default_settings_updates_unchanged_defaults(self):
         """Test that init updates unchanged default settings to match current config."""
         from apps.dynamic_settings.models import Setting
@@ -402,7 +403,7 @@ class TestInitDefaultSettingsCommand(BaseCommandTestCase):
         assert "Failed to initialize default settings" in str(exc_info.value)
         assert "Database error" in str(exc_info.value)
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
+    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True, "METRICS_COLLECTION": True})
     def test_handle_init_default_settings_with_overwrite(self):
         """Test that _handle_init_default_settings_command with --overwrite removes even modified settings."""
         from apps.dynamic_settings.models import Setting

--- a/tests/unit/tasks/test_task_groups.py
+++ b/tests/unit/tasks/test_task_groups.py
@@ -18,6 +18,11 @@ from apps.tasks.task_groups import (
     get_all_tasks_for_init,
 )
 
+# override_settings replaces the entire FEATURE_ENABLED dict; include both keys when tests need
+# metrics collectors plus anonymization tasks from get_all_enabled_tasks().
+_FLAGS_METRICS_AND_ANON_ON = {"METRICS_COLLECTION": True, "ANONYMIZED_DATA_COLLECTION": True}
+_FLAGS_METRICS_ON_ANON_OFF = {"METRICS_COLLECTION": True, "ANONYMIZED_DATA_COLLECTION": False}
+
 
 class TestTaskGroup(TestCase):
     """Test the TaskGroup class."""
@@ -164,10 +169,11 @@ class TestPredefinedTaskGroups(TestCase):
         assert "daily_task_cleanup" in task_ids
         assert "hourly_health_check" in task_ids
 
-    def test_metrics_collection_group_always_enabled(self):
-        """Test metrics collection group has no feature flag and always returns its tasks."""
+    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_ON_ANON_OFF)
+    def test_metrics_collection_group_respects_feature_flag(self):
+        """Test metrics collection group is gated by METRICS_COLLECTION (default-on in production settings)."""
         assert METRICS_COLLECTION_GROUP.name == "metrics_collection"
-        assert METRICS_COLLECTION_GROUP.feature_flag is None
+        assert METRICS_COLLECTION_GROUP.feature_flag == "METRICS_COLLECTION"
 
         task_ids = [task["task_id"] for task in METRICS_COLLECTION_GROUP.get_enabled_tasks()]
         assert len(task_ids) > 0
@@ -185,6 +191,11 @@ class TestPredefinedTaskGroups(TestCase):
         # Anonymize and send tasks must NOT be in this group
         assert "daily_anonymize" not in task_ids
         assert "send_to_segment_daily" not in task_ids
+
+    @override_settings(FEATURE_ENABLED={"METRICS_COLLECTION": False})
+    def test_metrics_collection_group_disabled(self):
+        """When METRICS_COLLECTION is false, the group contributes no enabled tasks."""
+        assert METRICS_COLLECTION_GROUP.get_enabled_tasks() == []
 
     def test_anonymization_group_structure(self):
         """Test ANONYMIZATION_GROUP contains only daily_anonymize with the correct flag."""
@@ -206,7 +217,7 @@ class TestPredefinedTaskGroups(TestCase):
         """Test ANONYMIZATION_GROUP returns no tasks when flag is disabled."""
         assert ANONYMIZATION_GROUP.get_enabled_tasks() == []
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
+    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_AND_ANON_ON)
     def test_no_duplicate_cron_slots(self):
         """Assert that no two enabled tasks across all groups share the same cron hour:minute slot.
 
@@ -246,9 +257,9 @@ class TestPredefinedTaskGroups(TestCase):
 class TestTaskGroupFunctions(TestCase):
     """Test utility functions for task groups."""
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": False})
+    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_ON_ANON_OFF)
     def test_get_all_enabled_tasks_flag_false(self):
-        """Collection tasks are present when flag is false, only anonymize/send are absent."""
+        """Metrics collection tasks stay on; anonymization tasks absent when ANONYMIZED_DATA_COLLECTION is false."""
         all_tasks = get_all_enabled_tasks()
         task_ids = list(all_tasks.keys())
 
@@ -256,7 +267,7 @@ class TestTaskGroupFunctions(TestCase):
         assert "daily_task_cleanup" in task_ids
         assert "hourly_health_check" in task_ids
 
-        # Metrics collection tasks - (always enabled regardless of the flag)
+        # Metrics collection tasks (METRICS_COLLECTION still true)
         assert "hourly_job_host_summary" in task_ids
         assert "daily_metrics_rollup" in task_ids
         assert "cleanup_metrics_data" in task_ids
@@ -270,7 +281,7 @@ class TestTaskGroupFunctions(TestCase):
             assert "group" in task_config
             assert "group_description" in task_config
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
+    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_AND_ANON_ON)
     def test_get_all_enabled_tasks_flag_true(self):
         """All tasks including anonymize/send are present when flag is true."""
         all_tasks = get_all_enabled_tasks()
@@ -280,9 +291,9 @@ class TestTaskGroupFunctions(TestCase):
         assert "hourly_job_host_summary" in task_ids
         assert "daily_metrics_rollup" in task_ids
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": False})
+    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_ON_ANON_OFF)
     def test_get_all_tasks_for_init_includes_flagged_tasks(self):
-        """get_all_tasks_for_init() returns anonymize/send tasks even when flag is false."""
+        """get_all_tasks_for_init() returns anonymize and metrics tasks regardless of flag values."""
         all_tasks = get_all_tasks_for_init()
         task_ids = list(all_tasks.keys())
 
@@ -291,6 +302,7 @@ class TestTaskGroupFunctions(TestCase):
 
         # The feature_flag must be stored in its config for runtime checking
         assert all_tasks["daily_anonymize"]["feature_flag"] == "ANONYMIZED_DATA_COLLECTION"
+        assert all_tasks["hourly_job_host_summary"]["feature_flag"] == "METRICS_COLLECTION"
 
         # Collection tasks must also be present
         assert "hourly_job_host_summary" in task_ids
@@ -302,6 +314,18 @@ class TestTaskGroupFunctions(TestCase):
         all_tasks = get_all_tasks_for_init()
         # hourly_job_events has enabled=False in METRICS_COLLECTION_GROUP
         assert "hourly_job_events" not in all_tasks
+
+    @override_settings(FEATURE_ENABLED={"METRICS_COLLECTION": False, "ANONYMIZED_DATA_COLLECTION": True})
+    def test_get_all_enabled_tasks_metrics_collection_false_excludes_pipeline(self):
+        """When METRICS_COLLECTION is false, hourly/daily collectors and rollup/cleanup are omitted."""
+        all_tasks = get_all_enabled_tasks()
+        task_ids = list(all_tasks.keys())
+
+        assert "daily_task_cleanup" in task_ids
+        assert "hourly_job_host_summary" not in task_ids
+        assert "daily_metrics_rollup" not in task_ids
+        assert "cleanup_metrics_data" not in task_ids
+        assert "daily_anonymize" in task_ids
 
 
 class TestTaskGroupIntegration(TestCase):
@@ -321,7 +345,7 @@ class TestTaskGroupIntegration(TestCase):
         assert scheduler == mock_scheduler
         assert scheduler.running is True
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
+    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_AND_ANON_ON)
     def test_all_flags_enabled(self):
         """Test that all tasks are present when ANONYMIZED_DATA_COLLECTION is enabled."""
         all_tasks = get_all_enabled_tasks()
@@ -330,16 +354,16 @@ class TestTaskGroupIntegration(TestCase):
         # System tasks
         assert any("cleanup" in task_id for task_id in task_ids)
 
-        # Metrics collection tasks (always on)
+        # Metrics collection tasks
         assert any("hourly" in task_id for task_id in task_ids)
         assert "daily_metrics_rollup" in task_ids
 
         # Anonymization tasks (from ANONYMIZATION_GROUP, enabled when flag is true)
         assert "daily_anonymize" in task_ids
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": False})
+    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_ON_ANON_OFF)
     def test_flag_false_stops_only_anonymize_send(self):
-        """Collection and cleanup tasks are present when flag is false; only anonymize/send are absent."""
+        """When ANONYMIZED_DATA_COLLECTION is false but METRICS_COLLECTION is true, only anonymize is absent."""
         all_tasks = get_all_enabled_tasks()
         task_ids = list(all_tasks.keys())
 


### PR DESCRIPTION
- Updated the README to clarify the control of metrics collection tasks via the `METRICS_COLLECTION` feature flag, which is enabled by default.
- Modified the default settings in `defaults.py` to include `METRICS_COLLECTION` with a description for local metrics collection.
- Refactored task groups in `task_groups.py` to gate metrics collection tasks by the `METRICS_COLLECTION` flag, ensuring local collection can be independently managed from anonymization tasks.
- Added unit tests to verify the behavior of metrics collection tasks when the feature flag is toggled, ensuring proper task execution based on the flag's state.

This commit improves the clarity and functionality of metrics collection management within the application.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scheduled task enablement for the core metrics pipeline; misconfiguration or missing re-init could stop local collection/cleanup until flags and system tasks are seeded correctly.
> 
> **Overview**
> Adds a new default-on feature flag, `METRICS_COLLECTION`, to control whether *local* metrics collectors, rollup, and metrics cleanup tasks run, decoupling that behavior from `ANONYMIZED_DATA_COLLECTION` (which now only gates anonymization/transmission).
> 
> Updates task group definitions so `METRICS_COLLECTION_GROUP` is feature-flagged and ensures `init-system-tasks` persists `_feature_flag` on metrics templates for runtime gating. Expands docs and tests to cover flag seeding and scheduler behavior when either flag is toggled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ca486050fcdb10326c67704588870967d569118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->