### PR TITLE
[AAP-73154] Fix: scheduler spams skip logs every 30s when feature flag is disabled

### DIFF
--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -128,7 +128,8 @@ FEATURE_ENABLED = {
     # Anonymization and Segment transmission only — does not gate METRICS_COLLECTION_GROUP.
     "ANONYMIZED_DATA_COLLECTION": True,
     # DASHBOARD_COLLECTION is intentionally omitted: set via METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION,
-    # DAB AAPFlag FEATURE_DASHBOARD_COLLECTION_ENABLED, or dynamic_settings.Setting — see get_feature_enabled_from_db.
+    # FEATURE_DASHBOARD_COLLECTION_ENABLED (top-level, installer convention), DAB AAPFlag
+    # FEATURE_DASHBOARD_COLLECTION_ENABLED, or dynamic_settings.Setting — see get_feature_enabled_from_db.
 }
 
 # Used when generating API URLs in views, example "/api/metrics/"; None means "/api/"

--- a/apps/tasks/apps.py
+++ b/apps/tasks/apps.py
@@ -23,6 +23,9 @@ def load_task_feature_flags(**kwargs) -> bool:
     ensures task-level feature flags survive every DAB migration without requiring
     a change to the django-ansible-base feature_flags.yaml.
 
+    Only metadata fields are updated on existing flags — ``value`` is left alone so
+    user-toggled states set via the Gateway UI are not overwritten.
+
     Returns True if flags were loaded successfully. On failure, logs at WARNING
     (with exception context) and returns False without re-raising, so migrate and
     other callers are not aborted by optional flag seeding.
@@ -60,6 +63,62 @@ def load_task_feature_flags(**kwargs) -> bool:
             "Failed to load tasks feature flags into AAPFlag",
             exc_info=True,
         )
+        return False
+    return True
+
+
+def sync_flag_values_from_settings() -> bool:
+    """
+    Propagate installer-level feature flag overrides to AAPFlag rows and the Gateway.
+
+    The installer writes top-level keys like ``FEATURE_DASHBOARD_COLLECTION_ENABLED: True``
+    into settings.yaml. Dynaconf surfaces these as direct settings attributes (e.g.
+    ``settings.FEATURE_DASHBOARD_COLLECTION_ENABLED``), but the AAPFlag row (read by the
+    Gateway) still holds the YAML-seeded default (usually ``False``).
+
+    This function reads each flag defined in ``feature_flags.yaml``, checks for a matching
+    top-level settings attribute, and — when the value differs from the stored AAPFlag —
+    updates the flag and saves **without** ``no_reverse_sync()`` so the change is pushed
+    to the Gateway resource server.
+
+    Called by ``init-default-settings`` (which runs during container startup) so the
+    Gateway reflects the installer's intent after every deploy.
+
+    Returns True if the sync completed without errors, False otherwise.
+    """
+    try:
+        from django.apps import apps as django_apps
+        from django.conf import settings
+
+        AAPFlag = django_apps.get_model("dab_feature_flags", "AAPFlag")
+
+        with _FEATURE_FLAGS_FILE.open() as f:
+            flags = yaml.safe_load(f) or []
+
+        for flag_def in flags:
+            flag_name = flag_def["name"]  # e.g. "FEATURE_DASHBOARD_COLLECTION_ENABLED"
+            settings_value = getattr(settings, flag_name, None)
+            if settings_value is None:
+                continue
+
+            desired = "True" if settings_value else "False"
+
+            flag = AAPFlag.objects.filter(name=flag_name, condition=flag_def.get("condition", "boolean")).first()
+            if flag is None:
+                logger.warning("sync_flag_values_from_settings: AAPFlag %s not found, skipping", flag_name)
+                continue
+
+            if flag.value == desired:
+                logger.debug("AAPFlag %s already set to %s, skipping", flag_name, desired)
+                continue
+
+            flag.value = desired
+            flag.full_clean(exclude=["resource"])
+            flag.save()  # no no_reverse_sync() — intentionally syncs to Gateway
+            logger.info("Updated AAPFlag %s to %s (from settings) and synced to Gateway", flag_name, desired)
+
+    except Exception:
+        logger.warning("Failed to sync flag values from settings to AAPFlag", exc_info=True)
         return False
     return True
 

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -117,6 +117,15 @@ class UnifiedTaskScheduler:
             except Exception as e:
                 logger.error(f"Error stopping cron scheduler: {str(e)}")
 
