### PR TITLE
[AAP-75685] Fix: reconcile APScheduler recurring jobs when feature flag is toggled at runtime

### DIFF
--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -158,11 +158,44 @@ class UnifiedTaskScheduler:
         except Exception as e:
             logger.error(f"Error synchronizing database tasks: {e}")
 
+    def _reconcile_recurring_feature_flags(self):
+        """Remove APScheduler jobs for recurring tasks whose feature flag has been disabled.
+
+        Iterates over a snapshot of the current tracking dict so that
+        _remove_database_task can safely mutate self._db_task_jobs during iteration.
+        Unflagged recurring tasks are left untouched — they are always enabled.
+        """
+        from .models import Task
+
+        for task_id, job_id in list(self._db_task_jobs.items()):
+            if not job_id.startswith("db_recurring_"):
+                continue
+            try:
+                task = Task.objects.get(id=task_id)
+            except Task.DoesNotExist:
+                # Stale entry — remove so the re-add loop cannot resurrect it.
+                self._remove_database_task(task_id)
+                continue
+            # Only act on tasks that carry a feature flag; unflagged tasks
+            # are always enabled and must never be removed here.
+            if not (task.task_data and task.task_data.get("_feature_flag")):
+                continue
+            if not self._task_feature_flag_enabled(task):
+                logger.info(
+                    f"Feature flag disabled for recurring task '{task.name}' (ID: {task_id}) — removing APScheduler job"
+                )
+                self._remove_database_task(task_id)
+
     def _periodic_database_sync(self):
         """Periodically check for new database tasks and add them to the scheduler."""
         close_old_connections()
         try:
             from .models import Task
+
+            # Reconcile feature-flag state for already-tracked recurring tasks before
+            # running new-task detection so that re-enabled tasks are picked up in the
+            # same sync cycle.
+            self._reconcile_recurring_feature_flags()
 
             # Get all pending database tasks (immediate, scheduled, or recurring)
             immediate_tasks = Task.immediate_tasks()

--- a/apps/tasks/tests/test_feature_flag_runtime_check.py
+++ b/apps/tasks/tests/test_feature_flag_runtime_check.py
@@ -157,3 +157,119 @@ class TestFeatureFlagRuntimeCheck:
         scheduler._execute_database_task(42)
 
         mock_submit.assert_not_called()
+
+
+@pytest.mark.unit
+class TestPeriodicSyncFlagReconciliation:
+    """Test that _periodic_database_sync reconciles APScheduler jobs with live feature-flag state.
+
+    AC#2/AC#3 requirement: recurring APScheduler jobs must be canceled when the associated
+    feature flag is disabled, and automatically re-added on the next sync when re-enabled.
+    """
+
+    def _make_scheduler_with_recurring_job(self, task_id=99, job_id=None):
+        """Return a scheduler with one recurring job pre-registered in _db_task_jobs."""
+        scheduler = UnifiedTaskScheduler()
+        scheduler._db_task_jobs[task_id] = job_id or f"db_recurring_{task_id}"
+        return scheduler
+
+    @patch("apps.tasks.cron_scheduler.close_old_connections")
+    @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
+    @patch("apps.tasks.models.Task")
+    def test_periodic_sync_removes_job_when_flag_disabled(self, mock_task_cls, mock_get_feature, mock_close):
+        """_periodic_database_sync removes APScheduler job when feature flag is disabled at runtime."""
+        task_id = 99
+        mock_task = _make_mock_task(task_id=task_id, task_data={"_feature_flag": "METRICS_COLLECTION"})
+        mock_task_cls.objects.get.return_value = mock_task
+        # Return empty querysets so the new-task detection loops are no-ops.
+        mock_task_cls.immediate_tasks.return_value = []
+        mock_task_cls.scheduled_tasks.return_value = []
+        mock_task_cls.recurring_tasks.return_value = []
+        mock_task_cls.objects.filter.return_value = []
+        mock_get_feature.return_value = False
+
+        scheduler = self._make_scheduler_with_recurring_job(task_id)
+        # Stub out remove_job so APScheduler is not actually invoked.
+        scheduler.scheduler.remove_job = MagicMock()
+
+        scheduler._periodic_database_sync()
+
+        assert task_id not in scheduler._db_task_jobs
+        scheduler.scheduler.remove_job.assert_called_once_with(f"db_recurring_{task_id}")
+
+    @patch("apps.tasks.cron_scheduler.close_old_connections")
+    @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
+    @patch("apps.tasks.models.Task")
+    def test_periodic_sync_readds_job_when_flag_reenabled(self, mock_task_cls, mock_get_feature, mock_close):
+        """After a job has been removed, the next sync re-adds it when the flag is re-enabled."""
+        task_id = 88
+        mock_task = _make_mock_task(task_id=task_id, task_data={"_feature_flag": "METRICS_COLLECTION"})
+        # recurring_tasks returns the task so the new-task detection loop sees it.
+        mock_task_cls.immediate_tasks.return_value = []
+        mock_task_cls.scheduled_tasks.return_value = []
+        mock_task_cls.recurring_tasks.return_value = [mock_task]
+        mock_task_cls.objects.filter.return_value = []
+        mock_get_feature.return_value = True
+
+        scheduler = UnifiedTaskScheduler()
+        # task_id is NOT in _db_task_jobs — simulates a previously removed job.
+        assert task_id not in scheduler._db_task_jobs
+        scheduler.scheduler.add_job = MagicMock()
+
+        scheduler._periodic_database_sync()
+
+        assert task_id in scheduler._db_task_jobs
+
+    @patch("apps.tasks.cron_scheduler.close_old_connections")
+    @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
+    @patch("apps.tasks.models.Task")
+    def test_periodic_sync_leaves_unflagged_tasks_alone(self, mock_task_cls, mock_get_feature, mock_close):
+        """Recurring tasks without _feature_flag are never removed by the reconciliation loop."""
+        task_id = 77
+        mock_task = _make_mock_task(task_id=task_id, task_data={})  # No feature flag
+        mock_task_cls.objects.get.return_value = mock_task
+        mock_task_cls.immediate_tasks.return_value = []
+        mock_task_cls.scheduled_tasks.return_value = []
+        mock_task_cls.recurring_tasks.return_value = []
+        mock_task_cls.objects.filter.return_value = []
+
+        scheduler = self._make_scheduler_with_recurring_job(task_id)
+        scheduler.scheduler.remove_job = MagicMock()
+
+        scheduler._periodic_database_sync()
+
+        # Job must still be tracked — reconciliation must not touch unflagged tasks.
+        assert task_id in scheduler._db_task_jobs
+        scheduler.scheduler.remove_job.assert_not_called()
+        # get_feature_enabled_from_db should never be called for unflagged tasks.
+        mock_get_feature.assert_not_called()
+
+    @patch("apps.tasks.cron_scheduler.close_old_connections")
+    @patch("apps.tasks.task_groups.get_feature_enabled_from_db")
+    @patch("apps.tasks.models.Task")
+    def test_periodic_sync_flag_disabled_then_reenabled_cycle(self, mock_task_cls, mock_get_feature, mock_close):
+        """Full disable → re-enable cycle: two sync calls remove then re-add the APScheduler job."""
+        task_id = 66
+        mock_task = _make_mock_task(task_id=task_id, task_data={"_feature_flag": "ANONYMIZED_DATA_COLLECTION"})
+        mock_task_cls.objects.get.return_value = mock_task
+        mock_task_cls.immediate_tasks.return_value = []
+        mock_task_cls.scheduled_tasks.return_value = []
+        mock_task_cls.objects.filter.return_value = []
+
+        # --- Cycle 1: flag is disabled ---
+        mock_task_cls.recurring_tasks.return_value = []
+        mock_get_feature.return_value = False
+
+        scheduler = self._make_scheduler_with_recurring_job(task_id)
+        scheduler.scheduler.remove_job = MagicMock()
+        scheduler.scheduler.add_job = MagicMock()
+
+        scheduler._periodic_database_sync()
+        assert task_id not in scheduler._db_task_jobs
+
+        # --- Cycle 2: flag is re-enabled; recurring_tasks returns the task again ---
+        mock_task_cls.recurring_tasks.return_value = [mock_task]
+        mock_get_feature.return_value = True
+
+        scheduler._periodic_database_sync()
+        assert task_id in scheduler._db_task_jobs


