### PR TITLE
Fix dashboard_reports tests broken by batch-pagination refactor

### DIFF
--- a/tests/coverage/dashboard_reports/test_dashboard_reports_tasks.py
+++ b/tests/coverage/dashboard_reports/test_dashboard_reports_tasks.py
@@ -62,10 +62,9 @@ def test_collect_data_success():
     now = datetime.now(tz=UTC)
     since = (now - timedelta(hours=2)).isoformat()
 
-    mock_jobs_result = {"results": [], "count": 0}
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
-        patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
+        patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
     ):
         result = _collect_data("test_task", since=since, until=now.isoformat())
 
@@ -104,12 +103,11 @@ def test_collect_dashboard_reports_initial_data_no_db():
 def test_collect_dashboard_reports_initial_data_success():
     from apps.dashboard_reports.tasks import collect_dashboard_reports_initial_data
 
-    mock_jobs_result = {"results": [], "count": 5}
     now = datetime.now(tz=UTC)
 
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
-        patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
+        patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
     ):
         result = collect_dashboard_reports_initial_data(
             since=(now - timedelta(days=1)).isoformat(),
@@ -127,10 +125,9 @@ def test_collect_dashboard_reports_initial_data_success():
 def test_collect_dashboard_reports_data_incremental():
     from apps.dashboard_reports.tasks import collect_dashboard_reports_data
 
-    mock_jobs_result = {"results": [], "count": 0}
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
-        patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
+        patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
     ):
         result = collect_dashboard_reports_data(incremental=True)
 
@@ -142,12 +139,11 @@ def test_collect_dashboard_reports_data_incremental():
 def test_collect_dashboard_reports_data_full():
     from apps.dashboard_reports.tasks import collect_dashboard_reports_data
 
-    mock_jobs_result = {"results": [], "count": 0}
     now = datetime.now(tz=UTC)
 
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
-        patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
+        patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
     ):
         result = collect_dashboard_reports_data(
             incremental=False,


### PR DESCRIPTION
Four tests were still mocking _collect_jobs after _collect_data was refactored to use _get_job_id_range + _process_batches. Without a mock for _get_job_id_range, the comparison while after_id < max_id raised TypeError on MagicMock objects. Fixes by patching _get_job_id_range to return (None, None) instead.

Assisted-by: (Claude Sonnet 4.6)