+    def _task_feature_flag_enabled(self, task) -> bool:
+        """Return False if the task carries a feature flag that is currently disabled."""
+        feature_flag = task.task_data.get("_feature_flag") if task.task_data else None
+        if not feature_flag:
+            return True
+        from .task_groups import get_feature_enabled_from_db
+
+        return get_feature_enabled_from_db(feature_flag)
+
     def _sync_database_tasks(self):
         """Synchronize database tasks with the scheduler."""
         try:
@@ -126,17 +135,22 @@ class UnifiedTaskScheduler:
             scheduled_tasks = Task.scheduled_tasks()
             recurring_tasks = Task.recurring_tasks()
 
-            # Add scheduled tasks
+            added_scheduled = 0
+            added_recurring = 0
+
+            # Add scheduled tasks whose feature flag is currently enabled
             for task in scheduled_tasks:
-                self._add_database_scheduled_task(task)
+                if self._task_feature_flag_enabled(task):
+                    self._add_database_scheduled_task(task)
+                    added_scheduled += 1
 
-            # Add recurring tasks
+            # Add recurring tasks whose feature flag is currently enabled
             for task in recurring_tasks:
-                self._add_database_recurring_task(task)
+                if self._task_feature_flag_enabled(task):
+                    self._add_database_recurring_task(task)
+                    added_recurring += 1
 
-            logger.info(
-                f"Synchronized {len(scheduled_tasks)} scheduled and {len(recurring_tasks)} recurring database tasks"
-            )
+            logger.info(f"Synchronized {added_scheduled} scheduled and {added_recurring} recurring database tasks")
 
         except Exception as e:
             logger.error(f"Error synchronizing database tasks: {e}")
@@ -159,6 +173,8 @@ class UnifiedTaskScheduler:
             # Handle immediate tasks - execute them right away
             for task in immediate_tasks:
                 if task.id not in self._db_task_jobs and task.is_ready_to_run():
+                    if not self._task_feature_flag_enabled(task):
+                        continue
                     logger.info(f"Found new immediate task: {task.name} (ID: {task.id}) - executing now")
                     # Track immediate task to prevent duplicate submissions
                     self._db_task_jobs[task.id] = f"db_immediate_{task.id}"
@@ -168,6 +184,8 @@ class UnifiedTaskScheduler:
             # Check for new scheduled tasks
             for task in scheduled_tasks:
                 if task.id not in self._db_task_jobs:
+                    if not self._task_feature_flag_enabled(task):
+                        continue
                     logger.info(f"Found new scheduled task: {task.name} (ID: {task.id})")
                     self._add_database_scheduled_task(task)
                     new_scheduled += 1
@@ -175,6 +193,8 @@ class UnifiedTaskScheduler:
             # Check for new recurring tasks
             for task in recurring_tasks:
                 if task.id not in self._db_task_jobs:
+                    if not self._task_feature_flag_enabled(task):
+                        continue
                     logger.info(f"Found new recurring task: {task.name} (ID: {task.id})")
                     self._add_database_recurring_task(task)
                     new_recurring += 1
@@ -278,9 +298,7 @@ class UnifiedTaskScheduler:
                 from .task_groups import get_feature_enabled_from_db
 
                 if not get_feature_enabled_from_db(feature_flag):
-                    logger.info(f"Skipping task '{task.name}': feature flag '{feature_flag}' is disabled")
-                    # Remove non-recurring tasks from tracking so they can be
-                    # retried on the next periodic sync when the flag is re-enabled.
+                    logger.debug(f"Skipping task '{task.name}': feature flag '{feature_flag}' is disabled")
                     if not task.cron_expression:
                         self._remove_database_task(task_id)
                     return

--- a/apps/tasks/management/commands/metrics_service.py
+++ b/apps/tasks/management/commands/metrics_service.py
@@ -228,7 +228,7 @@ class Command(BaseCommand):
         """Handle the init-default-settings command."""
         try:
             from apps.dynamic_settings.utils import initialize_default_settings
