### PR TITLE
fix(tests): update stuck-task test to use TASK_TIMEOUT setting

### DIFF
--- a/tests/coverage/tasks/test_cron_scheduler.py
+++ b/tests/coverage/tasks/test_cron_scheduler.py
@@ -356,7 +356,9 @@ def test_periodic_sync_fails_stuck_tasks(user, mock_apscheduler):
         name="stuck", function_name="hello_world", task_data={}, created_by=user, status="running"
     )
     # Backdate started_at to trigger stuck detection
-    started = timezone.now() - timedelta(seconds=cs.STUCK_TASK_TIMEOUT_SECONDS + 60)
+    from django.conf import settings as django_settings
+
+    started = timezone.now() - timedelta(seconds=django_settings.TASK_TIMEOUT + 60)
     Task.objects.filter(pk=task.pk).update(started_at=started)
     execution = TaskExecution.objects.create(task=task, status="running")
 


### PR DESCRIPTION
## Summary

- `STUCK_TASK_TIMEOUT_SECONDS` was removed in #218 when task timeout was consolidated into a single `TASK_TIMEOUT` Django setting
- The test `test_periodic_sync_fails_stuck_tasks` still referenced the old constant, causing an `AttributeError`
- Updated the test to use `django_settings.TASK_TIMEOUT` to match the current implementation

## Test plan

- [x] Run `uv run pytest tests/coverage/tasks/test_cron_scheduler.py::test_periodic_sync_fails_stuck_tasks` — passes
- [x] Run full test suite (`uv run pytest`) — 2116 passed, 0 failed

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.