### PR TITLE
[AAP-72454] Monthly AAP cost does not match cost of automated execution

### DIFF
--- a/apps/dashboard_reports/models.py
+++ b/apps/dashboard_reports/models.py
@@ -15,7 +15,7 @@ from typing import Any, Self
 from django.conf import settings
 from django.core.validators import MinValueValidator
 from django.db import IntegrityError, models, transaction
-from django.db.models import Case, F, When
+from django.db.models import Case, F, Sum, When
 from django.db.models.functions import Cast
 from metrics_utility.library.collectors.dashboard import AWXJobType
 
@@ -200,10 +200,61 @@ class SubscriptionCost(CommonModel):
         self, start: datetime | None = None, end: datetime | None = None
     ) -> decimal.Decimal:
         """
-        Calculate and return the per-second subscription cost based on the daily subscription cost.
+        Calculates the weighted subscription cost per elapsed second for a given date range.
+        Distributes the proportional monthly cost across all job elapsed seconds in the period.
+
+        Returns a value in units of (currency / second), suitable for direct multiplication
+        by a job's elapsed field (which is in seconds) to produce the job's share of the
+        subscription cost.
+
+        Formula: cost_per_elapsed_second = period_cost / sum(elapsed_seconds_in_period)
+        Verification: sum(job.elapsed * cost_per_elapsed_second) == period_cost
         """
-        daily_cost = self.daily_subscription_cost(start=start, end=end)
-        return daily_cost / decimal.Decimal(86400)  # 86400 seconds in a day
+        monthly_cost = decimal.Decimal(str(self.monthly_subscription_cost))
+
+        if start is None or end is None:
+            now = datetime.now(UTC)
+            days_in_month = calendar.monthrange(now.year, now.month)[1]
+            start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            end = now.replace(day=days_in_month, hour=23, minute=59, second=59, microsecond=999999)
+
+        if start > end:
+            start, end = end, start
+
+        # Normalize end to end-of-day to ensure the filter matches the day-count formula
+        end = end.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+        elapsed_result = JobData.objects.filter(
+            status__in=[JobStatusChoices.SUCCESSFUL, JobStatusChoices.FAILED],
+            finished__gte=start,
+            finished__lte=end,
+        ).aggregate(total_seconds=Sum("elapsed"))
+
+        total_elapsed_raw = elapsed_result["total_seconds"]
+        if total_elapsed_raw is None or total_elapsed_raw == 0:
+            # Return a near-zero sentinel rather than 0 to avoid ZeroDivisionError at call
+            # sites that multiply this rate by elapsed seconds. In practice this path is
+            # only hit when no successful/failed jobs exist in the period, so the rate is
+            # never applied to any real job.
+            return decimal.Decimal("0").quantize(decimal.Decimal("0.0000000001"))
+
+        total_elapsed_decimal = decimal.Decimal(str(total_elapsed_raw))
+
+        if start.year == end.year and start.month == end.month:
+            days_in_month = decimal.Decimal(str(calendar.monthrange(start.year, start.month)[1]))
+            total_period_days = decimal.Decimal(str((end.date() - start.date()).days + 1))
+            period_cost = monthly_cost * total_period_days / days_in_month
+        else:
+            period_cost = decimal.Decimal("0")
+            for current_year, current_month in _month_range_iter(start, end):
+                _, month_start_day, month_end_day = _get_month_overlap_days(current_year, current_month, start, end)
+                overlap_days = month_end_day - month_start_day + 1
+                if overlap_days > 0:
+                    days_in_month_dec = decimal.Decimal(str(calendar.monthrange(current_year, current_month)[1]))
+                    period_cost += monthly_cost * (decimal.Decimal(str(overlap_days)) / days_in_month_dec)
+
+        cost_per_unit = period_cost / total_elapsed_decimal
+        return cost_per_unit.quantize(decimal.Decimal("0.0000000001"), rounding=decimal.ROUND_HALF_UP)
 
 
 class FilterSet(CommonModel):

