### PR TITLE
[AAP-75693] Add TaskMetaDict TypedDict and import-time validation for TASK_METADATA

### DIFF
--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -12,6 +12,7 @@ Queue routing is defined per-function in TASK_METADATA ("queue" field).
 """
 
 import logging
+from typing import Any, TypedDict
 
 # Dashboard reports tasks
 from ..dashboard_reports.tasks import (
@@ -39,6 +40,43 @@ from .simple.hello_world import hello_world
 from .tasks_system import create_system_tasks, submit_task_to_dispatcher
 
 logger = logging.getLogger(__name__)
+
+# Valid queue names as defined in apps/settings/dispatcherd.yaml
+ALLOWED_QUEUES: frozenset[str] = frozenset({"dashboard", "maintenance", "metrics"})
+
+
+class TaskMetaDict(TypedDict):
+    """Typed structure for entries in TASK_METADATA.
+
+    All fields are required. Using TypedDict preserves dict-at-runtime
+    compatibility so callers using .get() continue to work unchanged.
+    """
+
+    queue: str
+    category: str
+    description: str
+    parameters: dict[str, Any]
+    examples: list[dict[str, Any]]
+
+
+def _validate_task_metadata(metadata: "dict[str, TaskMetaDict]") -> None:
+    """Validate all TASK_METADATA entries at module load time.
+
+    Raises ValueError immediately (fail-fast) if any entry is missing a
+    required field or specifies an unknown queue.  This catches
+    misconfigurations before the first request is served.
+    """
+    required_keys = {"queue", "category", "description", "parameters", "examples"}
+    for task_name, meta in metadata.items():
+        missing = required_keys - set(meta.keys())
+        if missing:
+            raise ValueError(f"TASK_METADATA[{task_name!r}] is missing required fields: {sorted(missing)}")
+        queue = meta["queue"]
+        if queue not in ALLOWED_QUEUES:
+            raise ValueError(
+                f"TASK_METADATA[{task_name!r}] has unknown queue {queue!r}. Allowed queues: {sorted(ALLOWED_QUEUES)}"
+            )
+
 
 # Task configuration for dispatcherd
 TASK_FUNCTIONS = {
@@ -83,7 +121,7 @@ def get_queue_for_function(function_name: str) -> str:
 
 
 # Enhanced task metadata for dashboard display
-TASK_METADATA = {
+TASK_METADATA: dict[str, TaskMetaDict] = {
     # Testing
     "hello_world": {
         "queue": "maintenance",
@@ -401,6 +439,9 @@ TASK_METADATA = {
     },
 }
 
+# Validate metadata at module load time — catches misconfiguration before first request
+_validate_task_metadata(TASK_METADATA)
+
 # Explicit exports for better IDE support
 __all__ = [
     # System tasks
@@ -419,9 +460,11 @@ __all__ = [
     "daily_anonymize_and_prepare",
     "send_anonymized_to_segment",
     # Configuration
+    "ALLOWED_QUEUES",
     "TASK_FUNCTIONS",
     "TASK_LOCKS",
     "TASK_METADATA",
+    "TaskMetaDict",
     "get_queue_for_function",
     # Dashboard reports
     "collect_dashboard_reports_data",

--- a/tests/unit/tasks/test_tasks_system.py
+++ b/tests/unit/tasks/test_tasks_system.py
@@ -319,6 +319,144 @@ class TestTaskRegistry(TestCase):
             assert queue, f"{func_name} has no queue in TASK_METADATA"
             assert queue in valid_queues, f"{func_name} has unknown queue {queue!r} (valid: {valid_queues})"
 
+    def test_task_metadata_has_all_required_fields(self):
+        """Every TASK_METADATA entry must contain all required TaskMetaDict fields."""
+        from apps.tasks.tasks import TASK_METADATA
+
+        required_keys = {"queue", "category", "description", "parameters", "examples"}
+        for func_name, meta in TASK_METADATA.items():
+            missing = required_keys - set(meta.keys())
+            assert not missing, f"TASK_METADATA[{func_name!r}] is missing fields: {sorted(missing)}"
+
+    def test_task_metadata_queues_are_in_allowed_queues(self):
+        """Every TASK_METADATA entry must use a queue from ALLOWED_QUEUES."""
+        from apps.tasks.tasks import ALLOWED_QUEUES, TASK_METADATA
+
+        for func_name, meta in TASK_METADATA.items():
+            queue = meta.get("queue")
+            assert queue in ALLOWED_QUEUES, (
+                f"TASK_METADATA[{func_name!r}] has unknown queue {queue!r}. Allowed: {sorted(ALLOWED_QUEUES)}"
+            )
+
+    def test_allowed_queues_is_frozenset(self):
+        """ALLOWED_QUEUES must be a frozenset containing the expected queue names."""
+        from apps.tasks.tasks import ALLOWED_QUEUES
+
+        assert isinstance(ALLOWED_QUEUES, frozenset)
+        assert "dashboard" in ALLOWED_QUEUES
+        assert "maintenance" in ALLOWED_QUEUES
+        assert "metrics" in ALLOWED_QUEUES
+
+
+# =============================================================================
+# TaskMetaDict and _validate_task_metadata Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestTaskMetadataValidation(TestCase):
+    """Test the TaskMetaDict type and _validate_task_metadata validation helper."""
+
+    def _make_valid_meta(self, **overrides):
+        """Return a minimal valid TaskMetaDict entry."""
+        entry = {
+            "queue": "maintenance",
+            "category": "Testing",
+            "description": "A test task",
+            "parameters": {},
+            "examples": [],
+        }
+        entry.update(overrides)
+        return entry
+
+    def test_validate_passes_for_valid_metadata(self):
+        """_validate_task_metadata should not raise for well-formed entries."""
+        from apps.tasks.tasks import _validate_task_metadata
+
+        metadata = {"good_task": self._make_valid_meta()}
+        # Must not raise
+        _validate_task_metadata(metadata)
+
+    def test_validate_raises_for_missing_queue(self):
+        """_validate_task_metadata should raise ValueError when 'queue' is absent."""
+        from apps.tasks.tasks import _validate_task_metadata
+
+        bad_entry = self._make_valid_meta()
+        del bad_entry["queue"]
+        with pytest.raises(ValueError, match="missing required fields"):
+            _validate_task_metadata({"bad_task": bad_entry})
+
+    def test_validate_raises_for_missing_category(self):
+        """_validate_task_metadata should raise ValueError when 'category' is absent."""
+        from apps.tasks.tasks import _validate_task_metadata
+
+        bad_entry = self._make_valid_meta()
+        del bad_entry["category"]
+        with pytest.raises(ValueError, match="missing required fields"):
+            _validate_task_metadata({"bad_task": bad_entry})
+
+    def test_validate_raises_for_missing_description(self):
+        """_validate_task_metadata should raise ValueError when 'description' is absent."""
+        from apps.tasks.tasks import _validate_task_metadata
+
+        bad_entry = self._make_valid_meta()
+        del bad_entry["description"]
+        with pytest.raises(ValueError, match="missing required fields"):
+            _validate_task_metadata({"bad_task": bad_entry})
+
+    def test_validate_raises_for_missing_parameters(self):
+        """_validate_task_metadata should raise ValueError when 'parameters' is absent."""
+        from apps.tasks.tasks import _validate_task_metadata
+
+        bad_entry = self._make_valid_meta()
+        del bad_entry["parameters"]
+        with pytest.raises(ValueError, match="missing required fields"):
+            _validate_task_metadata({"bad_task": bad_entry})
+
+    def test_validate_raises_for_missing_examples(self):
+        """_validate_task_metadata should raise ValueError when 'examples' is absent."""
+        from apps.tasks.tasks import _validate_task_metadata
+
+        bad_entry = self._make_valid_meta()
+        del bad_entry["examples"]
+        with pytest.raises(ValueError, match="missing required fields"):
+            _validate_task_metadata({"bad_task": bad_entry})
+
+    def test_validate_raises_for_unknown_queue(self):
+        """_validate_task_metadata should raise ValueError for a queue not in ALLOWED_QUEUES."""
+        from apps.tasks.tasks import _validate_task_metadata
+
+        bad_entry = self._make_valid_meta(queue="nonexistent_queue")
+        with pytest.raises(ValueError, match="unknown queue"):
+            _validate_task_metadata({"bad_task": bad_entry})
+
+    def test_validate_accepts_all_allowed_queues(self):
+        """_validate_task_metadata should pass for each value in ALLOWED_QUEUES."""
+        from apps.tasks.tasks import ALLOWED_QUEUES, _validate_task_metadata
+
+        for queue in ALLOWED_QUEUES:
+            entry = self._make_valid_meta(queue=queue)
+            # Must not raise
+            _validate_task_metadata({f"task_{queue}": entry})
+
+    def test_validate_reports_task_name_in_error(self):
+        """ValueError message must identify the offending task by name."""
+        from apps.tasks.tasks import _validate_task_metadata
+
+        bad_entry = self._make_valid_meta(queue="bad_queue")
+        with pytest.raises(ValueError, match="my_task"):
+            _validate_task_metadata({"my_task": bad_entry})
+
+    def test_validate_empty_metadata_passes(self):
+        """_validate_task_metadata must succeed for an empty dict."""
+        from apps.tasks.tasks import _validate_task_metadata
+
+        _validate_task_metadata({})
+
+    def test_task_meta_dict_is_exportable(self):
+        """TaskMetaDict must be importable from apps.tasks.tasks."""
+        from apps.tasks.tasks import TaskMetaDict  # noqa: F401 -- import-only test
+
 
 # =============================================================================
 # System Task Creation Tests


### PR DESCRIPTION
## Summary

The \`TASK_METADATA\` dictionary in \`apps/tasks/tasks.py\` was a plain \`dict[str, dict]\` with no type annotations or structural validation. Mistyped key names, invalid queue names, and missing required fields were only caught at test runtime (or not at all in production). This PR introduces a \`TaskMetaDict\` TypedDict and import-time validation so misconfigurations fail fast at module load, before the first request is served.

## Root Cause

\`TASK_METADATA\` lacked a typed schema. There was no enforcement that entries contained the required keys (\`queue\`, \`category\`, \`description\`, \`parameters\`, \`examples\`) or that the \`queue\` value was one of the valid dispatcherd channels (\`dashboard\`, \`maintenance\`, \`metrics\`). A mistyped entry would silently cause \`None\` returns from \`.get("queue")\` callers.

## Changes

- \`apps/tasks/tasks.py\`:
  - Add \`from typing import Any, TypedDict\`
  - Add \`ALLOWED_QUEUES: frozenset[str]\` constant (derived from \`dispatcherd.yaml\` channels)
  - Add \`TaskMetaDict\` TypedDict with required fields: \`queue\`, \`category\`, \`description\`, \`parameters\`, \`examples\`
  - Add \`_validate_task_metadata()\` function that raises \`ValueError\` at module load for missing fields or unknown queues
  - Type-annotate \`TASK_METADATA\` as \`dict[str, TaskMetaDict]\`
  - Call \`_validate_task_metadata(TASK_METADATA)\` immediately after the dict is defined
  - Export \`ALLOWED_QUEUES\`, \`TaskMetaDict\` in \`__all__\`
- \`tests/unit/tasks/test_tasks_system.py\`:
  - Add 3 new assertions to \`TestTaskRegistry\`: required-fields check, ALLOWED_QUEUES membership check, and frozenset type check
  - Add \`TestTaskMetadataValidation\` class with 11 unit tests covering all validation paths

## Risk Assessment

- **Confidence:** high
- **Risk:** low — TypedDict instances are regular dicts at runtime; all existing callers using \`.get()\` continue to work without modification. The validation call is additive and only raises on genuinely bad entries.
- **Scope:** 2 files changed

## Testing

- [x] Unit tests pass (lint clean locally)
- [x] Regression tests added — \`TestTaskMetadataValidation\` (11 tests) + 3 new assertions in \`TestTaskRegistry\`
- [x] Lint checks pass (ruff check + ruff format)

## JIRA

- Ticket: [AAP-75693](https://redhat.atlassian.net/browse/AAP-75693)

---
*Assisted-by: Debuggernaut (claude-opus-4-6) <noreply@redhat.com> | Review carefully before merging.*