### PR TITLE
AAP-72500: Refactor database connection handling in _collect_data function

### DIFF
--- a/apps/core/views/health.py
+++ b/apps/core/views/health.py
@@ -1,5 +1,5 @@
 from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
-from django.db import connection
+from django.db import close_old_connections, connection
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -20,6 +20,8 @@ class HealthView(AnsibleBaseView):
 
         # Database check
         try:
+            # Close any stale connections before health check
+            close_old_connections()
             connection.ensure_connection()
             health_status["checks"]["database"] = "ok"
         except Exception as e:

--- a/apps/dashboard_reports/tasks.py
+++ b/apps/dashboard_reports/tasks.py
@@ -93,7 +93,6 @@ def _collect_data(task_name: str, **kwargs) -> dict[str, Any]:
         "data": {"task_type": task_name, "date_range": {"start": None, "end": None}, "job_count": 0},
     }
     db_name = kwargs.get("database", DEFAULT_DB_NAME)
-    db_connection = None
     until = _parse_dt(kwargs.get("until"))
     since = _parse_dt(kwargs.get("since"))
 
@@ -131,12 +130,6 @@ def _collect_data(task_name: str, **kwargs) -> dict[str, Any]:
         result["error"] = True
         result["message"] = f"Collecting jobs failed: {str(e)}"
         return result
-    finally:
-        if db_connection is not None:
-            try:
-                db_connection.close()
-            except Exception:
-                logger.warning("Failed to close AWX DB connection in _collect_data()")
 
     failed_jobs = _sync_jobs_atomically(jobs["results"])
 

--- a/apps/dashboard_reports/viewsets/filter_options.py
+++ b/apps/dashboard_reports/viewsets/filter_options.py
@@ -67,9 +67,7 @@ class FilterOptionsViewSet(GenericViewSet):
         and forwarded to awx_query_function, which applies them via SQL LIMIT/OFFSET and also
         runs a COUNT(*) query.  The paginator is then initialised with a range() of the total
         count so that next/previous links are built correctly without slicing an in-memory list.
-        Ensures DB connection is closed after use.
         """
-        db_connection = None
         try:
             db_connection = get_db_connection("awx")
             page_size = self.paginator.get_page_size(request)
@@ -93,17 +91,10 @@ class FilterOptionsViewSet(GenericViewSet):
             logger.exception(self.list_error_msg)
             error_response = build_error_response(self.list_error_msg, status_code=500)
             return Response(error_response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-        finally:
-            if db_connection:
-                try:
-                    db_connection.close()
-                except Exception:
-                    logger.warning("Failed to close AWX DB connection in list()")
 
     def retrieve(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """
         Returns a single filter dropdown item by ID from AWX database.
-        Ensures DB connection is closed after use.
         """
         try:
             pk = int(kwargs.get("pk"))
@@ -116,7 +107,6 @@ class FilterOptionsViewSet(GenericViewSet):
             error_response = build_error_response(self.not_found_msg(pk), status_code=404)
             return Response(error_response, status=status.HTTP_404_NOT_FOUND)
 
-        db_connection = None
         try:
             db_connection = get_db_connection("awx")
             data, _ = self.awx_query_function(db_connection=db_connection, pk=pk)
@@ -125,9 +115,3 @@ class FilterOptionsViewSet(GenericViewSet):
             logger.exception(self.retrieve_error_msg)
             error_response = build_error_response(self.retrieve_error_msg, status_code=500)
             return Response(error_response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-        finally:
-            if db_connection:
-                try:
-                    db_connection.close()
-                except Exception:
-                    logger.warning("Failed to close AWX DB connection in retrieve()")

--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -300,14 +300,12 @@ def get_db_connection(db_name: str = "awx"):
         DO NOT CLOSE the returned connection. It is a Django-managed singleton
         shared across multiple tasks. Django handles connection lifecycle.
     """
-    from django.db import close_old_connections, connections
-
-    # Close any stale/unusable connections first
-    # This handles CONN_MAX_AGE expiry and connections with errors_occurred flag
-    close_old_connections()
+    from django.db import connections
 
     # Get the raw connection to bypass Django's cursor wrapper
     # This is necessary for PostgreSQL COPY commands used by metrics-utility
+    # NOTE: Do not call close_old_connections() here as it closes ALL connections
+    # including the default connection that may be holding advisory locks in run_with_lock()
     django_connection = connections[db_name]
 
     # Ensure the connection is open

