### PR TITLE
daily_anonymize: Schedule send_to_segment at random time, not dependent on service_id

### DIFF
--- a/apps/tasks/collectors/daily_anonymize_and_prepare.py
+++ b/apps/tasks/collectors/daily_anonymize_and_prepare.py
@@ -10,7 +10,6 @@ The output is a flattened structure with statistics and arrays ready for Segment
 
 import logging
 import random
-import uuid
 from datetime import date, timedelta
 from typing import Any
 
@@ -88,15 +87,7 @@ def daily_anonymize_and_prepare(**kwargs) -> dict[str, Any]:
             "aggregation_timestamp": aggregation_timestamp,
         }
 
-        from ansible_base.resource_registry.models.service_identifier import service_id
-
-        try:
-            installation_uuid = service_id()
-            seed = int(uuid.UUID(installation_uuid)) % (10**9)
-        except Exception as e:
-            logger.warning("Unable to derive jitter seed from service_id. Using fallback: %s", e)
-            seed = 0
-        offset_minutes = random.Random(seed).randint(0, 239)  # noqa: S311  # NOSONAR - scheduling jitter, not a security context
+        offset_minutes = random.randint(0, 239)
         send_scheduled_time = timezone.now() + timedelta(minutes=offset_minutes)
 
         # Use atomic transaction to prevent duplicate payloads and ensure the

--- a/apps/tasks/collectors/daily_anonymize_and_prepare.py
+++ b/apps/tasks/collectors/daily_anonymize_and_prepare.py
@@ -20,6 +20,11 @@ from ..utils import create_task_result, generate_salt, log_task_execution
 logger = logging.getLogger(__name__)
 
 
+def random_offset():
+    """Return a random jitter offset in minutes for scheduling."""
+    return random.randint(1, 240)  # noqa: S311
+
+
 def daily_anonymize_and_prepare(**kwargs) -> dict[str, Any]:
     """
     Anonymize daily metrics summary and prepare payload for Segment
@@ -87,7 +92,7 @@ def daily_anonymize_and_prepare(**kwargs) -> dict[str, Any]:
             "aggregation_timestamp": aggregation_timestamp,
         }
 
-        offset_minutes = random.randint(1, 240)
+        offset_minutes = random_offset()
         send_scheduled_time = timezone.now() + timedelta(minutes=offset_minutes)
 
         # Use atomic transaction to prevent duplicate payloads and ensure the

--- a/apps/tasks/collectors/daily_anonymize_and_prepare.py
+++ b/apps/tasks/collectors/daily_anonymize_and_prepare.py
@@ -87,7 +87,7 @@ def daily_anonymize_and_prepare(**kwargs) -> dict[str, Any]:
             "aggregation_timestamp": aggregation_timestamp,
         }
 
-        offset_minutes = random.randint(0, 239)
+        offset_minutes = random.randint(1, 240)
         send_scheduled_time = timezone.now() + timedelta(minutes=offset_minutes)
 
         # Use atomic transaction to prevent duplicate payloads and ensure the

--- a/tests/unit/tasks/collectors/test_daily_anonymize_and_prepare.py
+++ b/tests/unit/tasks/collectors/test_daily_anonymize_and_prepare.py
@@ -411,12 +411,3 @@ class TestDailyAnonymizeAndPrepare:
 
         assert result["status"] == "error"
         assert not Task.objects.filter(function_name="send_anonymized_to_segment").exists()
-
-    def test_jitter_offset_is_deterministic(self):
-        """Same UUID always produces the same jitter offset."""
-        import random
-        import uuid
-
-        test_uuid = "12345678-1234-5678-9012-123456789012"
-        seed = int(uuid.UUID(test_uuid)) % (10**9)
-        assert random.Random(seed).randint(0, 239) == random.Random(seed).randint(0, 239)

--- a/tests/unit/tasks/collectors/test_daily_anonymize_and_prepare.py
+++ b/tests/unit/tasks/collectors/test_daily_anonymize_and_prepare.py
@@ -387,7 +387,7 @@ class TestDailyAnonymizeAndPrepare:
         assert result["status"] == "success"
         task = Task.objects.get(function_name="send_anonymized_to_segment")
         assert task.task_data["payload_id"] == result["payload_id"]
-        assert before <= task.scheduled_time <= before + timedelta(minutes=239)
+        assert before < task.scheduled_time <= before + timedelta(minutes=240)
 
     @patch("metrics_utility.anonymized_rollups.anonymize_rollups")
     @patch("apps.tasks.collectors.daily_anonymize_and_prepare.generate_salt")

--- a/tests/unit/tasks/collectors/test_daily_anonymize_and_prepare.py
+++ b/tests/unit/tasks/collectors/test_daily_anonymize_and_prepare.py
@@ -411,3 +411,14 @@ class TestDailyAnonymizeAndPrepare:
 
         assert result["status"] == "error"
         assert not Task.objects.filter(function_name="send_anonymized_to_segment").exists()
+
+    @patch("uuid.UUID")
+    def test_jitter_offset_is_not_deterministic(self, mock_uuid):
+        """Jitter offset is random, not derived from installation UUID."""
+        mock_uuid.return_value = "12345678-1234-5678-9012-123456789012"
+
+        from apps.tasks.collectors.daily_anonymize_and_prepare import random_offset
+
+        result = random_offset()
+        assert 1 <= result <= 240
+        mock_uuid.assert_not_called()

--- a/tests/unit/tasks/collectors/test_daily_anonymize_and_prepare.py
+++ b/tests/unit/tasks/collectors/test_daily_anonymize_and_prepare.py
@@ -379,15 +379,16 @@ class TestDailyAnonymizeAndPrepare:
             aggregated_metrics={"job_host_summary_service": {}, "unified_jobs": {}, "execution_environments": {}},
         )
 
-        before = timezone.now()
-        result = daily_anonymize_and_prepare(summary_date=summary_date.isoformat())
+        now = timezone.now()
+        with patch("apps.tasks.collectors.daily_anonymize_and_prepare.timezone.now", return_value=now):
+            result = daily_anonymize_and_prepare(summary_date=summary_date.isoformat())
 
         from apps.tasks.models import Task
 
         assert result["status"] == "success"
         task = Task.objects.get(function_name="send_anonymized_to_segment")
         assert task.task_data["payload_id"] == result["payload_id"]
-        assert before < task.scheduled_time <= before + timedelta(minutes=240)
+        assert now < task.scheduled_time <= now + timedelta(minutes=240)
 
     @patch("metrics_utility.anonymized_rollups.anonymize_rollups")
     @patch("apps.tasks.collectors.daily_anonymize_and_prepare.generate_salt")


### PR DESCRIPTION
Issue: AAP-73548

The daily_anonymize task schedules the send_to_segment task for a random time within a 4 hour interval, to prevent thundering herd problems.

But computing the random seed from our service_id ensured that the same customer would send data at the same time each day.

That's leaking identifiable information, let's stop that.

Now, we compute a random 0-239 minutes offset each day.

(Related to #183, AAP-69217)