--- a/tests/coverage/dashboard_reports/test_dashboard_models_extended.py
+++ b/tests/coverage/dashboard_reports/test_dashboard_models_extended.py
@@ -265,20 +265,20 @@ def test_daily_subscription_cost_year_boundary():
 @pytest.mark.unit
 @pytest.mark.django_db
 def test_per_second_subscription_cost():
-    """per_second_subscription_cost is daily / 86400."""
+    """per_second_subscription_cost returns 0 (quantized) when no jobs exist in the period."""
     from apps.dashboard_reports.models import SubscriptionCost
 
     SubscriptionCost.objects.all().delete()
     cost = SubscriptionCost.get()
     per_sec = cost.per_second_subscription_cost()
-    daily = cost.daily_subscription_cost()
-    assert abs(per_sec - daily / decimal.Decimal(86400)) < decimal.Decimal("0.000001")
+    assert isinstance(per_sec, decimal.Decimal)
+    assert per_sec == decimal.Decimal("0").quantize(decimal.Decimal("0.0000000001"))
 
 
 @pytest.mark.unit
 @pytest.mark.django_db
 def test_per_second_subscription_cost_with_dates():
-    """per_second_subscription_cost passes date args through to daily_subscription_cost."""
+    """per_second_subscription_cost with no jobs in range returns 0 (quantized)."""
     from apps.dashboard_reports.models import SubscriptionCost
 
     SubscriptionCost.objects.all().delete()
@@ -287,7 +287,7 @@ def test_per_second_subscription_cost_with_dates():
     end = datetime(2024, 5, 31, tzinfo=UTC)
     per_sec = cost.per_second_subscription_cost(start=start, end=end)
     assert isinstance(per_sec, decimal.Decimal)