--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -330,8 +330,11 @@ def run_with_lock(lock_key: str, task_name: str, fn, **kwargs):
         fn: Task function to execute
         **kwargs: Arguments to pass to fn
     """
-    from django.db import connection
+    from django.db import close_old_connections, connection
     from metrics_utility.library.lock import lock
+
+    # Close any stale/unusable connections before acquiring lock
+    close_old_connections()
 
     with lock(lock_key, wait=False, db=connection) as acquired:
         if not acquired:

--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -287,13 +287,24 @@ def get_db_connection(db_name: str = "awx"):
     to use the raw connection for metrics-utility collectors that use COPY
     for efficient data extraction.
 
+    This function ensures the connection is healthy by calling close_old_connections()
+    which closes stale/unusable connections and respects CONN_MAX_AGE settings.
+
     Args:
         db_name: Database name from Django settings (default: 'awx')
 
     Returns:
         Raw database connection object (psycopg2 connection)
+
+    Note:
+        DO NOT CLOSE the returned connection. It is a Django-managed singleton
+        shared across multiple tasks. Django handles connection lifecycle.
     """
-    from django.db import connections
+    from django.db import close_old_connections, connections
+
+    # Close any stale/unusable connections first
+    # This handles CONN_MAX_AGE expiry and connections with errors_occurred flag
+    close_old_connections()
 
     # Get the raw connection to bypass Django's cursor wrapper
     # This is necessary for PostgreSQL COPY commands used by metrics-utility

--- a/tests/unit/dashboard_reports/test_filters.py
+++ b/tests/unit/dashboard_reports/test_filters.py
@@ -232,7 +232,6 @@ class TestFilterOptionsViewSet:
         request = MagicMock()
         response = viewset.retrieve(request, pk=1)
 
-        assert mock_db.close.called, "close() was never called — db_connection may be falsy"
         assert response.status_code == 200
 
     @patch("apps.dashboard_reports.viewsets.filter_options.get_db_connection")
@@ -248,7 +247,6 @@ class TestFilterOptionsViewSet:
         response = viewset.list(request)
 
         assert response.status_code == 200
-        assert mock_db.close.called
 
     @patch("apps.dashboard_reports.viewsets.filter_options.get_db_connection")
     def test_list_db_connection_close_failure_on_success(self, mock_conn, viewset):

--- a/tests/unit/dashboard_reports/test_tasks.py
+++ b/tests/unit/dashboard_reports/test_tasks.py
@@ -433,3 +433,39 @@ class TestDashboardReportsTasks:
         assert old_job2.id not in remaining_ids
         assert new_job1.id in remaining_ids
         assert new_job2.id in remaining_ids
+
+
+@pytest.mark.unit
+class TestCollectDataConnectionHandling:
+    """Regression tests for shared AWX DB connection lifecycle in _collect_data.
+
+    get_db_connection() returns Django's singleton raw psycopg connection object
+    (connections["awx"].connection). If _collect_data were to close that object
+    directly, any concurrent task holding the same reference would receive
+    'psycopg.OperationalError: the connection is closed'.  These tests pin the
+    invariant: _collect_data must never call .close() on the connection it receives,
+    regardless of whether collection succeeds or fails.
+    """
+
+    def test_does_not_close_connection_on_success(self, mock_dependencies):
+        """Connection is left open after a successful collection."""
+        mock_db_conn, mock_job_data, mock_dashboard_jobs, _ = mock_dependencies
+        mock_connection = MagicMock()
+        mock_db_conn.return_value = mock_connection
+        setup_collect_data_mocks(mock_job_data, mock_dashboard_jobs, jobs_result={"results": [{"id": 1}], "count": 1})
+
+        with patch("apps.dashboard_reports.tasks._sync_jobs_atomically", return_value=[]):
+            _collect_data("test_task")
+
+        mock_connection.close.assert_not_called()
+
+    def test_does_not_close_connection_on_gather_error(self, mock_dependencies):
+        """Connection is left open even when the collect step raises an exception."""
+        mock_db_conn, mock_job_data, mock_dashboard_jobs, _ = mock_dependencies
+        mock_connection = MagicMock()
+        mock_db_conn.return_value = mock_connection
+        setup_collect_data_mocks(mock_job_data, mock_dashboard_jobs, gather_exc=Exception("gather failed"))
+
+        _collect_data("test_task")
+
+        mock_connection.close.assert_not_called()

--- a/tests/unit/general/test_health_metrics.py
+++ b/tests/unit/general/test_health_metrics.py
@@ -39,7 +39,8 @@ class TestHealthEndpoint:
         assert response.status_code == status.HTTP_200_OK
 
     @pytest.mark.django_db
-    def test_health_check_fails_when_segment_payloads_failed(self, client):
+    @patch("apps.core.views.health.close_old_connections")
+    def test_health_check_fails_when_segment_payloads_failed(self, mock_close, client):
         """Test that health endpoint reports segment check failed when single failed segment payload exist."""
         from datetime import timedelta
 
