### PR TITLE
pr-checks - validate PR target branch

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,6 +23,20 @@ jobs:
           - 5432:5432
 
     steps:
+      - name: "Check PR target"
+        env:
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [[ "$BASE_REPO" == "ansible/metrics-service" && "$BASE_BRANCH" == "devel" ]]; then
+            echo "✓ PR targets devel on upstream"
+          elif [[ "$BASE_BRANCH" == stable-2.* ]]; then
+            echo "✓ PR targets $BASE_BRANCH"
+          else
+            echo "::error::PRs should target devel on ansible/metrics-service or a stable-2.x branch"
+            exit 1
+          fi
+
       - name: "Checkout metrics-service (${{ github.ref }})"
         uses: actions/checkout@v6
 


### PR DESCRIPTION
Adds a validation step to the PR checks workflow that rejects PRs targeting the wrong branch:
- upstream (`ansible/metrics-service`): only `devel`
- downstream: only `stable-2.x` branches

This runs as the first step, before checkout, so invalid PRs fail fast.