### PR TITLE
[AAP-73682] metrics-service health endpoint should return "good" status consistent with AAP status vocabulary

### DIFF
--- a/apps/core/logging_config.py
+++ b/apps/core/logging_config.py
@@ -24,9 +24,7 @@ class DispatcherdReconnectFilter(logging.Filter):
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if record.name == "asyncio" and "CallbackHolder.done_callback" in record.getMessage():
-            return False
-        return True
+        return not (record.name == "asyncio" and "CallbackHolder.done_callback" in record.getMessage())
 
 
 class JsonFormatter(logging.Formatter):

--- a/apps/core/tests/test_health.py
+++ b/apps/core/tests/test_health.py
@@ -17,10 +17,10 @@ class TestHealthEndpoint(TestCase):
     def setUp(self):
         self.client = APIClient()
 
-    def test_health_returns_healthy(self):
+    def test_health_returns_good(self):
         response = self.client.get("/health/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        self.assertEqual(data["status"], "healthy")
+        self.assertEqual(data["status"], "good")
         self.assertIn("database", data["checks"])
         self.assertEqual(data["checks"]["database"], "ok")

--- a/apps/core/views/health.py
+++ b/apps/core/views/health.py
@@ -1,4 +1,4 @@
-from ansible_base.lib.constants import STATUS_DEGRADED, STATUS_FAILED, STATUS_GOOD
+from ansible_base.lib.constants import STATUS_DEGRADED, STATUS_GOOD
 from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
 from django.db import close_old_connections, connection
 from rest_framework import status
@@ -37,8 +37,8 @@ class HealthView(AnsibleBaseView):
             if most_recent is not None:
                 health_status["checks"]["segment_send"] = {}
 
-                if most_recent.status == STATUS_FAILED:
-                    health_status["checks"]["segment_send"]["status"] = STATUS_FAILED
+                if most_recent.status == "failed":
+                    health_status["checks"]["segment_send"]["status"] = "failed"
                     health_status["checks"]["segment_send"]["last_failure_at"] = str(most_recent.modified.isoformat())
                 else:
                     health_status["checks"]["segment_send"]["status"] = "ok"

--- a/apps/core/views/health.py
+++ b/apps/core/views/health.py
@@ -1,3 +1,4 @@
+from ansible_base.lib.constants import STATUS_DEGRADED, STATUS_FAILED, STATUS_GOOD
 from ansible_base.lib.utils.views.ansible_base import AnsibleBaseView
 from django.db import close_old_connections, connection
 from rest_framework import status
@@ -16,7 +17,7 @@ class HealthView(AnsibleBaseView):
     authentication_classes = []
 
     def get(self, request):
-        health_status: dict = {"status": "healthy", "checks": {}}
+        health_status: dict = {"status": STATUS_GOOD, "checks": {}}
 
         # Database check
         try:
@@ -25,7 +26,7 @@ class HealthView(AnsibleBaseView):
             connection.ensure_connection()
             health_status["checks"]["database"] = "ok"
         except Exception as e:
-            health_status["status"] = "unhealthy"
+            health_status["status"] = STATUS_DEGRADED
             health_status["checks"]["database"] = f"error: {str(e)}"
 
         # Segment send check (no data is shown if there's no payloads to check)
@@ -36,8 +37,8 @@ class HealthView(AnsibleBaseView):
             if most_recent is not None:
                 health_status["checks"]["segment_send"] = {}
 
-                if most_recent.status == "failed":
-                    health_status["checks"]["segment_send"]["status"] = "failed"
+                if most_recent.status == STATUS_FAILED:
+                    health_status["checks"]["segment_send"]["status"] = STATUS_FAILED
                     health_status["checks"]["segment_send"]["last_failure_at"] = str(most_recent.modified.isoformat())
                 else:
                     health_status["checks"]["segment_send"]["status"] = "ok"
@@ -47,7 +48,7 @@ class HealthView(AnsibleBaseView):
             health_status["checks"]["segment_send"]["error"] = str(e)
 
         http_status = (
-            status.HTTP_200_OK if health_status["status"] == "healthy" else status.HTTP_503_SERVICE_UNAVAILABLE
+            status.HTTP_200_OK if health_status["status"] == STATUS_GOOD else status.HTTP_503_SERVICE_UNAVAILABLE
         )
 
         return Response(health_status, status=http_status)

--- a/tests/unit/general/test_health_metrics.py
+++ b/tests/unit/general/test_health_metrics.py
@@ -21,7 +21,7 @@ class TestHealthEndpoint:
         """Test that health endpoint returns correct JSON structure when healthy."""
         response = client.get("/health/")
         json_response = response.json()
-        assert json_response["status"] == "healthy"
+        assert json_response["status"] == "good"
         assert json_response["checks"]["database"] == "ok"
 
     def test_health_check_returns_503_when_database_fails(self, client, db):
@@ -35,7 +35,7 @@ class TestHealthEndpoint:
         """Test that health endpoint doesn't require authentication."""
         response = client.get("/health/")
         json_response = response.json()
-        assert json_response["status"] == "healthy"
+        assert json_response["status"] == "good"
         assert response.status_code == status.HTTP_200_OK
 
     @pytest.mark.django_db
@@ -56,7 +56,7 @@ class TestHealthEndpoint:
 
         response = client.get("/health/")
         json_response = response.json()
-        assert json_response["status"] == "healthy"
+        assert json_response["status"] == "good"
         assert json_response["checks"]["segment_send"]["status"] == "failed"
         assert "last_failure_at" in json_response["checks"]["segment_send"]
         assert response.status_code == status.HTTP_200_OK
@@ -92,7 +92,7 @@ class TestHealthEndpoint:
 
         response = client.get("/health/")
         json_response = response.json()
-        assert json_response["status"] == "healthy"
+        assert json_response["status"] == "good"
         assert json_response["checks"]["segment_send"]["status"] == "failed"
         assert "last_failure_at" in json_response["checks"]["segment_send"]
         assert response.status_code == status.HTTP_200_OK
@@ -128,7 +128,7 @@ class TestHealthEndpoint:
 
         response = client.get("/health/")
         json_response = response.json()
-        assert json_response["status"] == "healthy"
+        assert json_response["status"] == "good"
         assert json_response["checks"]["segment_send"]["status"] == "ok"
         assert "last_success_at" in json_response["checks"]["segment_send"]
         assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
# [AAP-73682] metrics-service health endpoint should return "good" status consistent with AAP status vocabulary

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - The health endpoint (`GET /health/`) status values are changed from `"healthy"` / `"unhealthy"` to `"good"` / `"degraded"`, and the segment send check now uses `"failed"` from the same constant set. All status string literals in the view are replaced with `STATUS_GOOD`, `STATUS_DEGRADED`, and `STATUS_FAILED` imported from `ansible_base.lib.constants`. Tests in both metrics-service and automation-metrics-operator are updated to match.
- Why is this change needed?
  - Other AAP services (gateway, EDA, controller) already use `"good"` / `"degraded"` / `"failed"` from `ansible_base.lib.constants` for their health endpoints. Metrics-service was the outlier, returning `"healthy"` / `"unhealthy"`, which forces consumers to handle a different status vocabulary for one service.
- How does this change address the issue?
  - The view imports the shared constants and uses them in place of inline strings, ensuring metrics-service speaks the same health status language as the rest of the platform. The HTTP status code logic (`200` for good, `503` otherwise) is unchanged.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
- A running metrics-service instance
- 
### Steps to Test
1. Start the service with a healthy database: `python manage.py runserver`
2. Send `GET /health/` and verify the response contains `"status": "good"` with HTTP 200
3. Stop the database and send `GET /health/` again
4. Verify the response contains `"status": "degraded"` with HTTP 503
5. Run the test suite: `uv run pytest apps/core/tests/test_health.py tests/unit/general/test_health_metrics.py -v`

### Expected Results
<!-- Describe what should happen after following the steps -->
- All health-related tests pass
- `GET /health/` returns `{"status": "good", ...}` when the service is healthy
- `GET /health/` returns `{"status": "degraded", ...}` when the database is unreachable

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `/health/` response vocabulary from `healthy/unhealthy` to `good/degraded`, which is an API-contract change for any consumers parsing the status string. Logic is otherwise unchanged and covered by updated tests.
> 
> **Overview**
> Updates `GET /health/` to use AAP-wide status constants (`STATUS_GOOD`, `STATUS_DEGRADED`) instead of the previous string literals, and adjusts the HTTP 200 vs 503 decision to key off `STATUS_GOOD`.
> 
> Updates health endpoint tests to expect `"good"` in the JSON response, and makes a small readability refactor in `DispatcherdReconnectFilter` by collapsing the filter logic into a single boolean expression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af602672c5ea965e8fadcd6b44593c37b9ba458e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->