-            from apps.tasks.apps import load_task_feature_flags
+            from apps.tasks.apps import load_task_feature_flags, sync_flag_values_from_settings
 
             overwrite = options.get("overwrite", False) if options else False
             initialize_default_settings(overwrite=overwrite)
@@ -236,7 +236,11 @@ class Command(BaseCommand):
             # mirrors what the post_migrate signal does during `migrate`, but
             # must also run here because init-default-settings is called in
             # production without a preceding migrate (DB is pre-migrated).
-            if load_task_feature_flags():
+            flags_seeded = load_task_feature_flags()
+            # Propagate installer settings.yaml overrides (e.g. FEATURE_DASHBOARD_COLLECTION_ENABLED: True)
+            # to AAPFlag values so the Gateway UI reflects the installer's intent.
+            sync_flag_values_from_settings()
+            if flags_seeded:
                 self.output.success("Initialized default settings")
             else:
                 self.output.warning(

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -7,7 +7,8 @@ a centralized way to manage different categories of tasks.
 Feature enabled settings are stored in the database using the Setting model, allowing
 runtime configuration without code changes. Values resolve in order: Setting row,
 then settings.FEATURE_ENABLED when the key is present (including env overrides),
-then DAB AAPFlag FEATURE_<name>_ENABLED, then the function default.
+then the direct top-level settings attribute FEATURE_<name>_ENABLED (set by the installer
+via settings.yaml), then DAB AAPFlag FEATURE_<name>_ENABLED, then the function default.
 
 run `manage.py metrics_utility init-system-tasks` to update the DB from `TASK_GROUPS`
 """
@@ -26,11 +27,13 @@ def get_feature_enabled_from_db(setting_name: str, default: bool = False) -> boo
     Get a feature enabled value from database settings.
 
     Order: ``Setting`` row → ``FEATURE_ENABLED[setting_name]`` if that key exists
-    (Dynaconf merges ``METRICS_SERVICE_FEATURE_ENABLED__*``) → boolean ``AAPFlag``
-    ``FEATURE_<setting_name>_ENABLED`` → ``default``.
+    (Dynaconf merges ``METRICS_SERVICE_FEATURE_ENABLED__*``) → top-level
+    ``FEATURE_<setting_name>_ENABLED`` settings attribute (set directly in settings.yaml
+    by the installer) → boolean ``AAPFlag`` ``FEATURE_<setting_name>_ENABLED`` → ``default``.
 
     Feature keys omitted from ``FEATURE_ENABLED`` in defaults (e.g. ``DASHBOARD_COLLECTION``)
-    use the AAPFlag / default path so platform toggles work without a duplicate static default.
+    use the direct-attribute / AAPFlag / default path so platform toggles work without a
+    duplicate static default.
 
     Args:
         setting_name: Name of the feature enabled setting
@@ -56,11 +59,18 @@ def get_feature_enabled_from_db(setting_name: str, default: bool = False) -> boo
         if setting_name in feature_enabled:
             return bool(feature_enabled[setting_name])
 
+        # Direct top-level attribute set by the installer (e.g. FEATURE_DASHBOARD_COLLECTION_ENABLED: True
+        # in settings.yaml). Checked before AAPFlag so installer opt-in overrides the seeded default.
+        direct_attr = f"FEATURE_{setting_name}_ENABLED"
+        direct_value = getattr(settings, direct_attr, None)
+        if direct_value is not None:
+            return bool(direct_value)
+
         # Platform default from DAB (YAML-seeded), when not overridden above
         try:
             from ansible_base.feature_flags.models import AAPFlag
 
-            flag = AAPFlag.objects.filter(name=f"FEATURE_{setting_name}_ENABLED", condition="boolean").first()
+            flag = AAPFlag.objects.filter(name=direct_attr, condition="boolean").first()
             if flag is not None:
                 return flag.value.lower() in ("true", "1", "yes", "on")
         except Exception as e:

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -34,6 +34,7 @@ class TestPeriodicDatabaseSync:
         mock_immediate_task.id = 1
         mock_immediate_task.name = "Immediate Task"
         mock_immediate_task.is_ready_to_run.return_value = True
+        mock_immediate_task.task_data = {}
 
         mock_task_model.immediate_tasks.return_value = [mock_immediate_task]
         mock_task_model.scheduled_tasks.return_value = []
@@ -58,6 +59,7 @@ class TestPeriodicDatabaseSync:
         mock_scheduled_task = MagicMock()
         mock_scheduled_task.id = 2
         mock_scheduled_task.name = "Scheduled Task"
+        mock_scheduled_task.task_data = {}
 
         mock_task_model.immediate_tasks.return_value = []
         mock_task_model.scheduled_tasks.return_value = [mock_scheduled_task]
@@ -80,6 +82,7 @@ class TestPeriodicDatabaseSync:
         mock_recurring_task = MagicMock()
         mock_recurring_task.id = 3
         mock_recurring_task.name = "Recurring Task"
+        mock_recurring_task.task_data = {}
 
         mock_task_model.immediate_tasks.return_value = []
         mock_task_model.scheduled_tasks.return_value = []
@@ -136,6 +139,71 @@ class TestPeriodicDatabaseSync:
 
         # Assert
         mock_execute.assert_not_called()
+
+    @patch("apps.tasks.task_groups.get_feature_enabled_from_db", return_value=False)
+    @patch("apps.tasks.models.Task")
+    def test_skips_immediate_task_with_disabled_feature_flag(self, mock_task_model, mock_flag):
+        """Immediate tasks whose feature flag is off are silently skipped."""
+        scheduler = UnifiedTaskScheduler()
+        scheduler.running = True
+
+        mock_task = MagicMock()
+        mock_task.id = 1
+        mock_task.name = "Flagged Task"
+        mock_task.is_ready_to_run.return_value = True
+        mock_task.task_data = {"_feature_flag": "DASHBOARD_COLLECTION"}
+
+        mock_task_model.immediate_tasks.return_value = [mock_task]
+        mock_task_model.scheduled_tasks.return_value = []
+        mock_task_model.recurring_tasks.return_value = []
+
+        with patch.object(scheduler, "_execute_database_task") as mock_execute:
+            scheduler._periodic_database_sync()
+
+        mock_execute.assert_not_called()
+        assert 1 not in scheduler._db_task_jobs
+
+    @patch("apps.tasks.task_groups.get_feature_enabled_from_db", return_value=False)
+    @patch("apps.tasks.models.Task")
+    def test_skips_recurring_task_with_disabled_feature_flag(self, mock_task_model, mock_flag):
+        """Recurring tasks whose feature flag is off are not added to the scheduler."""
+        scheduler = UnifiedTaskScheduler()
+        scheduler.running = True
+
+        mock_task = MagicMock()
+        mock_task.id = 2
+        mock_task.name = "Flagged Recurring"
+        mock_task.task_data = {"_feature_flag": "DASHBOARD_COLLECTION"}
+
+        mock_task_model.immediate_tasks.return_value = []
+        mock_task_model.scheduled_tasks.return_value = []
+        mock_task_model.recurring_tasks.return_value = [mock_task]
+
+        with patch.object(scheduler, "_add_database_recurring_task") as mock_add:
+            scheduler._periodic_database_sync()
+
+        mock_add.assert_not_called()
+
+    @patch("apps.tasks.task_groups.get_feature_enabled_from_db", return_value=True)
+    @patch("apps.tasks.models.Task")
+    @patch.object(UnifiedTaskScheduler, "_add_database_recurring_task")
+    def test_adds_recurring_task_when_flag_is_enabled(self, mock_add, mock_task_model, mock_flag):
+        """Recurring tasks are added once their feature flag is re-enabled."""
+        scheduler = UnifiedTaskScheduler()
+        scheduler.running = True
+
+        mock_task = MagicMock()
+        mock_task.id = 3
+        mock_task.name = "Re-enabled Task"
+        mock_task.task_data = {"_feature_flag": "DASHBOARD_COLLECTION"}
+
+        mock_task_model.immediate_tasks.return_value = []
+        mock_task_model.scheduled_tasks.return_value = []
+        mock_task_model.recurring_tasks.return_value = [mock_task]
+
+        scheduler._periodic_database_sync()
+
+        mock_add.assert_called_once_with(mock_task)
 
     @patch("apps.tasks.cron_scheduler.close_old_connections")
     @patch("apps.tasks.models.Task")
@@ -326,7 +394,9 @@ class TestSyncDatabaseTasks:
         scheduler = UnifiedTaskScheduler()
 
         mock_scheduled_task = MagicMock()
+        mock_scheduled_task.task_data = {}
         mock_recurring_task = MagicMock()
+        mock_recurring_task.task_data = {}
 
         mock_task_model.scheduled_tasks.return_value = [mock_scheduled_task]
         mock_task_model.recurring_tasks.return_value = [mock_recurring_task]

--- a/tests/unit/tasks/test_feature_enabled_db.py
+++ b/tests/unit/tasks/test_feature_enabled_db.py
@@ -110,10 +110,11 @@ class TestFeatureEnabledAAPFlagFallback(TestCase):
     """Test AAPFlag fallback in get_feature_enabled_from_db.
 
     Priority chain:
-      1. dynamic_settings.Setting  (runtime DB override)
-      2. settings.FEATURE_ENABLED  (when the key is present, e.g. env overrides)
-      3. AAPFlag.value             (YAML-seeded platform default)
-      4. default argument
+      1. dynamic_settings.Setting         (runtime DB override)
+      2. settings.FEATURE_ENABLED         (when the key is present, e.g. env overrides)
+      3. settings.FEATURE_<name>_ENABLED  (top-level attr, set directly by installer settings.yaml)
+      4. AAPFlag.value                    (YAML-seeded platform default)
+      5. default argument
     """
 
     def _make_mock_flag(self, value: str) -> MagicMock:
@@ -205,6 +206,24 @@ class TestFeatureEnabledAAPFlagFallback(TestCase):
     def test_dashboard_collection_uses_aap_flag_when_omitted_from_feature_enabled(self):
         """When the key is absent from FEATURE_ENABLED, the platform AAPFlag applies."""
         with self._patch_aap_flag(self._make_mock_flag("True")), override_settings(FEATURE_ENABLED={}):
+            assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=False) is True
+
+    @override_settings(FEATURE_ENABLED={}, FEATURE_DASHBOARD_COLLECTION_ENABLED=True)
+    def test_direct_top_level_attr_overrides_false_aap_flag(self):
+        """FEATURE_<name>_ENABLED top-level attr (installer convention) wins over a false AAPFlag."""
+        with self._patch_aap_flag(self._make_mock_flag("False")):
+            assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=False) is True
+
+    @override_settings(FEATURE_ENABLED={}, FEATURE_DASHBOARD_COLLECTION_ENABLED=False)
+    def test_direct_top_level_attr_false_overrides_true_aap_flag(self):
+        """FEATURE_<name>_ENABLED=False suppresses a true AAPFlag."""
+        with self._patch_aap_flag(self._make_mock_flag("True")):
+            assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=True) is False
+
+    @override_settings(FEATURE_ENABLED={"DASHBOARD_COLLECTION": True}, FEATURE_DASHBOARD_COLLECTION_ENABLED=False)
+    def test_feature_enabled_dict_takes_precedence_over_direct_attr(self):
+        """FEATURE_ENABLED dict (tier 2) beats the top-level attr (tier 3)."""
+        with self._patch_aap_flag(self._make_mock_flag("False")):
             assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=False) is True
 
     @override_settings(FEATURE_ENABLED={"SETTINGS_FLAG": True})

--- a/tests/unit/tasks/test_tasks_apps.py
+++ b/tests/unit/tasks/test_tasks_apps.py
@@ -8,9 +8,9 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 import yaml
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
-from apps.tasks.apps import load_task_feature_flags
+from apps.tasks.apps import load_task_feature_flags, sync_flag_values_from_settings
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -228,6 +228,105 @@ class TestLoadTaskFeatureFlags(TestCase):
     # ------------------------------------------------------------------
     # TasksConfig.ready wires up the signal
     # ------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestSyncFlagValuesFromSettings(TestCase):
+    """Tests for sync_flag_values_from_settings."""
+
+    def _make_mock_flag(self, value: str) -> MagicMock:
+        flag = MagicMock()
+        flag.value = value
+        return flag
+
+    def _make_file_patch(self, flags=_SAMPLE_FLAGS):
+        yaml_content = yaml.dump(flags)
+        mock_file_path = MagicMock()
+        mock_file_path.open.return_value.__enter__ = lambda s: io.StringIO(yaml_content)
+        mock_file_path.open.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_file_path
+
+    @override_settings(FEATURE_DASHBOARD_COLLECTION_ENABLED=True)
+    def test_updates_aap_flag_when_settings_differs(self):
+        """AAPFlag.value is updated and saved (without no_reverse_sync) when settings say True but flag is False."""
+        mock_flag = self._make_mock_flag("False")
+        mock_aap_flag_class = MagicMock()
+        mock_aap_flag_class.objects.filter.return_value.first.return_value = mock_flag
+        mock_file_path = self._make_file_patch()
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+        ):
+            result = sync_flag_values_from_settings()
+
+        assert result is True
+        assert mock_flag.value == "True"
+        mock_flag.save.assert_called_once()
+
+    @override_settings(FEATURE_DASHBOARD_COLLECTION_ENABLED=False)
+    def test_updates_aap_flag_to_false_when_settings_says_false(self):
+        """AAPFlag.value is set to False and saved when settings override disagrees."""
+        mock_flag = self._make_mock_flag("True")
+        mock_aap_flag_class = MagicMock()
+        mock_aap_flag_class.objects.filter.return_value.first.return_value = mock_flag
+        mock_file_path = self._make_file_patch()
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+        ):
+            sync_flag_values_from_settings()
+
+        assert mock_flag.value == "False"
+        mock_flag.save.assert_called_once()
+
+    @override_settings(FEATURE_DASHBOARD_COLLECTION_ENABLED=True)
+    def test_skips_save_when_value_already_matches(self):
+        """No save is triggered when the AAPFlag value already matches the settings."""
+        mock_flag = self._make_mock_flag("True")
+        mock_aap_flag_class = MagicMock()
+        mock_aap_flag_class.objects.filter.return_value.first.return_value = mock_flag
+        mock_file_path = self._make_file_patch()
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+        ):
+            sync_flag_values_from_settings()
+
+        mock_flag.save.assert_not_called()
+
+    def test_no_op_when_no_settings_override(self):
+        """Flags with no matching top-level settings attr are left untouched."""
+        mock_flag = self._make_mock_flag("False")
+        mock_aap_flag_class = MagicMock()
+        mock_aap_flag_class.objects.filter.return_value.first.return_value = mock_flag
+        mock_file_path = self._make_file_patch()
+
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", return_value=mock_aap_flag_class),
+        ):
+            result = sync_flag_values_from_settings()
+
+        assert result is True
+        mock_flag.save.assert_not_called()
+
+    @patch("apps.tasks.apps.logger")
+    @override_settings(FEATURE_DASHBOARD_COLLECTION_ENABLED=True)
+    def test_returns_false_and_logs_on_exception(self, mock_logger):
+        """Returns False and logs a warning when an unexpected exception occurs."""
+        mock_file_path = self._make_file_patch()
+        with (
+            patch("apps.tasks.apps._FEATURE_FLAGS_FILE", mock_file_path),
+            patch("django.apps.apps.get_model", side_effect=Exception("registry down")),
+        ):
+            result = sync_flag_values_from_settings()
+
+        assert result is False
+        mock_logger.warning.assert_called_once_with(
+            "Failed to sync flag values from settings to AAPFlag", exc_info=True
+        )
 
     def test_ready_connects_signal_to_feature_flags_app(self):
         """TasksConfig.ready() connects load_task_feature_flags to the dab_feature_flags

--- a/tests/unit/tasks/test_tasks_apps.py
+++ b/tests/unit/tasks/test_tasks_apps.py
@@ -229,6 +229,7 @@ class TestLoadTaskFeatureFlags(TestCase):
     # TasksConfig.ready wires up the signal
     # ------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestSyncFlagValuesFromSettings(TestCase):
     """Tests for sync_flag_values_from_settings."""


### PR DESCRIPTION
## Problem

When a feature flag such as `DASHBOARD_COLLECTION` is disabled, the 30-second
`_periodic_database_sync` loop was producing a **\"Skipping task…\" log message
at every cycle** for tasks in that group.

The root cause is the `initial_dashboard_collection` task — it has `cron: None`,
making it an **immediate task** (`scheduled_time=None`, `cron_expression=None`).
The cycle was:

1. `_periodic_database_sync` finds the task via `Task.immediate_tasks()` (it's still `status="pending"` in the DB).
2. Calls `_execute_database_task`, which checks the feature flag → disabled.
3. Logs `INFO: "Skipping task '…': feature flag 'DASHBOARD_COLLECTION' is disabled"`.
4. Calls `_remove_database_task` — removes from the in-memory `_db_task_jobs` dict, but **the DB row stays `status="pending"`**.
5. Next 30-second tick: task is found again → repeat forever.

The same issue applies (at lower frequency) to recurring cron tasks whose flag is off — they fire on their cron schedule and log a skip each time.

## Fix

Gate task pickup in the sync methods behind a feature flag check **before** adding the task to the scheduler. If the flag is off, the task is skipped silently with no log and no DB modification. The DB row stays intact so it is automatically picked up the next time the sync runs after the flag is re-enabled — no manual `init-system-tasks` required.

### Changes

**`apps/tasks/cron_scheduler.py`**

- `_task_feature_flag_enabled(task)` — new private helper; reads `task.task_data["_feature_flag"]` and calls `get_feature_enabled_from_db`. Returns `True` when no flag is set.
- `_sync_database_tasks` (startup sync) — checks the helper before adding each scheduled/recurring task to APScheduler.
- `_periodic_database_sync` (30-second loop) — checks the helper before adding immediate, scheduled, or recurring tasks. Tasks with a disabled flag are skipped silently via `continue`.
- `_execute_database_task` — skip log downgraded from `INFO` to `DEBUG`. This is a safety net for tasks already loaded into APScheduler that fire while the flag is off (e.g. recurring tasks added at startup before a flag is toggled); they are now quiet.

### Behaviour after this fix

| Scenario | Before | After |
|---|---|---|
| Flag off, immediate task pending | Skip log every 30s | No log; task stays pending in DB |
| Flag re-enabled | Task must be recreated manually (or via `init-system-tasks`) | Automatically picked up on next 30s sync |
| Flag off, recurring task fires on cron | INFO skip log on every cron fire | DEBUG skip log (silent by default) |
| Flag on, task runs normally | ✅ unchanged | ✅ unchanged |

**`tests/unit/tasks/test_cron_scheduler.py`**

- Existing mock tasks fixed: `task_data = {}` added to all mocks that were leaving it as a `MagicMock`, which caused `get_feature_enabled_from_db` to be called against a closed DB connection.
- Three new test cases covering the new behaviour:
  - `test_skips_immediate_task_with_disabled_feature_flag`
  - `test_skips_recurring_task_with_disabled_feature_flag`
  - `test_adds_recurring_task_when_flag_is_enabled`

## Testing

```bash
uv run pytest tests/unit/tasks/test_cron_scheduler.py -v
# 29 passed
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task scheduling and feature-flag propagation to `AAPFlag`, which can affect which tasks run and what the Gateway UI shows if the sync logic is wrong. Changes are localized but impact runtime behavior on deploy/startup.
> 
> **Overview**
> Reduces scheduler noise and unnecessary dispatch attempts by **skipping discovery/scheduling of DB tasks whose `_feature_flag` is currently disabled**, rather than repeatedly picking them up and logging skips every sync cycle; runtime skip logging in `_execute_database_task` is also downgraded to `DEBUG` as a safety net.
> 
> Adds propagation of **installer-provided top-level `FEATURE_<name>_ENABLED` overrides** into both the feature resolution path (`get_feature_enabled_from_db`) and into persisted `AAPFlag` values via a new `sync_flag_values_from_settings()` run during `metrics_service init-default-settings`, so the Gateway reflects installer intent after deploys. Unit tests are updated/expanded to cover the new flag gating and override precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc2dc61ed99e9dc89040a2eecf8a75c9ff41eb48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->