-    assert per_sec > 0
+    assert per_sec == decimal.Decimal("0").quantize(decimal.Decimal("0.0000000001"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/coverage/general/test_final_push.py
+++ b/tests/coverage/general/test_final_push.py
@@ -83,15 +83,15 @@ def test_handle_run_command_calls_start_services():
 @pytest.mark.django_db
 def test_subscription_cost_per_second():
     import decimal
-    from datetime import date
+    from datetime import UTC, datetime, timezone
 
     from apps.dashboard_reports.models import SubscriptionCost
 
     SubscriptionCost.objects.all().delete()
     cost = SubscriptionCost.get()
     result = cost.per_second_subscription_cost(
-        start=date(2024, 1, 1),
-        end=date(2024, 1, 31),
+        start=datetime(2024, 1, 1, tzinfo=UTC),
+        end=datetime(2024, 1, 31, tzinfo=UTC),
     )
     assert isinstance(result, decimal.Decimal)
 

--- a/tests/unit/dashboard_reports/test_daily_subscription_cost.py
+++ b/tests/unit/dashboard_reports/test_daily_subscription_cost.py
@@ -1,10 +1,18 @@
 import datetime
 import decimal
+from datetime import UTC
 from unittest.mock import patch
 
 import pytest
 
-from apps.dashboard_reports.models import SubscriptionCost, _get_month_overlap_days, _month_range_iter
+from apps.dashboard_reports.models import (
+    JobData,
+    JobStatusChoices,
+    SubscriptionCost,
+    TemplateMetadata,
+    _get_month_overlap_days,
+    _month_range_iter,
+)
 
 
 @pytest.mark.unit
@@ -186,51 +194,296 @@ class TestDailySubscriptionCost:
         expected = decimal.Decimal("310") / decimal.Decimal(31)
         assert result == expected
 
-    def test_per_second_subscription_cost_standard(self):
-        """Test per_second_subscription_cost with default monthly cost and no date range."""
-        subscription_cost = SubscriptionCost.objects.create(
-            monthly_subscription_cost=3000.00,
-            engineer_avg_hourly_rate=60.00,
-            include_template_creation_time_in_costs=True,
-        )
-        daily_cost = subscription_cost.daily_subscription_cost()
-        expected = daily_cost / decimal.Decimal(86400)
-        result = subscription_cost.per_second_subscription_cost()
-        assert result == expected
+    def test_daily_subscription_cost_zero_overlap_falls_back_to_default(self):
+        """If the multi-month loop accumulates zero total_days, fall back to default daily cost."""
 
-    def test_per_second_subscription_cost_zero(self):
-        """Test per_second_subscription_cost with zero monthly cost."""
-        subscription_cost = SubscriptionCost.objects.create(
-            monthly_subscription_cost=0.00,
-            engineer_avg_hourly_rate=60.00,
-            include_template_creation_time_in_costs=True,
+        SubscriptionCost.objects.all().delete()
+        cost = SubscriptionCost.objects.create(
+            monthly_subscription_cost=decimal.Decimal("3000.00"),
+            engineer_avg_hourly_rate=decimal.Decimal("60.00"),
         )
-        result = subscription_cost.per_second_subscription_cost()
-        assert result == decimal.Decimal("0.00")
+        start = datetime.datetime(2024, 1, 15, tzinfo=UTC)
+        end = datetime.datetime(2024, 3, 15, tzinfo=UTC)
 
-    def test_per_second_subscription_cost_custom_dates(self):
-        """Test per_second_subscription_cost with custom start/end dates."""
-        subscription_cost = SubscriptionCost.objects.create(
-            monthly_subscription_cost=3100.00,
-            engineer_avg_hourly_rate=60.00,
-            include_template_creation_time_in_costs=True,
-        )
-        start = datetime.datetime(2026, 3, 1, tzinfo=datetime.UTC)
-        end = datetime.datetime(2026, 3, 31, tzinfo=datetime.UTC)
-        daily_cost = subscription_cost.daily_subscription_cost(start=start, end=end)
-        expected = daily_cost / decimal.Decimal(86400)
-        result = subscription_cost.per_second_subscription_cost(start=start, end=end)
-        assert result == expected
+        # Patch _get_month_overlap_days to always return 0 overlap so total_days stays 0
+        with patch("apps.dashboard_reports.models._get_month_overlap_days", return_value=(31, 5, 4)):
+            # month_end_day (4) - month_start_day (5) + 1 = 0 → overlap <= 0 for all months
+            result = cost.daily_subscription_cost(start=start, end=end)
 
-    def test_per_second_subscription_cost_decimal_precision(self):
-        """Test per_second_subscription_cost with decimal precision."""
-        subscription_cost = SubscriptionCost.objects.create(
-            monthly_subscription_cost=1234.56,
-            engineer_avg_hourly_rate=60.00,
-            include_template_creation_time_in_costs=True,
-        )
-        daily_cost = subscription_cost.daily_subscription_cost()
-        result = subscription_cost.per_second_subscription_cost()
-        # Check that result is a Decimal and matches expected precision
+        # Should fall back to default_daily_cost
         assert isinstance(result, decimal.Decimal)
-        assert result == daily_cost / decimal.Decimal(86400)
+        assert result > 0
+
+
+@pytest.mark.unit
+@pytest.mark.django_db(transaction=True, reset_sequences=True)
+class TestPerSecondSubscriptionCost:
+    """
+    Tests for SubscriptionCost.per_second_subscription_cost().
+
+    The method returns cost_per_elapsed_second (currency / second) where:
+      cost_per_elapsed_second * total_elapsed_seconds_in_period == total_period_cost
+
+    This distributes the proportional monthly subscription cost across all
+    successful/failed job elapsed seconds in the period.
+    """
+
+    @pytest.fixture()
+    def subscription_cost(self) -> "SubscriptionCost":
+        db = SubscriptionCost.get()
+        db.monthly_subscription_cost = decimal.Decimal("2000.00")
+        db.save()
+        return db
+
+    @pytest.fixture()
+    def jobs_in_march(self, subscription_cost: "SubscriptionCost"):
+        """Two successful jobs in March 2025, each with elapsed=500 seconds."""
+
+        TemplateMetadata.objects.create(template_id=101, template_name="Test Template")
+        JobData.objects.create(
+            job_id=1001,
+            template_name="Test Template",
+            template_id=101,
+            status=JobStatusChoices.SUCCESSFUL,
+            started=datetime.datetime(2025, 3, 1, 10, 0, 0, tzinfo=datetime.UTC),
+            finished=datetime.datetime(2025, 3, 1, 10, 8, 20, tzinfo=datetime.UTC),
+            elapsed=decimal.Decimal("500"),
+        )
+        JobData.objects.create(
+            job_id=1002,
+            template_name="Test Template",
+            template_id=101,
+            status=JobStatusChoices.SUCCESSFUL,
+            started=datetime.datetime(2025, 3, 15, 12, 0, 0, tzinfo=datetime.UTC),
+            finished=datetime.datetime(2025, 3, 15, 12, 8, 20, tzinfo=datetime.UTC),
+            elapsed=decimal.Decimal("500"),
+        )
+
+    def test_full_month_weighted_cost(self, subscription_cost: "SubscriptionCost", jobs_in_march: None) -> None:
+        """Full March: period_cost == monthly_cost; total_elapsed == 1000s → rate = 2000/1000 = 2."""
+        start = datetime.datetime(2025, 3, 1, tzinfo=datetime.UTC)
+        end = datetime.datetime(2025, 3, 31, tzinfo=datetime.UTC)
+
+        result = subscription_cost.per_second_subscription_cost(start, end)
+
+        expected = (decimal.Decimal("2000") / decimal.Decimal("1000")).quantize(decimal.Decimal("0.0000000001"))
+        assert result == expected
+
+    def test_partial_month_weighted_cost(self, subscription_cost, jobs_in_march):
+        start = datetime.datetime(2025, 3, 1, tzinfo=datetime.UTC)
+        end = datetime.datetime(2025, 3, 15, tzinfo=datetime.UTC)
+
+        result = subscription_cost.per_second_subscription_cost(start, end)
+
+        period_cost = decimal.Decimal("2000") * decimal.Decimal("15") / decimal.Decimal("31")
+        expected = (period_cost / decimal.Decimal("1000")).quantize(
+            decimal.Decimal("0.0000000001")
+        )  # both jobs are in range
+        assert result == expected
+
+    def test_multi_month_weighted_cost(self, subscription_cost: "SubscriptionCost") -> None:
+        """Feb + March full months: period_cost = 4000, total_elapsed = 200+300 = 500 → rate = 8."""
+
+        TemplateMetadata.objects.create(template_id=202, template_name="Multi Month Template")
+        JobData.objects.create(
+            job_id=2001,
+            template_name="Multi Month Template",
+            template_id=202,
+            status=JobStatusChoices.SUCCESSFUL,
+            started=datetime.datetime(2025, 2, 10, tzinfo=datetime.UTC),
+            finished=datetime.datetime(2025, 2, 10, 1, 0, 0, tzinfo=datetime.UTC),
+            elapsed=decimal.Decimal("200"),
+        )
+        JobData.objects.create(
+            job_id=2002,
+            template_name="Multi Month Template",
+            template_id=202,
+            status=JobStatusChoices.SUCCESSFUL,
+            started=datetime.datetime(2025, 3, 10, tzinfo=datetime.UTC),
+            finished=datetime.datetime(2025, 3, 10, 1, 0, 0, tzinfo=datetime.UTC),
+            elapsed=decimal.Decimal("300"),
+        )
+
+        start = datetime.datetime(2025, 2, 1, tzinfo=datetime.UTC)
+        end = datetime.datetime(2025, 3, 31, tzinfo=datetime.UTC)
+
+        result = subscription_cost.per_second_subscription_cost(start, end)
+
+        # Feb (28/28) + Mar (31/31) = 2000 + 2000 = 4000; total_elapsed = 500
+        expected = (decimal.Decimal("4000") / decimal.Decimal("500")).quantize(decimal.Decimal("0.0000000001"))
+        assert result == expected
+
+    def test_no_jobs_returns_fallback(self, subscription_cost):
+        start = datetime.datetime(2025, 1, 1, tzinfo=datetime.UTC)
+        end = datetime.datetime(2025, 1, 31, tzinfo=datetime.UTC)
+
+        result = subscription_cost.per_second_subscription_cost(start, end)
+
+        assert result == decimal.Decimal("0").quantize(decimal.Decimal("0.0000000001"))
+
+    def test_zero_monthly_cost_returns_zero_rate(
+        self, subscription_cost: "SubscriptionCost", jobs_in_march: None
+    ) -> None:
+        """Zero monthly cost → period_cost = 0 → rate = 0."""
+        subscription_cost.monthly_subscription_cost = decimal.Decimal("0.00")
+        subscription_cost.save()
+
+        start = datetime.datetime(2025, 3, 1, tzinfo=datetime.UTC)
+        end = datetime.datetime(2025, 3, 31, tzinfo=datetime.UTC)
+
+        result = subscription_cost.per_second_subscription_cost(start, end)
+
+        assert result == decimal.Decimal("0").quantize(decimal.Decimal("0.0000000001"))
+
+    def test_failed_jobs_are_included(self, subscription_cost: "SubscriptionCost") -> None:
+        """Failed jobs must be included in the elapsed total."""
+
+        TemplateMetadata.objects.create(template_id=303, template_name="Failed Template")
+        JobData.objects.create(
+            job_id=3001,
+            template_name="Failed Template",
+            template_id=303,
+            status=JobStatusChoices.FAILED,
+            started=datetime.datetime(2025, 3, 5, tzinfo=datetime.UTC),
+            finished=datetime.datetime(2025, 3, 5, 1, 0, 0, tzinfo=datetime.UTC),
+            elapsed=decimal.Decimal("1000"),
+        )
+
+        start = datetime.datetime(2025, 3, 1, tzinfo=datetime.UTC)
+        end = datetime.datetime(2025, 3, 31, tzinfo=datetime.UTC)
+
+        result = subscription_cost.per_second_subscription_cost(start, end)
+
+        expected = (decimal.Decimal("2000") / decimal.Decimal("1000")).quantize(decimal.Decimal("0.0000000001"))
+        assert result == expected
+
+    def test_start_greater_than_end_is_swapped(
+        self, subscription_cost: "SubscriptionCost", jobs_in_march: None
+    ) -> None:
+        """Reversed start/end should give same result as normal order."""
+        result_normal = subscription_cost.per_second_subscription_cost(
+            datetime.datetime(2025, 3, 1, tzinfo=datetime.UTC),
+            datetime.datetime(2025, 3, 31, tzinfo=datetime.UTC),
+        )
+        result_reversed = subscription_cost.per_second_subscription_cost(
+            datetime.datetime(2025, 3, 31, tzinfo=datetime.UTC),
+            datetime.datetime(2025, 3, 1, tzinfo=datetime.UTC),
+        )
+        assert result_normal == result_reversed
+
+    def test_cost_distribution_invariant(self, subscription_cost: "SubscriptionCost", jobs_in_march: None) -> None:
+        """
+        Core invariant: cost_per_second * total_elapsed ≈ period_cost.
+        Tolerance is one quantization unit per elapsed second.
+        """
+        start = datetime.datetime(2025, 3, 1, tzinfo=datetime.UTC)
+        end = datetime.datetime(2025, 3, 31, tzinfo=datetime.UTC)
+
+        rate = subscription_cost.per_second_subscription_cost(start, end)
+        total_elapsed = decimal.Decimal("1000")  # two jobs × 500s each
+        reconstructed = rate * total_elapsed
+
+        expected_period_cost = decimal.Decimal("2000")
+        tolerance = decimal.Decimal("0.0000000001") * total_elapsed
+
+        assert abs(reconstructed - expected_period_cost) <= tolerance, (
+            f"Invariant broken: |{reconstructed} - {expected_period_cost}| > {tolerance}"
+        )
+
+    @patch("apps.dashboard_reports.models.datetime")
+    def test_no_date_defaults_to_current_month(self, mock_datetime, subscription_cost: "SubscriptionCost") -> None:
+        """
+        When start/end are None the method defaults to the current full calendar month.
+        A job finishing within that month must be included in the elapsed sum.
+        """
+
+        fixed_now = datetime.datetime(2025, 6, 15, 12, 0, 0, tzinfo=datetime.UTC)
+        mock_datetime.now.return_value = fixed_now
+
+        TemplateMetadata.objects.create(template_id=404, template_name="June Template")
+        JobData.objects.create(
+            job_id=4001,
+            template_name="June Template",
+            template_id=404,
+            status=JobStatusChoices.SUCCESSFUL,
+            started=datetime.datetime(2025, 6, 10, 0, 0, 0, tzinfo=datetime.UTC),
+            finished=datetime.datetime(2025, 6, 10, 0, 16, 40, tzinfo=datetime.UTC),
+            elapsed=decimal.Decimal("1000"),
+        )
+
+        result = subscription_cost.per_second_subscription_cost()
+
+        # Full June (30 days) → period_cost = monthly_cost; elapsed = 1000s
+        expected = (decimal.Decimal("2000") / decimal.Decimal("1000")).quantize(decimal.Decimal("0.0000000001"))
+        assert result == expected
+
+    def test_pending_and_cancelled_jobs_are_excluded(self, subscription_cost: "SubscriptionCost") -> None:
+        """Jobs with status other than SUCCESSFUL or FAILED must not contribute to the elapsed sum."""
+
+        TemplateMetadata.objects.create(template_id=505, template_name="Mixed Status Template")
+        # This job should be counted
+        JobData.objects.create(
+            job_id=5001,
+            template_name="Mixed Status Template",
+            template_id=505,
+            status=JobStatusChoices.SUCCESSFUL,
+            started=datetime.datetime(2025, 4, 1, tzinfo=datetime.UTC),
+            finished=datetime.datetime(2025, 4, 1, 0, 16, 40, tzinfo=datetime.UTC),
+            elapsed=decimal.Decimal("1000"),
+        )
+        # These jobs must NOT be counted
+        for job_id, status in [
+            (5002, JobStatusChoices.PENDING),
+            (5003, JobStatusChoices.RUNNING),
+            (5004, JobStatusChoices.CANCELED),
+        ]:
+            JobData.objects.create(
+                job_id=job_id,
+                template_name="Mixed Status Template",
+                template_id=505,
+                status=status,
+                started=datetime.datetime(2025, 4, 2, tzinfo=datetime.UTC),
+                finished=datetime.datetime(2025, 4, 2, 1, 0, 0, tzinfo=datetime.UTC),
+                elapsed=decimal.Decimal("9999"),
+            )
+
+        start = datetime.datetime(2025, 4, 1, tzinfo=datetime.UTC)
+        end = datetime.datetime(2025, 4, 30, tzinfo=datetime.UTC)
+
+        result = subscription_cost.per_second_subscription_cost(start, end)
+
+        # Only the SUCCESSFUL job's 1000s should count; period_cost = 2000 (full April)
+        expected = (decimal.Decimal("2000") / decimal.Decimal("1000")).quantize(decimal.Decimal("0.0000000001"))
+        assert result == expected
+
+    def test_cross_year_boundary_cost(self, subscription_cost: "SubscriptionCost") -> None:
+        """Full Dec + full Jan spanning a year boundary should sum two full monthly costs."""
+
+        TemplateMetadata.objects.create(template_id=606, template_name="Year Boundary Template")
+        JobData.objects.create(
+            job_id=6001,
+            template_name="Year Boundary Template",
+            template_id=606,
+            status=JobStatusChoices.SUCCESSFUL,
+            started=datetime.datetime(2024, 12, 15, tzinfo=datetime.UTC),
+            finished=datetime.datetime(2024, 12, 15, 1, 0, 0, tzinfo=datetime.UTC),
+            elapsed=decimal.Decimal("400"),
+        )
+        JobData.objects.create(
+            job_id=6002,
+            template_name="Year Boundary Template",
+            template_id=606,
+            status=JobStatusChoices.SUCCESSFUL,
+            started=datetime.datetime(2025, 1, 15, tzinfo=datetime.UTC),
+            finished=datetime.datetime(2025, 1, 15, 1, 0, 0, tzinfo=datetime.UTC),
+            elapsed=decimal.Decimal("600"),
+        )
+
+        start = datetime.datetime(2024, 12, 1, tzinfo=datetime.UTC)
+        end = datetime.datetime(2025, 1, 31, tzinfo=datetime.UTC)
+
+        result = subscription_cost.per_second_subscription_cost(start, end)
+
+        # Dec (31/31) + Jan (31/31) = 2000 + 2000 = 4000; total_elapsed = 1000s
+        expected = (decimal.Decimal("4000") / decimal.Decimal("1000")).quantize(decimal.Decimal("0.0000000001"))
+        assert result == expected

--- a/tests/unit/dashboard_reports/test_export_urls.py
+++ b/tests/unit/dashboard_reports/test_export_urls.py
@@ -17,6 +17,7 @@ from apps.dashboard_reports.models import (
 )
 
 FIXED_DAILY_SUBSCRIPTION_COST = decimal.Decimal("161.29")
+FIXED_PER_SECOND_COST = decimal.Decimal("0.001")
 
 
 def get_now() -> datetime.datetime:
@@ -174,8 +175,8 @@ class TestExportEndpointGeneral:
     @pytest.fixture(autouse=True)
     def fixed_subscription_cost(self):
         with patch(
-            "apps.dashboard_reports.models.SubscriptionCost.daily_subscription_cost",
-            return_value=FIXED_DAILY_SUBSCRIPTION_COST,
+            "apps.dashboard_reports.models.SubscriptionCost.per_second_subscription_cost",
+            return_value=FIXED_PER_SECOND_COST,
         ):
             yield
 
@@ -274,8 +275,8 @@ class TestExportSummaryCSV:
     @pytest.fixture(autouse=True)
     def fixed_subscription_cost(self):
         with patch(
-            "apps.dashboard_reports.models.SubscriptionCost.daily_subscription_cost",
-            return_value=FIXED_DAILY_SUBSCRIPTION_COST,
+            "apps.dashboard_reports.models.SubscriptionCost.per_second_subscription_cost",
+            return_value=FIXED_PER_SECOND_COST,
         ):
             yield
 
@@ -393,8 +394,8 @@ class TestExportROICSV:
     @pytest.fixture(autouse=True)
     def fixed_subscription_cost(self):
         with patch(
-            "apps.dashboard_reports.models.SubscriptionCost.daily_subscription_cost",
-            return_value=FIXED_DAILY_SUBSCRIPTION_COST,
+            "apps.dashboard_reports.models.SubscriptionCost.per_second_subscription_cost",
+            return_value=FIXED_PER_SECOND_COST,
         ):
             yield
 
@@ -487,8 +488,8 @@ class TestExportTrendsCSV:
     @pytest.fixture(autouse=True)
     def fixed_subscription_cost(self):
         with patch(
-            "apps.dashboard_reports.models.SubscriptionCost.daily_subscription_cost",
-            return_value=FIXED_DAILY_SUBSCRIPTION_COST,
+            "apps.dashboard_reports.models.SubscriptionCost.per_second_subscription_cost",
+            return_value=FIXED_PER_SECOND_COST,
         ):
             yield
 

--- a/tests/unit/dashboard_reports/test_report_view_data.py
+++ b/tests/unit/dashboard_reports/test_report_view_data.py
@@ -27,6 +27,7 @@ _VALID_PERIOD_DAYS = frozenset({7, 14, 30, 60, 90})
 # which causes test failures in months with fewer days (e.g. April=30, February=28).
 # 161.29 = 5000 (default monthly_subscription_cost) / 31 days — matches the expected cost constants.
 FIXED_DAILY_SUBSCRIPTION_COST = decimal.Decimal("161.29")
+FIXED_PER_SECOND_SUBSCRIPTION_COST = FIXED_DAILY_SUBSCRIPTION_COST / decimal.Decimal(86400)
 
 
 def get_now() -> datetime.datetime:
@@ -501,8 +502,8 @@ class TestReportViewData:
     @pytest.fixture(autouse=True)
     def fixed_subscription_cost(self):
         with patch(
-            "apps.dashboard_reports.models.SubscriptionCost.daily_subscription_cost",
-            return_value=FIXED_DAILY_SUBSCRIPTION_COST,
+            "apps.dashboard_reports.models.SubscriptionCost.per_second_subscription_cost",
+            return_value=FIXED_PER_SECOND_SUBSCRIPTION_COST,
         ):
             yield
 
@@ -612,8 +613,8 @@ class TestDashboardReportViewSetEndpoints:
     @pytest.fixture(autouse=True)
     def fixed_subscription_cost(self):
         with patch(
-            "apps.dashboard_reports.models.SubscriptionCost.daily_subscription_cost",
-            return_value=FIXED_DAILY_SUBSCRIPTION_COST,
+            "apps.dashboard_reports.models.SubscriptionCost.per_second_subscription_cost",
+            return_value=FIXED_PER_SECOND_SUBSCRIPTION_COST,
         ):
             yield
 
@@ -850,8 +851,8 @@ class TestReportViewDataNoCreationTime:
     @pytest.fixture(autouse=True)
     def fixed_subscription_cost(self):
         with patch(
-            "apps.dashboard_reports.models.SubscriptionCost.daily_subscription_cost",
-            return_value=FIXED_DAILY_SUBSCRIPTION_COST,
+            "apps.dashboard_reports.models.SubscriptionCost.per_second_subscription_cost",
+            return_value=FIXED_PER_SECOND_SUBSCRIPTION_COST,
         ):
             yield
 

--- a/tests/unit/dashboard_reports/test_report_views.py
+++ b/tests/unit/dashboard_reports/test_report_views.py
@@ -1,3 +1,4 @@
+import decimal
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -431,16 +432,22 @@ class TestDashboardReportViewSet:
         assert result["job_chart"]["items"][0]["value"] == 5
 
     # Test details endpoint logic with mocks
+    @patch("apps.dashboard_reports.viewsets.dashboard_report.SubscriptionCost.get")
     @patch("apps.dashboard_reports.viewsets.dashboard_report.JobData.objects")
     @patch("apps.dashboard_reports.viewsets.dashboard_report.JobHostSummary.objects")
     @patch.object(DashboardReportViewSet, "get_chart_data")
     @patch.object(DashboardReportViewSet, "get_serializer")
-    def test_details(self, mock_serializer, mock_chart, mock_host_objects, mock_jobdata, viewset, factory):
+    def test_details(
+        self, mock_serializer, mock_chart, mock_host_objects, mock_jobdata, mock_subcost, viewset, factory
+    ):
         class TestViewSet(DashboardReportViewSet):
             def details(self, request, *args, **kwargs):
                 return super().details.__wrapped__(self, request, *args, **kwargs)
 
         test_viewset = TestViewSet()
+        mock_subcost.return_value.cost_employee_per_minute = 1
+        mock_subcost.return_value.per_second_subscription_cost.return_value = decimal.Decimal("0.001")
+        mock_subcost.return_value.include_template_creation_time_in_costs = True
         mock_jobdata.all.return_value = MagicMock()
         # unique hosts: JobHostSummary.objects.filter(...).values(...).distinct().count()
         mock_host_objects.filter.return_value.values.return_value.distinct.return_value.count.return_value = 2


### PR DESCRIPTION
# [AAP-72454] Monthly AAP cost does not match cost of automated execution

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
    - Subscription cost was not being calculated correctly, so in this PR, this is being fixed.
        - same/similar fix as here:   https://github.com/ansible/automation-reports/pull/230
- Why is this change needed?
    - see above 
- How does this change address the issue?
    - see above  

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
See README for setting up development environment.

Other requierements:
- running metrics service DB (with migrations)
- running awx DB (with migrations)

### Steps to Test
- run all unit tests: `pytest -m unit`
- run unit tests just for subscription cost calculation: `pytest -m unit tests/unit/dashboard_reports/test_daily_subscription_cost.py`


## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->
