### PR TITLE
Revert "Filter transient dispatcherd pg_notify reconnection errors from container logs"

### DIFF
--- a/apps/core/logging_config.py
+++ b/apps/core/logging_config.py
@@ -11,22 +11,6 @@ from datetime import UTC, datetime
 from typing import Any
 
 
-class DispatcherdReconnectFilter(logging.Filter):
-    """Suppress transient pg_notify reconnection errors logged by the asyncio event loop.
-
-    When dispatcherd loses its PostgreSQL NOTIFY/LISTEN connection it retries every
-    second and the asyncio event loop logs each failed attempt at ERROR level via the
-    'asyncio' logger.  These are expected during service startup or a brief DB restart
-    and are not actionable — dispatcherd recovers automatically once the DB is reachable.
-
-    The filter matches on 'CallbackHolder.done_callback', which is unique to
-    dispatcherd's asyncio_tasks.py, so unrelated asyncio errors are unaffected.
-    """
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        return not (record.name == "asyncio" and "CallbackHolder.done_callback" in record.getMessage())
-
-
 class JsonFormatter(logging.Formatter):
     """
     Format log records as single-line JSON for container stdout.

--- a/metrics_service/settings.py
+++ b/metrics_service/settings.py
@@ -180,9 +180,6 @@ LOGGING = {
         "request_id": {
             "()": "ansible_base.lib.logging.filters.RequestIdFilter",
         },
-        "dispatcherd_reconnect": {
-            "()": "apps.core.logging_config.DispatcherdReconnectFilter",
-        },
     },
     "formatters": {
         "simple": {
@@ -198,7 +195,7 @@ LOGGING = {
         "console": {
             "class": "logging.StreamHandler",
             "formatter": "verbose",
-            "filters": ["request_id", "dispatcherd_reconnect"],
+            "filters": ["request_id"],
         },
     },
     "loggers": {


### PR DESCRIPTION
Reverts commit 8bd2a5c2b00bb5c24595998589649b297e0aca0f which was committed directly to `devel` in error (committed by Claude without going through a PR).

## Changes reverted

- Removes `DispatcherdReconnectFilter` from `apps/core/logging_config.py`
- Reverts `metrics_service/settings.py` to remove the filter from the logging config

## Next steps

If the underlying fix is still needed (suppressing transient dispatcherd pg_notify reconnection errors from failing the container health test), it should be re-proposed via a proper PR with review.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk revert limited to logging configuration; it only affects which messages are emitted to stdout (no auth/data-path changes).
> 
> **Overview**
> Reverts the prior change that suppressed transient dispatcherd PostgreSQL NOTIFY/LISTEN reconnection errors.
> 
> Removes `DispatcherdReconnectFilter` from `apps/core/logging_config.py` and drops the corresponding filter entry/handler wiring from `metrics_service/settings.py`, so these asyncio/dispatcherd reconnect errors will appear in container logs again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24dc16e2281e30580fe1ce0a2e49fe7d70f4905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->