### PR TITLE
AAP-75687: Add DLQ alerting, requeue endpoint, and configurable max_payloads for Segment failures

### DIFF
--- a/apps/tasks/collectors/send_anonymized_to_segment.py
+++ b/apps/tasks/collectors/send_anonymized_to_segment.py
@@ -5,6 +5,7 @@ This task fetches pending anonymized payloads from the database and sends them
 to Segment.com, handling retries and stale payload recovery.
 """
 
+import json
 import logging
 from datetime import timedelta
 from typing import Any
@@ -19,6 +20,45 @@ from ..utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _log_dead_letter(payload) -> None:
+    """
+    Emit a structured ERROR log for a payload that has exhausted all retries.
+
+    This serves as a lightweight dead-letter-queue (DLQ) substitute: the log
+    record contains enough information for operators (and log-based alerting
+    rules) to identify, diagnose, and manually recover the payload without
+    requiring an external queue.
+
+    The log entry includes the full anonymized_data so that the payload can be
+    reconstructed and re-submitted if needed.
+
+    Args:
+        payload: AnonymizedMetricsPayload that has reached ``status='failed'``
+    """
+    try:
+        payload_json = json.dumps(payload.anonymized_data)
+    except (TypeError, ValueError):
+        payload_json = "<serialization error>"
+
+    logger.error(
+        "SEGMENT_DLQ payload exhausted all retries and will not be resent automatically. "
+        "Manual intervention required.",
+        extra={
+            "dlq_event": "segment_payload_exhausted",
+            "payload_id": payload.id,
+            "summary_date": str(payload.summary_date),
+            "retry_count": payload.retry_count,
+            "max_retries": payload.max_retries,
+            "last_error": payload.error_message,
+            "segment_event_name": payload.segment_event_name,
+            "segment_user_id": payload.segment_user_id,
+            "payload_size_bytes": payload.payload_size_bytes,
+            "created": payload.created.isoformat() if payload.created else None,
+            "anonymized_data": payload_json,
+        },
+    )
 
 
 def _get_payloads_to_send(payload_id: int | None, max_payloads: int, stale_threshold) -> list:
@@ -92,6 +132,10 @@ def _handle_failed_send(payload, segment_result: dict, results: dict) -> None:
         # Log an error if we are past the maximum retry limit, else, log a warning about the retry
         payload.status = "failed"
         logger.error("Segment send failed, not retrying", extra=details)
+        # Emit DLQ-style structured log so the lost payload can be recovered and
+        # log-based alerting (e.g. Prometheus loki rule or ELK alert on
+        # dlq_event=segment_payload_exhausted) fires immediately.
+        _log_dead_letter(payload)
     else:
         payload.status = "retry"
         logger.warning("Segment send failed, retrying", extra=details)
@@ -138,6 +182,8 @@ def _process_single_payload(payload, results: dict) -> None:
         payload.status = "failed"
         payload.error_message = "Max retries exceeded"
         payload.save()
+        # Emit DLQ structured log so operators can recover the payload
+        _log_dead_letter(payload)
         results["skipped"] += 1
         return
 
@@ -263,7 +309,8 @@ def send_anonymized_to_segment(**kwargs) -> dict[str, Any]:
     Returns:
         dict: Task result with send statistics
     """
-    max_payloads = kwargs.get("max_payloads", 5)
+    default_max_payloads = getattr(settings, "SEGMENT_MAX_PAYLOADS", 5)
+    max_payloads = kwargs.get("max_payloads", default_max_payloads)
     payload_id = kwargs.get("payload_id")
     stale_minutes = kwargs.get("stale_minutes", 10)
 

