### PR TITLE
fix(AAP-75690): close non-lock-holding connections between task executions

### DIFF
--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -279,6 +279,29 @@ def parse_datetime_string(date_str: str | None) -> Any:
         return None
 
 
+def close_connections_except(preserve_alias: str = "default") -> None:
+    """
+    Close stale/unusable connections for all DB aliases except the one specified.
+
+    This is used to clean up idle connections in long-running workers without
+    disturbing the connection that holds a PostgreSQL advisory lock.
+
+    Django's ``close_old_connections()`` closes ALL connections, which would
+    release advisory locks held on the default connection by ``run_with_lock()``.
+    This helper closes only the non-lock-holding connections.
+
+    Args:
+        preserve_alias: The DB alias whose connection must not be closed
+                        (default: "default", which is the advisory-lock connection).
+    """
+    from django.db import connections
+
+    for alias in connections:
+        if alias == preserve_alias:
+            continue
+        connections[alias].close_if_unusable_or_obsolete()
+
+
 def get_db_connection(db_name: str = "awx"):
     """
     Get a raw database connection that supports PostgreSQL COPY commands.
@@ -287,8 +310,10 @@ def get_db_connection(db_name: str = "awx"):
     to use the raw connection for metrics-utility collectors that use COPY
     for efficient data extraction.
 
-    This function ensures the connection is healthy by calling close_old_connections()
-    which closes stale/unusable connections and respects CONN_MAX_AGE settings.
+    Closes stale/unusable connections on all aliases except the "default"
+    connection, which may be holding a PostgreSQL advisory lock acquired by
+    ``run_with_lock()``.  This prevents idle connections from accumulating
+    across task executions in long-running workers.
 
     Args:
         db_name: Database name from Django settings (default: 'awx')
@@ -302,10 +327,14 @@ def get_db_connection(db_name: str = "awx"):
     """
     from django.db import connections
 
+    # Close stale connections on all aliases except "default" (the advisory-lock
+    # connection).  Calling the global close_old_connections() is intentionally
+    # avoided here because it would close the default connection and release any
+    # advisory lock held by run_with_lock().
+    close_connections_except(preserve_alias="default")
+
     # Get the raw connection to bypass Django's cursor wrapper
     # This is necessary for PostgreSQL COPY commands used by metrics-utility
-    # NOTE: Do not call close_old_connections() here as it closes ALL connections
-    # including the default connection that may be holding advisory locks in run_with_lock()
     django_connection = connections[db_name]
 
     # Ensure the connection is open

--- a/tests/unit/tasks/test_tasks_utils_comprehensive.py
+++ b/tests/unit/tasks/test_tasks_utils_comprehensive.py
@@ -233,11 +233,68 @@ class TestParseDatetimeString(TestCase):
         self.assertEqual(result.tzinfo, UTC)
 
 
+class TestCloseConnectionsExcept(TestCase):
+    """Test close_connections_except function."""
+
+    def test_skips_preserved_alias(self):
+        """Connections for the preserved alias are not touched."""
+        mock_default_conn = MagicMock()
+        mock_other_conn = MagicMock()
+
+        mock_connections = MagicMock()
+        mock_connections.__iter__ = MagicMock(return_value=iter(["default", "awx"]))
+        mock_connections.__getitem__.side_effect = lambda alias: (
+            mock_default_conn if alias == "default" else mock_other_conn
+        )
+
+        with patch("apps.tasks.utils.connections", mock_connections):
+            utils.close_connections_except(preserve_alias="default")
+
+        mock_default_conn.close_if_unusable_or_obsolete.assert_not_called()
+        mock_other_conn.close_if_unusable_or_obsolete.assert_called_once()
+
+    def test_closes_non_preserved_aliases(self):
+        """All aliases except the preserved one have close_if_unusable_or_obsolete called."""
+        mock_conn_a = MagicMock()
+        mock_conn_b = MagicMock()
+        mock_conn_c = MagicMock()
+
+        aliases = {"alpha": mock_conn_a, "beta": mock_conn_b, "gamma": mock_conn_c}
+        mock_connections = MagicMock()
+        mock_connections.__iter__ = MagicMock(return_value=iter(aliases))
+        mock_connections.__getitem__.side_effect = aliases.__getitem__
+
+        with patch("apps.tasks.utils.connections", mock_connections):
+            utils.close_connections_except(preserve_alias="beta")
+
+        mock_conn_a.close_if_unusable_or_obsolete.assert_called_once()
+        mock_conn_b.close_if_unusable_or_obsolete.assert_not_called()
+        mock_conn_c.close_if_unusable_or_obsolete.assert_called_once()
+
+    def test_default_preserve_alias_is_default(self):
+        """Default preserve_alias is 'default'."""
+        mock_default_conn = MagicMock()
+        mock_awx_conn = MagicMock()
+
+        mock_connections = MagicMock()
+        mock_connections.__iter__ = MagicMock(return_value=iter(["default", "awx"]))
+        mock_connections.__getitem__.side_effect = lambda alias: (
+            mock_default_conn if alias == "default" else mock_awx_conn
+        )
+
+        with patch("apps.tasks.utils.connections", mock_connections):
+            utils.close_connections_except()
+
+        mock_default_conn.close_if_unusable_or_obsolete.assert_not_called()
+        mock_awx_conn.close_if_unusable_or_obsolete.assert_called_once()
+
+
 class TestGetDbConnection(TestCase):
     """Test get_db_connection function."""
 