### PR DESCRIPTION
## Summary

The `UnifiedTaskScheduler._periodic_database_sync` method only detected **new** tasks — those not already in `self._db_task_jobs`. It never revisited already-registered APScheduler cron jobs to check whether a feature flag had since been toggled. Disabling a feature flag at runtime left the APScheduler job running (it would silently skip dispatch in `_execute_database_task`, but the job was never removed). Re-enabling a flag after removal also failed to re-add the job because the task was still in `_db_task_jobs`. This fix adds a feature-flag reconciliation step that removes APScheduler jobs when their flag is disabled and relies on the existing new-task detection loop to re-add them on re-enable.

## Root Cause

`_periodic_database_sync` guards all task additions with `if task.id not in self._db_task_jobs`, but never iterates over already-tracked recurring tasks to check whether their feature flag has changed state. `_remove_database_task` (the correct removal path) already existed and was correct — it was simply never called from the periodic sync for flag state changes.

## Changes

- `apps/tasks/cron_scheduler.py`: Extract new `_reconcile_recurring_feature_flags` helper that iterates over tracked recurring jobs (identified by the `db_recurring_` job ID prefix), re-evaluates each task's feature flag via `_task_feature_flag_enabled`, and calls `_remove_database_task` when the flag is disabled. The helper is called at the top of `_periodic_database_sync` before the new-task detection loops. Unflagged tasks are explicitly left untouched. Extracted into a helper to keep `_periodic_database_sync` within complexity limits.
- `apps/tasks/tests/test_feature_flag_runtime_check.py`: Add `TestPeriodicSyncFlagReconciliation` with four test cases covering: job removal on flag disable, job re-addition on flag re-enable, unflagged tasks left untouched, and a full disable → re-enable cycle.

## Risk Assessment

- **Confidence:** high
- **Risk:** low — the change adds a new reconciliation block that reuses existing, well-tested helpers (`_task_feature_flag_enabled`, `_remove_database_task`). The existing new-task detection loops are not modified.
- **Scope:** 2 files changed

## Testing

- [ ] Unit tests pass
- [ ] Regression test added (if applicable)
- [ ] Lint checks pass

## JIRA

- Ticket: [AAP-75685](https://redhat.atlassian.net/browse/AAP-75685)

---
*Assisted-by: Debuggernaut (claude-opus-4-6) <noreply@redhat.com> | Review carefully before merging.*