### PR TITLE
[AAP-74369] Make task timeout nullable to respect dispatcherd.yaml default_timeout

### DIFF
--- a/apps/settings/dispatcherd.yaml
+++ b/apps/settings/dispatcherd.yaml
@@ -25,7 +25,6 @@ service:
 
   # Task execution settings
   task_settings:
-    default_timeout: 3600 # 1 hour default timeout
     max_retries: 3
     retry_delay: 30 # 30 seconds between retries
 

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -15,9 +15,10 @@ from apscheduler.triggers.date import DateTrigger
 from django.db import close_old_connections, transaction
 from django.utils import timezone
 
-from apps.tasks.models import STUCK_TASK_TIMEOUT_SECONDS
-
 logger = logging.getLogger(__name__)
+
+DEFAULT_TASK_TIMEOUT_SECONDS = 3600
+STUCK_TASK_TIMEOUT_SECONDS = DEFAULT_TASK_TIMEOUT_SECONDS
 
 
 def _inject_dispatch_timestamps(function_name: str, task_data: dict) -> dict:
@@ -334,7 +335,6 @@ class UnifiedTaskScheduler:
                     scheduled_time=None,  # Execute immediately
                     cron_expression=None,  # This is not a recurring task
                     max_attempts=task.max_attempts,
-                    timeout_seconds=task.timeout_seconds,
                     created_by=task.created_by,
                     is_system_task=task.is_system_task,
                 )

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -15,9 +15,9 @@ from apscheduler.triggers.date import DateTrigger
 from django.db import close_old_connections, transaction
 from django.utils import timezone
 
-logger = logging.getLogger(__name__)
+from apps.tasks.models import STUCK_TASK_TIMEOUT_SECONDS
 
-STUCK_TASK_TIMEOUT_SECONDS = 3600
+logger = logging.getLogger(__name__)
 
 
 def _inject_dispatch_timestamps(function_name: str, task_data: dict) -> dict:

--- a/apps/tasks/management/commands/metrics_service.py
+++ b/apps/tasks/management/commands/metrics_service.py
@@ -21,6 +21,7 @@ from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
+from apps.tasks.cron_scheduler import DEFAULT_TASK_TIMEOUT_SECONDS
 from apps.tasks.models import Task
 from apps.tasks.services import OutputFormatter
 
@@ -99,8 +100,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "--timeout",
             type=int,
-            default=3600,
-            help="Task timeout in seconds (default: 3600)",
+            default=DEFAULT_TASK_TIMEOUT_SECONDS,
+            help=f"Task timeout in seconds (default: {DEFAULT_TASK_TIMEOUT_SECONDS})",
         )
         parser.add_argument(
             "--max-tasks",
@@ -590,7 +591,7 @@ class Command(BaseCommand):
             str(manage_py),
             "run_dispatcherd",
             f"--workers={config['dispatcher_workers']}",
-            f"--timeout={config['timeout']}",
+            *([f"--timeout={config['timeout']}"] if config["timeout"] is not None else []),
             f"--max-tasks={config['max_tasks']}",
             f"--log-level={config['log_level']}",
         ]
@@ -733,7 +734,7 @@ class Command(BaseCommand):
             "port": options.get("port", "8000"),
             "gunicorn_workers": gunicorn_workers,
             "dispatcher_workers": dispatcher_workers,
-            "timeout": options.get("timeout", 3600),
+            "timeout": options.get("timeout", DEFAULT_TASK_TIMEOUT_SECONDS),
             "max_tasks": options.get("max_tasks", 100),
             "log_level": options.get("log_level", "INFO"),
             "check_interval": options.get("check_interval", 60),

--- a/apps/tasks/management/commands/run_dispatcherd.py
+++ b/apps/tasks/management/commands/run_dispatcherd.py
@@ -9,8 +9,8 @@ import sys
 
 from django.core.management.base import BaseCommand
 
+from apps.tasks.cron_scheduler import DEFAULT_TASK_TIMEOUT_SECONDS
 from apps.tasks.dispatcherd_config import setup_dispatcherd_config
-from apps.tasks.models import STUCK_TASK_TIMEOUT_SECONDS
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +31,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "--timeout",
             type=int,
-            default=STUCK_TASK_TIMEOUT_SECONDS,
-            help="Task timeout in seconds (default: 3600)",
+            default=DEFAULT_TASK_TIMEOUT_SECONDS,
+            help=f"Task timeout in seconds (default: {DEFAULT_TASK_TIMEOUT_SECONDS})",
         )
         parser.add_argument(
             "--max-tasks",

--- a/apps/tasks/management/commands/run_dispatcherd.py
+++ b/apps/tasks/management/commands/run_dispatcherd.py
@@ -10,6 +10,7 @@ import sys
 from django.core.management.base import BaseCommand
 
 from apps.tasks.dispatcherd_config import setup_dispatcherd_config
+from apps.tasks.models import STUCK_TASK_TIMEOUT_SECONDS
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--timeout",
             type=int,
-            default=3600,
+            default=STUCK_TASK_TIMEOUT_SECONDS,
             help="Task timeout in seconds (default: 3600)",
         )
         parser.add_argument(

--- a/apps/tasks/migrations/0004_remove_task_timeout_seconds.py
+++ b/apps/tasks/migrations/0004_remove_task_timeout_seconds.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tasks', '0003_remove_anonymizedmetricspayload_unique_active_payload_per_summary_and_more'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='task',
+            name='timeout_seconds',
+        ),
+    ]

