### PR TITLE
[events] Add collect_job_events task and EVENTS_COLLECTION feature flag

### DIFF
--- a/apps/tasks/collectors/collect_events.py
+++ b/apps/tasks/collectors/collect_events.py
@@ -1,0 +1,222 @@
+"""Collector for AWX job event data using keyset pagination."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from apps.tasks.utils import create_task_result, get_db_connection, log_task_execution, parse_datetime_string
+
+# NOTE: requires Unit 1 PR (JobEvent model) to be merged before this import resolves.
+# The try/except below handles the missing model gracefully during development.
+try:
+    from apps.events.models import JobEvent
+except ImportError:
+    JobEvent = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+COLLECTOR_TYPE = "job_events"
+DEFAULT_LOOKBACK_DAYS = 7
+
+
+def _get_last_watermark() -> tuple[datetime | None, int | None]:
+    """
+    Return (last_job_created, last_awx_event_id) from the most recent successful collection.
+
+    Reads the ``collection_parameters`` JSON field of the most recent
+    ``HourlyMetricsCollection`` record with ``collector_type="job_events"`` and
+    ``status="collected"``.  Returns (None, None) when no prior collection exists.
+    """
+    from apps.tasks.models import HourlyMetricsCollection
+
+    last = (
+        HourlyMetricsCollection.objects.filter(collector_type=COLLECTOR_TYPE, status="collected")
+        .order_by("-collection_timestamp")
+        .first()
+    )
+    if last is None:
+        return None, None
+
+    params = last.collection_parameters or {}
+    raw_ts = params.get("last_job_created")
+    last_id = params.get("last_awx_event_id")
+
+    if not raw_ts:
+        return None, None
+
+    dt = parse_datetime_string(raw_ts)
+    if dt is None:
+        logger.warning("collect_job_events: could not parse last_job_created=%r; starting from scratch", raw_ts)
+        return None, None
+    return dt, last_id
+
+
+def _save_window_record(
+    window_start: datetime,
+    status: str,
+    events_in_window: int,
+    last_job_created: datetime | None,
+    last_awx_event_id: int | None,
+    error_message: str = "",
+) -> None:
+    """Persist a HourlyMetricsCollection record for the completed time window."""
+    from apps.tasks.models import HourlyMetricsCollection
+
+    collection_params: dict[str, Any] = {
+        "events_in_window": events_in_window,
+    }
+    if last_job_created is not None:
+        collection_params["last_job_created"] = last_job_created.isoformat()
+    if last_awx_event_id is not None:
+        collection_params["last_awx_event_id"] = last_awx_event_id
+
+    HourlyMetricsCollection.objects.update_or_create(
+        collector_type=COLLECTOR_TYPE,
+        collection_timestamp=window_start,
+        defaults={
+            "raw_data": {},
+            "status": status,
+            "error_message": error_message,
+            "collection_parameters": collection_params,
+        },
+    )
+
+
+def collect_job_events(**kwargs: Any) -> dict[str, Any]:
+    """Collect AWX job events into metrics-service using keyset pagination.
+
+    Iterates hourly time windows aligned to AWX's ``main_jobevent`` partitions.
+    The high-water mark (``last_job_created`` + ``last_awx_event_id``) is read
+    from the most recent successful ``HourlyMetricsCollection`` with
+    ``collector_type="job_events"``.  If no prior collection exists the function
+    defaults to ``DEFAULT_LOOKBACK_DAYS`` days ago.
+
+    For each hourly window the function calls ``JobEventExtractor`` from
+    ``metrics_utility`` (Unit 5 PR) and bulk-inserts batches into the local
+    ``JobEvent`` table using ``update_conflicts`` so re-runs are idempotent.
+
+    Args:
+        **kwargs: Optional task data.  Not currently used but kept for
+            consistency with other collector functions.
+
+    Returns:
+        dict: Standard task result with ``status``, ``events_collected``, and
+            ``windows_processed`` keys.
+    """
+    if JobEvent is None:
+        msg = (
+            "collect_job_events: apps.events.models.JobEvent is not importable. "
+            "Ensure the Unit 1 PR (JobEvent model) has been merged and migrations applied."
+        )
+        logger.error(msg)
+        return create_task_result("error", error=msg)
+
+    try:
+        from metrics_utility.library.collectors.controller.main_jobevent_events import JobEventExtractor
+    except ImportError:
+        msg = (
+            "collect_job_events: metrics_utility.library.collectors.controller.main_jobevent_events "
+            "is not importable. Ensure the Unit 5 PR (JobEventExtractor) has been merged and "
+            "metrics-utility has been updated."
+        )
+        logger.error(msg)
+        return create_task_result("error", error=msg)
+
+    log_task_execution("collect_job_events", "start")
+
+    now = datetime.now(tz=UTC).replace(minute=0, second=0, microsecond=0)
+    last_job_created, last_awx_event_id = _get_last_watermark()
+
+    if last_job_created is not None:
+        # Re-open the watermark hour: events written at hh:59 may arrive after hh+1 starts.
+        window_start = last_job_created.replace(minute=0, second=0, microsecond=0)
+    else:
+        window_start = now - timedelta(days=DEFAULT_LOOKBACK_DAYS)
+
+    if window_start >= now:
+        log_task_execution("collect_job_events", "skipped", "watermark is already at current hour")
+        return create_task_result(
+            "success",
+            data={"events_collected": 0, "windows_processed": 0, "message": "No new windows to process"},
+        )
+
+    db_connection = get_db_connection("awx")
+
+    total_events = 0
+    windows_processed = 0
+    cursor_job_created = last_job_created
+    cursor_event_id = last_awx_event_id
+
+    current_window = window_start
+    while current_window < now:
+        window_end = current_window + timedelta(hours=1)
+        events_in_window = 0
+
+        try:
+            extractor = JobEventExtractor(db=db_connection, since=current_window, until=window_end)
+            for batch in extractor:
+                if not batch:
+                    continue
+                JobEvent.objects.bulk_create(
+                    [JobEvent(**row) for row in batch],
+                    update_conflicts=True,
+                    update_fields=["failed", "changed", "duration", "collected_at"],
+                    unique_fields=["awx_event_id"],
+                )
+                events_in_window += len(batch)
+
+                for row in batch:
+                    row_created = row.get("job_created")
+                    row_id = row.get("awx_event_id")
+                    if row_created is not None:
+                        if cursor_job_created is None or row_created > cursor_job_created:
+                            cursor_job_created = row_created
+                            cursor_event_id = row_id
+                        elif row_created == cursor_job_created and row_id is not None:
+                            if cursor_event_id is None or row_id > cursor_event_id:
+                                cursor_event_id = row_id
+
+            _save_window_record(
+                window_start=current_window,
+                status="collected",
+                events_in_window=events_in_window,
+                last_job_created=cursor_job_created,
+                last_awx_event_id=cursor_event_id,
+            )
+            total_events += events_in_window
+            windows_processed += 1
+
+        except Exception as exc:
+            logger.exception(
+                "collect_job_events: error processing window %s–%s: %s",
+                current_window.isoformat(),
+                window_end.isoformat(),
+                exc,
+            )
+            _save_window_record(
+                window_start=current_window,
+                status="failed",
+                events_in_window=events_in_window,
+                last_job_created=cursor_job_created,
+                last_awx_event_id=cursor_event_id,
+                error_message=str(exc),
+            )
+            return create_task_result(
+                "error",
+                data={"events_collected": total_events, "windows_processed": windows_processed},
+                error=f"Collection failed at window {current_window.isoformat()}: {exc}",
+            )
+
+        current_window = window_end
+
+    log_task_execution(
+        "collect_job_events",
+        "completed",
+        f"Collected {total_events} events across {windows_processed} windows",
+    )
+    return create_task_result(
+        "success",
+        data={"events_collected": total_events, "windows_processed": windows_processed},
+    )

--- a/apps/tasks/feature_flags.yaml
+++ b/apps/tasks/feature_flags.yaml
@@ -27,3 +27,17 @@
   toggle_type: run-time
   labels:
     - metrics
+- name: FEATURE_EVENTS_COLLECTION_ENABLED
+  ui_name: Events Collection
+  visibility: true
+  condition: boolean
+  value: 'False'
+  support_level: TECHNOLOGY_PREVIEW
+  description: >-
+    Enable collection of AWX job event data into metrics-service.
+    When enabled, job events are collected from the AWX main_jobevent table
+    using keyset pagination and stored locally for analysis.
+  support_url: ''
+  toggle_type: run-time
+  labels:
+    - metrics

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -340,12 +340,34 @@ DASHBOARD_COLLECTION_GROUP = TaskGroup(
     ],
 )
 
+# Events Collection Group — high-scale AWX job event pipeline.
+# Feature flag: EVENTS_COLLECTION (default: False — customer opt-in).
+# Requires Unit 1 (JobEvent model) and Unit 5 (JobEventExtractor from metrics-utility) PRs.
+# TODO (Unit 3): add cleanup_job_events_old_data task once the cleanup function is implemented.
+EVENTS_COLLECTION_GROUP = TaskGroup(
+    name="events_collection",
+    description="AWX job event collection into metrics-service using keyset pagination (opt-in)",
+    feature_flag="EVENTS_COLLECTION",
+    tasks=[
+        {
+            "task_id": "collect_job_events",
+            "function": "collect_job_events",
+            "cron": "0 */2 * * *",  # Every 2 hours
+            "args": {},
+            "enabled": True,
+            "description": "Collect AWX job events from main_jobevent using keyset pagination (every 2 hours)",
+        },
+        # TODO (Unit 3): add cleanup_job_events_old_data here once implemented.
+    ],
+)
+
 # Registry of all task groups
 TASK_GROUPS = [
     SYSTEM_TASKS_GROUP,
     METRICS_COLLECTION_GROUP,
     ANONYMIZATION_GROUP,
     DASHBOARD_COLLECTION_GROUP,
+    EVENTS_COLLECTION_GROUP,
 ]
 
 

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -27,6 +27,7 @@ from .cleanup.cleanup_old_tasks import cleanup_old_tasks
 
 # Import collector tasks
 from .collectors.collect_daily_metrics import collect_daily_metrics
+from .collectors.collect_events import collect_job_events
 from .collectors.collect_hourly_metrics import collect_hourly_metrics
 from .collectors.collect_snapshot_metrics import collect_snapshot_metrics
 from .collectors.daily_anonymize_and_prepare import daily_anonymize_and_prepare
@@ -62,6 +63,8 @@ TASK_FUNCTIONS = {
     "collect_dashboard_reports_data": collect_dashboard_reports_data,
     "collect_dashboard_reports_initial_data": collect_dashboard_reports_initial_data,
     "cleanup_dashboard_reports_old_data": cleanup_dashboard_reports_old_data,
+    # Events collection (requires Unit 1 JobEvent model and Unit 5 JobEventExtractor)
+    "collect_job_events": collect_job_events,
 }
 
 # Tasks that require a PostgreSQL advisory lock during scheduled execution.
@@ -76,6 +79,7 @@ TASK_LOCKS = {
     "collect_dashboard_reports_data",
     "collect_dashboard_reports_initial_data",
     "cleanup_dashboard_reports_old_data",
+    "collect_job_events",
 }
 
 
@@ -407,6 +411,19 @@ TASK_METADATA = {
             {"name": "Extended retention", "data": {"retention_period_days": 180}},
         ],
     },
+    # Events collection
+    "collect_job_events": {
+        "queue": "metrics",
+        "category": "Events Collection",
+        "description": (
+            "Collect AWX job events from main_jobevent into metrics-service using keyset pagination. "
+            "Requires Unit 1 (JobEvent model) and Unit 5 (JobEventExtractor) PRs to be merged."
+        ),
+        "parameters": {},
+        "examples": [
+            {"name": "Default collection", "data": {}},
+        ],
+    },
 }
 
 # Explicit exports for better IDE support
@@ -435,4 +452,6 @@ __all__ = [
     "collect_dashboard_reports_data",
     "collect_dashboard_reports_initial_data",
     "cleanup_dashboard_reports_old_data",
+    # Events collection
+    "collect_job_events",
 ]


### PR DESCRIPTION
## Summary

- Adds `collect_job_events()` collector in `apps/tasks/collectors/collect_events.py`
- Collector imports `JobEventExtractor` from `metrics-utility`, iterates hourly time windows, and bulk-inserts batches into `JobEvent` using `update_conflicts=True`
- Tracks progress via `HourlyMetricsCollection` (collector\_type=`job_events`), storing last `(job_created, awx_event_id)` cursor in `collection_parameters`
- Registers `EVENTS_COLLECTION_GROUP` (disabled by default) in `task_groups.py` with cron `0 */2 * * *`
- Adds `EVENTS_COLLECTION` feature flag to `apps/tasks/feature_flags.yaml`

## Test plan

- [ ] `uv run pytest tests/unit/ -x -q` passes
- [ ] `from apps.tasks.tasks import TASK_FUNCTIONS; 'collect_job_events' in TASK_FUNCTIONS` is `True`
- [ ] `uv run poe lint` passes

## Dependencies

Requires the `JobEvent` model PR (Unit 1) to be merged before collecting events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new high-volume ingestion task that reads from the AWX DB and bulk-upserts into a local `JobEvent` table on a schedule; correctness and load depend on watermarking and extractor behavior, though gated behind a default-off feature flag.
> 
> **Overview**
> Adds an opt-in AWX job event ingestion pipeline via a new `collect_job_events` collector that pages through hourly windows, bulk upserts into `JobEvent`, and records per-window progress/watermarks in `HourlyMetricsCollection` for idempotent resume.
> 
> Introduces the `FEATURE_EVENTS_COLLECTION_ENABLED` flag and a new `EVENTS_COLLECTION_GROUP` scheduled every 2 hours, wiring the task into `TASK_FUNCTIONS`, `TASK_LOCKS`, and `TASK_METADATA`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a4f75623ae05274f07141c58c5374ecc545ba48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->