### PR TITLE
AAP-75684: Validate task_data against TASK_METADATA function schema at task creation

### DIFF
--- a/apps/tasks/v1/serializers.py
+++ b/apps/tasks/v1/serializers.py
@@ -186,6 +186,64 @@ class TaskCreateSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(f"Invalid JSON data: {e}") from e
         return value
 
+    def validate(self, attrs):
+        """Cross-field validation: check task_data parameters against the function schema."""
+        attrs = super().validate(attrs)
+        function_name = attrs.get("function_name")
+        task_data = attrs.get("task_data", {})
+
+        # Only proceed if we have a valid function_name (field-level validate already
+        # confirmed it exists in TASK_FUNCTIONS; skip if missing due to earlier error).
+        if not function_name or not isinstance(task_data, dict):
+            return attrs
+
+        from apps.tasks.tasks import TASK_METADATA
+
+        metadata = TASK_METADATA.get(function_name)
+        if not metadata:
+            # No schema defined for this function — nothing to validate against.
+            return attrs
+
+        parameters = metadata.get("parameters", {})
+        errors = {}
+
+        # Check for required parameters that are absent from task_data.
+        for param_name, param_schema in parameters.items():
+            if param_schema.get("required") and param_name not in task_data:
+                errors[param_name] = f"This field is required for function '{function_name}'."
+
+        # Validate types and bounds for each provided key.
+        type_map = {"integer": int, "boolean": bool, "string": str}
+        for key, val in task_data.items():
+            if key not in parameters:
+                errors[key] = f"Unknown parameter '{key}' for function '{function_name}'."
+                continue
+
+            param_schema = parameters[key]
+            expected_type_str = param_schema.get("type")
+            expected_type = type_map.get(expected_type_str)
+
+            if expected_type is not None and not isinstance(val, expected_type):
+                # bool is a subclass of int in Python; reject booleans for integer fields.
+                if expected_type is int and isinstance(val, bool):
+                    errors[key] = "Expected an integer, got boolean."
+                    continue
+                errors[key] = f"Expected type '{expected_type_str}', got '{type(val).__name__}'."
+                continue
+
+            if expected_type is int:
+                minimum = param_schema.get("min")
+                maximum = param_schema.get("max")
+                if minimum is not None and val < minimum:
+                    errors[key] = f"Value {val} is below the minimum of {minimum}."
+                elif maximum is not None and val > maximum:
+                    errors[key] = f"Value {val} exceeds the maximum of {maximum}."
+
+        if errors:
+            raise serializers.ValidationError({"task_data": errors})
+
+        return attrs
+
     def validate_user(self, value):
         """Validate user exists if provided."""
         if value:


### PR DESCRIPTION
## Summary

Fixes [AAP-75684](https://redhat.atlassian.net/browse/AAP-75684) — `task_data` JSON field not validated against function schema at task creation.

### Problem

`TaskCreateSerializer.validate_task_data` only checked that the value was valid JSON. It did not:
- Enforce that required parameters were present.
- Reject unknown/extra parameters.
- Check parameter types (integer vs. boolean vs. string).
- Enforce integer `min`/`max` bounds.

A malformed `task_data` payload would be accepted at creation time and only fail at task execution, exhausting the retry budget before the operator knew there was an input error.

### Fix

Added a cross-field `validate()` method to `TaskCreateSerializer` that, once `function_name` is confirmed valid (by the existing `validate_function_name` field validator), inspects `TASK_METADATA[function_name]["parameters"]` and validates the submitted `task_data` dict against it:

- **Required parameters** — returns HTTP 400 with a descriptive error if any are missing.
- **Unknown parameters** — rejects keys not declared in the schema.
- **Type checking** — validates `integer`, `boolean`, and `string` types; correctly rejects booleans for integer-typed fields (Python `bool` is a subclass of `int`).
- **Bounds checking** — enforces `min`/`max` for integer parameters.

Functions that have no `TASK_METADATA` entry (only in `TASK_FUNCTIONS`) pass through without validation, preserving backward compatibility for tasks not yet documented.

### Files Changed

- `apps/tasks/v1/serializers.py` — added `validate()` on `TaskCreateSerializer` (58 lines)

### Testing

- `ruff check` passes with no warnings.
- Existing test suite covers task creation; new validation paths can be exercised by sending payloads with missing required fields (e.g., `collect_hourly_metrics` without `collector_type`) or wrong types.

Assisted-by: Debuggernaut (claude-opus-4-6) <noreply@redhat.com>