--- a/apps/tasks/settings.py
+++ b/apps/tasks/settings.py
@@ -11,5 +11,10 @@ When True, appends '_Test' to all Segment event names to separate end-to-end
 test data from real customer data. Override with METRICS_SERVICE_SEGMENT_TEST_MODE
 environment variable."""
 
+SEGMENT_MAX_PAYLOADS = 5
+"""Maximum number of AnonymizedMetricsPayload records processed per send_anonymized_to_segment
+task execution. Increase this value if the queue grows faster than the default batch size
+can drain it. Override with METRICS_SERVICE_SEGMENT_MAX_PAYLOADS environment variable."""
+
 # SEGMENT_WRITE_KEY = "test-segment-write-key-change-in-production"
 # """Segment Write Key this needs to be set in environment variables to run locally in producitoon its mounted as a file"""

--- a/apps/tasks/v1/urls.py
+++ b/apps/tasks/v1/urls.py
@@ -30,6 +30,7 @@ router.register(r"executions", TaskExecutionViewSet, basename="taskexecution")
 # /api/v1/tasks/{id}/cancel/ - Cancel task (manage_tasks cancel)
 # /api/v1/tasks/cleanup/ - Cleanup old tasks (manage_tasks cleanup)
 # /api/v1/tasks/available_functions/ - Get available task functions
+# /api/v1/tasks/requeue_failed_payloads/ - Requeue failed Segment payloads (DLQ recovery)
 router.register(r"", TaskViewSet, basename="task")
 
 urlpatterns = [
@@ -54,3 +55,4 @@ urlpatterns = [
 # POST   /api/v1/tasks/{id}/cancel/         - Cancel task (manage_tasks cancel)
 # POST   /api/v1/tasks/cleanup/             - Cleanup old tasks (manage_tasks cleanup)
 # GET    /api/v1/tasks/available_functions/ - Get available task functions
+# POST   /api/v1/tasks/requeue_failed_payloads/ - Requeue failed Segment payloads (DLQ recovery, AAP-75687)

--- a/apps/tasks/v1/views.py
+++ b/apps/tasks/v1/views.py
@@ -38,7 +38,7 @@ from rest_framework.response import Response
 
 from apps.core.permissions import DeveloperModeRequired
 from apps.tasks.api_utils import build_error_response
-from apps.tasks.models import Task, TaskExecution
+from apps.tasks.models import AnonymizedMetricsPayload, Task, TaskExecution
 
 from .base_views import BaseViewSet
 from .serializers import (
@@ -415,6 +415,66 @@ class TaskViewSet(BaseViewSet):
             return Response({"message": "Task scheduled for immediate execution", "task_id": str(task.id)})
         except Exception as e:
             error_response = build_error_response(f"Failed to schedule task: {str(e)}", status_code=500)
+            return Response(error_response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    @action(detail=False, methods=["post"])
+    def requeue_failed_payloads(self, request: HttpRequest) -> Response:
+        """
+        Reset AnonymizedMetricsPayload records that are in ``failed`` status back to
+        ``pending`` so they will be picked up on the next ``send_anonymized_to_segment``
+        run.
+
+        This is the lightweight dead-letter-queue (DLQ) recovery mechanism for
+        AAP-75687.  Operators call this endpoint after investigating why payloads
+        failed (see the ``SEGMENT_DLQ`` log entries) and deciding it is safe to
+        retry them.
+
+        Optionally accepts a JSON body with:
+            - ``payload_ids`` (list[int]): Limit requeue to specific payload IDs.
+              When omitted, all ``failed`` payloads are requeued.
+            - ``reset_retry_count`` (bool, default false): When ``true``, also
+              reset ``retry_count`` to 0 so the payload gets a full fresh set of
+              retries.  Use this when the underlying Segment connectivity issue has
+              been resolved.
+
+        Returns:
+            Response: Count of requeued payloads and their IDs.
+        """
+        payload_ids = request.data.get("payload_ids")
+        reset_retry_count = bool(request.data.get("reset_retry_count", False))
+
+        try:
+            qs = AnonymizedMetricsPayload.objects.filter(status="failed")
+            if payload_ids:
+                qs = qs.filter(id__in=payload_ids)
+
+            ids_to_requeue = list(qs.values_list("id", flat=True))
+
+            if not ids_to_requeue:
+                return Response(
+                    {
+                        "message": "No failed payloads found matching the given criteria.",
+                        "requeued_count": 0,
+                        "requeued_ids": [],
+                    }
+                )
+
+            update_fields = {"status": "pending", "error_message": ""}
+            if reset_retry_count:
+                update_fields["retry_count"] = 0
+
+            AnonymizedMetricsPayload.objects.filter(id__in=ids_to_requeue).update(**update_fields)
+
+            return Response(
+                {
+                    "message": f"Requeued {len(ids_to_requeue)} failed payload(s) for retransmission.",
+                    "requeued_count": len(ids_to_requeue),
+                    "requeued_ids": ids_to_requeue,
+                    "reset_retry_count": reset_retry_count,
+                }
+            )
+        except Exception as e:
+            error_response = build_error_response(f"Failed to requeue payloads: {str(e)}", status_code=500)
             return Response(error_response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     @action(detail=False, methods=["post"])


### PR DESCRIPTION
## Summary

Closes [AAP-75687](https://redhat.atlassian.net/browse/AAP-75687) — P1 reliability: no alerting or DLQ for failed Segment payloads after max retries.

### Changes

- **Structured DLQ logging** (`apps/tasks/collectors/send_anonymized_to_segment.py`):
  - New `_log_dead_letter()` helper emits a structured `logger.error` with field `dlq_event=segment_payload_exhausted` when an `AnonymizedMetricsPayload` exhausts all retries.
  - The log record includes `payload_id`, `summary_date`, `retry_count`, `max_retries`, `last_error`, `segment_event_name`, `segment_user_id`, `payload_size_bytes`, and the full `anonymized_data` JSON — enough to reconstruct and replay the payload.
  - Called from both the `_handle_failed_send` path (retry cap exceeded during a live send attempt) and the `_process_single_payload` pre-flight guard (payload already in `retry` status with no retries left).
  - Operators can alert on this log field in Loki/ELK/Splunk without needing Prometheus instrumentation or external queue infrastructure.

- **Configurable `max_payloads`** (`apps/tasks/settings.py`):
  - New `SEGMENT_MAX_PAYLOADS = 5` default, overridable via `METRICS_SERVICE_SEGMENT_MAX_PAYLOADS` env var.
  - `send_anonymized_to_segment` now reads this setting as its default so the batch size can be tuned without a code change (satisfies AC3).

- **Requeue endpoint** (`apps/tasks/v1/views.py`, `apps/tasks/v1/urls.py`):
  - New `POST /api/v1/tasks/requeue_failed_payloads/` action on `TaskViewSet`.
  - Resets `failed` `AnonymizedMetricsPayload` records back to `pending` for retransmission.
  - Optional request body: `payload_ids` (list of ints) to target specific records; `reset_retry_count` (bool) to grant a fresh set of retries after the root cause is resolved (satisfies AC2).

## Test plan

- [ ] Confirm `ruff check` passes on all modified files (CI will verify).
- [ ] Trigger a payload to exhaust retries (set `max_retries=1`, mock Segment to always fail) and verify `SEGMENT_DLQ` log line appears with all expected structured fields.
- [ ] Set `METRICS_SERVICE_SEGMENT_MAX_PAYLOADS=10` and verify `send_anonymized_to_segment` processes up to 10 payloads per run.
- [ ] Call `POST /api/v1/tasks/requeue_failed_payloads/` with and without `payload_ids`/`reset_retry_count` and verify payloads are reset to `pending`.
- [ ] Call `POST /api/v1/tasks/requeue_failed_payloads/` with no failed payloads and verify a clean empty response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)