### PR TITLE
[POST 2.7] [AAP-73901] Set SECURE_PROXY_SSL_HEADER to generate https:// API URLs

### DIFF
--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -56,8 +56,6 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
     ],
-    "UNAUTHENTICATED_USER": None,
-    "UNAUTHENTICATED_TOKEN": None,
     "DEFAULT_FILTER_BACKENDS": [
         "rest_framework.filters.SearchFilter",
         "rest_framework.filters.OrderingFilter",

--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -135,6 +135,11 @@ FEATURE_ENABLED = {
 # Used when generating API URLs in views, example "/api/metrics/"; None means "/api/"
 URL_PREFIX = None
 
+# Trust X-Forwarded-Proto: https from the upstream proxy (Envoy/NGINX) when deployed
+# behind a TLS-terminating gateway. Override to None in standalone dev environments
+# where NGINX terminates TLS directly (SECURE_PROXY_SSL_HEADER is not needed there).
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 
 @post_hook
 def load_prometheus_middlewares(settings: Dynaconf) -> dict:


### PR DESCRIPTION
## Summary

Two bugs fixed in `apps/settings/defaults.py`:

**1. Metrics API links use `http://` instead of `https://`**

`SECURE_PROXY_SSL_HEADER` was not set, so Django had no signal that it was behind a TLS-terminating proxy. `APIRootView` and DRF pagination generated `http://` absolute links, breaking Swagger UI navigation and client integrations.

Sets `SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")` so Django generates correct `https://` links when running behind the AAP gateway.

**2. Unauthenticated requests to `/api/v1/service-index/resources/` return 500 instead of 403**

`REST_FRAMEWORK["UNAUTHENTICATED_USER"] = None` caused DRF to set `request.user = None` (rather than `AnonymousUser`) for unauthenticated requests. DAB's `HasResourceRegistryPermissions` calls `user.is_superuser` unconditionally, raising `AttributeError: 'NoneType' object has no attribute 'is_superuser'` — a 500 that Envoy's outlier detection treated as a backend failure, ejecting the endpoint and causing 30s windows of 503 "no healthy upstream" on `/api/metrics/`.

Removing the override restores the DRF default (`AnonymousUser`), so unauthenticated service-index calls return a clean 403 instead of crashing. AWX does not set `UNAUTHENTICATED_USER` and is unaffected by this bug.

The gateway operator side of these fixes (correcting `service_path` in the Envoy configmap and adding `enable_gateway_auth: true` to the metrics route) is tracked in [AAP-73901](https://redhat.atlassian.net/browse/AAP-73901).

## Test plan

- [ ] Deploy metrics service behind AAP gateway on OCP
- [ ] Verify Swagger UI links and DRF browsable API pagination links use `https://` and `/api/metrics/v1/` paths
- [ ] Confirm `POST /api/v1/service-index/resources/` returns 403 (not 500) when called without auth
- [ ] Confirm no 503 "no healthy upstream" windows on `/api/metrics/` after sustained traffic
- [ ] Verify `SECURE_PROXY_SSL_HEADER` can be overridden to `None` in local dev settings

🤖 Generated with [Claude Code](https://claude.ai/claude-code)