--- a/apps/tasks/models.py
+++ b/apps/tasks/models.py
@@ -45,8 +45,6 @@ except ImportError:
             abstract = True
 
 
-STUCK_TASK_TIMEOUT_SECONDS = 3600
-
 logger = logging.getLogger(__name__)
 
 
@@ -99,10 +97,6 @@ class Task(NamedCommonModel, AuditableModel, StatusTrackingMixin):
     attempts = models.PositiveIntegerField(default=0, help_text="Number of execution attempts")
 
     max_attempts = models.PositiveIntegerField(default=3, help_text="Maximum number of retry attempts")
-
-    timeout_seconds = models.PositiveIntegerField(
-        default=STUCK_TASK_TIMEOUT_SECONDS, help_text="Task timeout in seconds"
-    )
 
     # Execution results (inherited from StatusTrackingMixin)
     result_data = models.JSONField(default=dict, blank=True, help_text="JSON result data from task execution")

--- a/apps/tasks/models.py
+++ b/apps/tasks/models.py
@@ -45,6 +45,8 @@ except ImportError:
             abstract = True
 
 
+STUCK_TASK_TIMEOUT_SECONDS = 3600
+
 logger = logging.getLogger(__name__)
 
 
@@ -98,7 +100,9 @@ class Task(NamedCommonModel, AuditableModel, StatusTrackingMixin):
 
     max_attempts = models.PositiveIntegerField(default=3, help_text="Maximum number of retry attempts")
 
-    timeout_seconds = models.PositiveIntegerField(default=3600, help_text="Task timeout in seconds")
+    timeout_seconds = models.PositiveIntegerField(
+        default=STUCK_TASK_TIMEOUT_SECONDS, help_text="Task timeout in seconds"
+    )
 
     # Execution results (inherited from StatusTrackingMixin)
     result_data = models.JSONField(default=dict, blank=True, help_text="JSON result data from task execution")

--- a/apps/tasks/tests/test_feature_flag_runtime_check.py
+++ b/apps/tasks/tests/test_feature_flag_runtime_check.py
@@ -24,7 +24,6 @@ def _make_mock_task(task_id=42, task_data=None, status="pending", cron_expressio
     mock_task.cron_expression = cron_expression
     mock_task.function_name = "hello_world"
     mock_task.max_attempts = 3
-    mock_task.timeout_seconds = 3600
     mock_task.created_by = None
     mock_task.is_system_task = True
     return mock_task

--- a/apps/tasks/v1/serializers.py
+++ b/apps/tasks/v1/serializers.py
@@ -54,7 +54,6 @@ class TaskSerializer(BaseModelSerializer, StatusFieldMixin):
             "status",
             "attempts",
             "max_attempts",
-            "timeout_seconds",
             "result_data",
             "started_at",
             "completed_at",
@@ -142,7 +141,6 @@ class TaskCreateSerializer(serializers.ModelSerializer):
             "scheduled_time",
             "cron_expression",
             "max_attempts",
-            "timeout_seconds",
             "user",
         ]
         extra_kwargs = {
@@ -153,7 +151,6 @@ class TaskCreateSerializer(serializers.ModelSerializer):
             "task_data": {"required": False, "help_text": "JSON object with task parameters"},
             "cron_expression": {"required": False, "help_text": "Cron expression for recurring tasks"},
             "max_attempts": {"default": 3},
-            "timeout_seconds": {"default": 3600},
         }
 
     def validate_function_name(self, value):

--- a/tests/unit/core/test_core_models.py
+++ b/tests/unit/core/test_core_models.py
@@ -76,7 +76,6 @@ class TaskModelTestCase(TestCase):
         self.assertEqual(self.task.status, "pending")
         self.assertEqual(self.task.attempts, 0)
         self.assertEqual(self.task.max_attempts, 3)
-        self.assertEqual(self.task.timeout_seconds, 3600)
         self.assertIsNone(self.task.cron_expression)  # Non-recurring task
 
     def test_task_is_ready_to_run(self):


### PR DESCRIPTION
# [AAP-74369] Make task timeout nullable to respect dispatcherd.yaml default_timeout

## Description
The default task timeout was hardcoded to 3600 in multiple Python layers (model field, CLI args, serializer, config extraction), which meant dispatcherd.yaml's `default_timeout` was always silently overridden.

  This PR removes those hardcoded defaults by:
  - Making `Task.timeout_seconds` nullable (`null=True, blank=True, default=None`)
  - Changing `--timeout` CLI args in `metrics_service` and `run_dispatcherd` to default to `None`
  - Only passing `--timeout` to the dispatcherd subprocess when explicitly set
  - Updating the TaskCreate serializer default to `None`

  With these changes, `dispatcherd.yaml` is the single source of truth for the default timeout. An explicit timeout can still be passed at the CLI or set per-task in the DB, and both will be respected.

  ## Files changed
  - `apps/tasks/models.py` — `timeout_seconds` made nullable
  - `apps/tasks/migrations/0004_nullable_timeout_seconds.py` — migration for above
  - `apps/tasks/management/commands/metrics_service.py` — `--timeout` default → `None`, subprocess guard
  - `apps/tasks/management/commands/run_dispatcherd.py` — `--timeout` default → `None`
  - `apps/tasks/v1/serializers.py` — `timeout_seconds` serializer default → `None`
  - `apps/tasks/cron_scheduler.py` — clarified comment on `STUCK_TASK_TIMEOUT_SECONDS`
  - `apps/settings/dispatcherd.yaml` — minor comment cleanup


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