@@ -61,7 +62,8 @@ class TestHealthEndpoint:
         assert response.status_code == status.HTTP_200_OK
 
     @pytest.mark.django_db
-    def test_health_check_fails_when_multiple_segment_payloads_failed(self, client):
+    @patch("apps.core.views.health.close_old_connections")
+    def test_health_check_fails_when_multiple_segment_payloads_failed(self, mock_close, client):
         """Test that health endpoint reports segment check failed status when many failed segment payloads exist."""
         from datetime import timedelta
 
@@ -96,7 +98,8 @@ class TestHealthEndpoint:
         assert response.status_code == status.HTTP_200_OK
 
     @pytest.mark.django_db
-    def test_health_check_passes_when_multiple_segment_payloads_send(self, client):
+    @patch("apps.core.views.health.close_old_connections")
+    def test_health_check_passes_when_multiple_segment_payloads_send(self, mock_close, client):
         """Test that health endpoint reports segment ok when many failed segment payloads exist."""
         from datetime import timedelta
 

--- a/tests/unit/tasks/test_tasks_utils_comprehensive.py
+++ b/tests/unit/tasks/test_tasks_utils_comprehensive.py
@@ -265,8 +265,15 @@ class TestGetDbConnection(TestCase):
 
     @patch("django.db.close_old_connections")
     @patch("django.db.connections")
-    def test_get_db_connection_calls_close_old_connections(self, mock_connections, mock_close_old):
-        """Test that get_db_connection calls close_old_connections before getting connection."""
+    def test_get_db_connection_does_not_call_close_old_connections(self, mock_connections, mock_close_old):
+        """Test that get_db_connection does NOT call close_old_connections.
+
+        close_old_connections() closes ALL Django connections, not just one.
+        If called during task execution, it can close connections holding advisory locks,
+        causing lock release failures.
+
+        close_old_connections() should only be called at task entry points like run_with_lock().
+        """
         mock_raw_conn = MagicMock()
         mock_django_conn = MagicMock()
         mock_django_conn.connection = mock_raw_conn
@@ -274,31 +281,11 @@ class TestGetDbConnection(TestCase):
 
         result = utils.get_db_connection()
 
-        # Verify close_old_connections was called
-        mock_close_old.assert_called_once()
-        # Verify it was called before ensure_connection
-        self.assertTrue(mock_close_old.called)
+        # Verify close_old_connections was NOT called
+        mock_close_old.assert_not_called()
+        # Verify ensure_connection was still called
         mock_django_conn.ensure_connection.assert_called_once()
         self.assertEqual(result, mock_raw_conn)
-
-    @patch("django.db.close_old_connections")
-    @patch("django.db.connections")
-    def test_get_db_connection_call_order(self, mock_connections, mock_close_old):
-        """Test that close_old_connections is called before ensure_connection."""
-        mock_raw_conn = MagicMock()
-        mock_django_conn = MagicMock()
-        mock_django_conn.connection = mock_raw_conn
-        mock_connections.__getitem__.return_value = mock_django_conn
-
-        # Track call order
-        call_order = []
-        mock_close_old.side_effect = lambda: call_order.append("close_old")
-        mock_django_conn.ensure_connection.side_effect = lambda: call_order.append("ensure")
-
-        utils.get_db_connection()
-
-        # Verify close_old_connections was called before ensure_connection
-        self.assertEqual(call_order, ["close_old", "ensure"])
 
 
 class TestRunWithLock(TestCase):
@@ -328,6 +315,25 @@ class TestRunWithLock(TestCase):
         fn.assert_not_called()
         self.assertEqual(result["status"], "error")
         self.assertIn("Could not acquire lock", result["error"])
+
+    @patch("django.db.close_old_connections")
+    @patch("metrics_utility.library.lock.lock")
+    def test_run_with_lock_calls_close_old_connections(self, mock_lock_cls, mock_close_old):
+        """Test that run_with_lock calls close_old_connections before acquiring lock.
+
+        This is critical because close_old_connections() must be called BEFORE
+        acquiring advisory locks to ensure stale connections are cleaned up first.
+        If called during execution, it would close ALL connections including the
+        one holding the lock.
+        """
+        mock_lock_cls.return_value.__enter__ = MagicMock(return_value=True)
+        mock_lock_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        fn = MagicMock(return_value={"status": "success"})
+        utils.run_with_lock("my_lock", "my_task", fn, foo="bar")
+
+        # Verify close_old_connections was called
+        mock_close_old.assert_called_once()
 
 
 class TestGenerateSalt(TestCase):

--- a/tests/unit/tasks/test_tasks_utils_comprehensive.py
+++ b/tests/unit/tasks/test_tasks_utils_comprehensive.py
@@ -301,7 +301,6 @@ class TestGetDbConnection(TestCase):
         self.assertEqual(call_order, ["close_old", "ensure"])
 
 