+    @patch("apps.tasks.utils.close_connections_except")
     @patch("django.db.connections")
-    def test_get_db_connection_default(self, mock_connections):
+    def test_get_db_connection_default(self, mock_connections, mock_close_except):
         """Test getting default AWX database connection."""
         mock_raw_conn = MagicMock()
         mock_django_conn = MagicMock()
@@ -250,8 +307,9 @@ class TestGetDbConnection(TestCase):
         mock_django_conn.ensure_connection.assert_called_once()
         self.assertEqual(result, mock_raw_conn)
 
+    @patch("apps.tasks.utils.close_connections_except")
     @patch("django.db.connections")
-    def test_get_db_connection_custom_db(self, mock_connections):
+    def test_get_db_connection_custom_db(self, mock_connections, mock_close_except):
         """Test getting custom database connection."""
         mock_raw_conn = MagicMock()
         mock_django_conn = MagicMock()
@@ -264,15 +322,16 @@ class TestGetDbConnection(TestCase):
         self.assertEqual(result, mock_raw_conn)
 
     @patch("django.db.close_old_connections")
+    @patch("apps.tasks.utils.close_connections_except")
     @patch("django.db.connections")
-    def test_get_db_connection_does_not_call_close_old_connections(self, mock_connections, mock_close_old):
-        """Test that get_db_connection does NOT call close_old_connections.
+    def test_get_db_connection_calls_close_connections_except(
+        self, mock_connections, mock_close_except, mock_close_old
+    ):
+        """Test that get_db_connection calls close_connections_except, not close_old_connections.
 
-        close_old_connections() closes ALL Django connections, not just one.
-        If called during task execution, it can close connections holding advisory locks,
-        causing lock release failures.
-
-        close_old_connections() should only be called at task entry points like run_with_lock().
+        close_old_connections() closes ALL Django connections including the "default"
+        connection that may hold a PostgreSQL advisory lock in run_with_lock().
+        close_connections_except() safely skips the lock-holding connection.
         """
         mock_raw_conn = MagicMock()
         mock_django_conn = MagicMock()
@@ -281,9 +340,11 @@ class TestGetDbConnection(TestCase):
 
         result = utils.get_db_connection()
 
-        # Verify close_old_connections was NOT called
+        # close_connections_except must be called, preserving "default"
+        mock_close_except.assert_called_once_with(preserve_alias="default")
+        # The global close_old_connections must NOT be called
         mock_close_old.assert_not_called()
-        # Verify ensure_connection was still called
+        # ensure_connection is still called
         mock_django_conn.ensure_connection.assert_called_once()
         self.assertEqual(result, mock_raw_conn)
 


### PR DESCRIPTION
## Summary

Stale DB connections accumulated in long-running dispatcherd workers because `close_old_connections()` was intentionally skipped inside `get_db_connection()` to avoid releasing the PostgreSQL advisory lock held on the `default` connection by `run_with_lock()`. As a result, connections to the `awx` database (and any other non-default aliases) were never closed, exhausting the PostgreSQL connection pool over time.

## Changes

- **`apps/tasks/utils.py`** — Add `close_connections_except(preserve_alias='default')`: iterates all Django DB aliases and calls `close_if_unusable_or_obsolete()` on each one except the specified alias. Call this from `get_db_connection()` so non-lock-holding connections are cleaned up between task executions without disturbing the advisory lock.
- **`tests/unit/tasks/test_tasks_utils_comprehensive.py`** — Replace the previous "does not call close_old_connections" test with a test that verifies `close_connections_except` IS called with `preserve_alias='default'`. Add a new `TestCloseConnectionsExcept` suite covering the skip logic for the preserved alias.

## How it works

`run_with_lock()` acquires an advisory lock on `connection` (the Django `default` alias). `close_connections_except(preserve_alias='default')` skips that alias entirely and calls `close_if_unusable_or_obsolete()` on all others (e.g. `awx`). This satisfies the acceptance criteria:

- Advisory-lock connection tracked explicitly by alias.
- `close_if_unusable_or_obsolete()` called on all other connections between task executions.
- Existing functionality is unaffected.

## Test plan

- [ ] Unit tests in `TestCloseConnectionsExcept` verify preserved alias is skipped and all others are closed
- [ ] `test_get_db_connection_calls_close_connections_except` verifies `close_old_connections` is not called and `close_connections_except` is called with `preserve_alias='default'`
- [ ] Existing `run_with_lock` tests continue to pass
- [ ] `ruff check .` passes with no warnings

Fixes: AAP-75690

**Note:** This comment was written by Debuggernaut (autonomous bug-fixing agent).