-
 class TestRunWithLock(TestCase):
     """Test run_with_lock function."""
 

--- a/tests/unit/tasks/test_tasks_utils_comprehensive.py
+++ b/tests/unit/tasks/test_tasks_utils_comprehensive.py
@@ -263,6 +263,44 @@ class TestGetDbConnection(TestCase):
         mock_connections.__getitem__.assert_called_once_with("custom_db")
         self.assertEqual(result, mock_raw_conn)
 
+    @patch("django.db.close_old_connections")
+    @patch("django.db.connections")
+    def test_get_db_connection_calls_close_old_connections(self, mock_connections, mock_close_old):
+        """Test that get_db_connection calls close_old_connections before getting connection."""
+        mock_raw_conn = MagicMock()
+        mock_django_conn = MagicMock()
+        mock_django_conn.connection = mock_raw_conn
+        mock_connections.__getitem__.return_value = mock_django_conn
+
+        result = utils.get_db_connection()
+
+        # Verify close_old_connections was called
+        mock_close_old.assert_called_once()
+        # Verify it was called before ensure_connection
+        self.assertTrue(mock_close_old.called)
+        mock_django_conn.ensure_connection.assert_called_once()
+        self.assertEqual(result, mock_raw_conn)
+
+    @patch("django.db.close_old_connections")
+    @patch("django.db.connections")
+    def test_get_db_connection_call_order(self, mock_connections, mock_close_old):
+        """Test that close_old_connections is called before ensure_connection."""
+        mock_raw_conn = MagicMock()
+        mock_django_conn = MagicMock()
+        mock_django_conn.connection = mock_raw_conn
+        mock_connections.__getitem__.return_value = mock_django_conn
+
+        # Track call order
+        call_order = []
+        mock_close_old.side_effect = lambda: call_order.append("close_old")
+        mock_django_conn.ensure_connection.side_effect = lambda: call_order.append("ensure")
+
+        utils.get_db_connection()
+
+        # Verify close_old_connections was called before ensure_connection
+        self.assertEqual(call_order, ["close_old", "ensure"])
+
+
 
 class TestRunWithLock(TestCase):
     """Test run_with_lock function."""


### PR DESCRIPTION
## Root Cause

Two concurrent tasks — `collect_hourly_metrics` (queue: `metrics`) and `collect_dashboard_reports_data` (queue: `dashboard`) — run in the same dispatcherd worker process, which uses a shared thread pool (`max_workers: 4`). Both tasks call `get_db_connection("awx")`, which returns a direct reference to Django's singleton raw psycopg connection object (`connections["awx"].connection`).

`_collect_data()` had a `finally` block that explicitly closed this raw connection:

\`\`\`python
finally:
    if db_connection is not None:
        try:
            db_connection.close()  # closes the shared raw psycopg socket
        except Exception:
            logger.warning("Failed to close AWX DB connection in _collect_data()")
\`\`\`

Because `get_db_connection()` returns a reference to the same underlying object, closing it in one task invalidates the connection for any other concurrently-running task. Critically, Django's connection wrapper (`connections["awx"]`) is not notified of the close — its internal `self.connection` still points to the now-dead socket. When the other task (or a retry of the same task) calls `ensure_connection()`, Django sees `self.connection is not None` and skips reconnecting, handing back the closed connection. This produces:

```
psycopg.OperationalError: the connection is closed
```

## Fix

Removed the `finally` block and the `db_connection = None` sentinel that existed solely to guard it. Django already manages the lifetime of the `"awx"` connection for the worker thread — no manual close is needed or safe to do on the raw underlying object.

## Why `run_with_lock` doesn't prevent this

`run_with_lock` uses a PostgreSQL advisory lock keyed to the function name. It prevents two instances of the **same** task from running simultaneously, but does nothing to prevent two **different** tasks (e.g. `collect_hourly_metrics` and `collect_dashboard_reports_data`) from running concurrently in the same process and sharing the connection pool.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes database connection lifecycle for background tasks and health checks; mistakes here could cause connection leaks or intermittent task failures under concurrency, though behavior is covered by new regression tests.
> 
> **Overview**
> Prevents concurrent background tasks from breaking each other by **removing manual `.close()` calls on the shared raw AWX DB connection** in `_collect_data` and the dashboard filter dropdown viewset.
> 
> Moves stale-connection cleanup to safer boundaries by calling `close_old_connections()` in `HealthView` before `ensure_connection()` and in `run_with_lock()` before acquiring advisory locks, and adds/updates unit tests to pin the new connection-handling invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dae1cf25f7b4e689b5c109a0815f7e4f054ec354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->