### PR TITLE
AAP-77009: rename FEATURE_ENABLED→FEATURE, make feature flags env-var driven

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,11 +136,11 @@ The task system has several layers:
 - **`METRICS_COLLECTION_GROUP`** — Always enabled (no feature flag). Contains all hourly/daily collection tasks, `daily_metrics_rollup`, and `cleanup_metrics_data`. Local metrics are collected regardless of the opt-out flag to prevent data gaps.
 - **`ANONYMIZATION_GROUP`** — Controlled by `ANONYMIZED_DATA_COLLECTION` feature flag (default: enabled, customer opt-out). Contains only `daily_anonymize_and_prepare` and `send_anonymized_to_segment` — the tasks that transmit data to Red Hat.
 
-Feature flags are stored in the `dynamic_settings_setting` DB table (managed by `apps/dynamic_settings/`). They fall back to `FEATURE_ENABLED` in Django settings if not in DB.
+Feature flags are stored in the `dynamic_settings_setting` DB table (managed by `apps/dynamic_settings/`). They fall back to `FEATURE` in Django settings if not in DB.
 
 ```bash
 # Toggle at runtime without restart
-METRICS_SERVICE_FEATURE_ENABLED__ANONYMIZED_DATA_COLLECTION=false
+METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION=false
 ```
 
 ### API Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ The task system has several layers:
 Feature flags are stored in the `dynamic_settings_setting` DB table (managed by `apps/dynamic_settings/`). They fall back to `FEATURE` in Django settings if not in DB.
 
 ```bash
-# Toggle at runtime without restart
+# Toggle (requires process/pod restart to take effect)
 METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION=false
 ```
 

--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ We have these feature flags:
 |`ANONYMIZED_DATA_COLLECTION`|true|
 |`DASHBOARD_COLLECTION`|false (customer opt-in)|
 
-You can change defaults using `METRICS_SERVICE_FEATURE_ENABLED__` prefixed environment variables.
+You can change defaults using `METRICS_SERVICE_FEATURE__` prefixed environment variables.
 
 ```sh
 # Pause local collectors, rollup, and metrics cleanup (default: true)
-METRICS_SERVICE_FEATURE_ENABLED__METRICS_COLLECTION=false
+METRICS_SERVICE_FEATURE__METRICS_COLLECTION=false
 
 # Disable anonymization and Segment transmission (default: true)
-METRICS_SERVICE_FEATURE_ENABLED__ANONYMIZED_DATA_COLLECTION=false
+METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION=false
 ```
 
 These environment variables (or their default values) are used to populate the feature flags database tables during `manage.py metrics_service init-default-settings`. You can also use `python manage.py metrics_service remove-default-settings` to remove these settings from the database.
@@ -317,7 +317,7 @@ METRICS_SERVICE_DATABASES__default__NAME=metrics_service
 METRICS_SERVICE_DATABASES__default__OPTIONS__sslmode=prefer
 
 # Task App
-METRICS_SERVICE_FEATURE_ENABLED__ANONYMIZED_DATA_COLLECTION="true"
+METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION="true"
 DISPATCHERD_CONFIG_FILE=/app/apps/settings/dispatcherd.yaml
 DISPATCHERD_ENABLED="true"
 ```

--- a/README.md
+++ b/README.md
@@ -173,9 +173,13 @@ METRICS_SERVICE_FEATURE__METRICS_COLLECTION=false
 METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION=false
 ```
 
-These environment variables (or their default values) are used to populate the feature flags database tables during `manage.py metrics_service init-default-settings`. You can also use `python manage.py metrics_service remove-default-settings` to remove these settings from the database.
+Feature flags are resolved at runtime with this precedence:
 
-The feature flag values in the database determine which scheduled tasks run (checked at execution time). If a value is missing from the database, the environment variable or static default is used as the fallback.
+1. **DB row** in `dynamic_settings_setting` (written via the API, `dbshell`, or a prior `init-default-settings` run) — always wins
+2. **Env var** (`METRICS_SERVICE_FEATURE__*`) — used on fresh installs or when no DB row exists
+3. **Static default** in `settings.FEATURE` — fallback if neither of the above is set
+
+`init-default-settings` no longer pre-seeds these flags into the database, so env vars take effect on fresh installs without a DB row overriding them. Existing DB rows (from prior deploys or manual updates) continue to take precedence — a pod restart is required for env var changes to be picked up by the running service.
 
 After upgrading to a version that adds `METRICS_COLLECTION`, run `python manage.py metrics_service init-system-tasks` once so system tasks include `_feature_flag` for metrics collection templates.
 

--- a/apps/dynamic_settings/utils.py
+++ b/apps/dynamic_settings/utils.py
@@ -267,3 +267,27 @@ def initialize_default_settings(overwrite: bool = False):
         logger.info(f"Initialized {created_count} default settings in database")
     if skipped_count > 0:
         logger.debug(f"Skipped {skipped_count} existing settings")
+
+    # On upgrade, delete system-seeded `true` rows for FEATURE flags.
+    # A `true` row is redundant — the static default and env var both produce `true`
+    # when no row exists, so keeping it only blocks env var overrides (e.g. an
+    # operator setting METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION=false).
+    # `false` rows are kept: they represent an explicit opt-out that must survive.
+    # Rows changed via the settings API (previous_value != None) are left untouched
+    # regardless of their value — they are intentional runtime toggles.
+    feature_dict = getattr(django_settings, "FEATURE", {})
+    cleaned_count = 0
+    for flag_key in feature_dict:
+        try:
+            deleted, _ = Setting.objects.filter(
+                setting_key=flag_key,
+                current_value=json.dumps(True),
+                previous_value=None,
+            ).delete()
+            if deleted:
+                logger.info(f"Removed redundant system-seeded 'true' row for '{flag_key}'; env var now applies")
+                cleaned_count += deleted
+        except Exception as e:
+            logger.warning(f"Failed to clean up feature flag row for '{flag_key}': {e}")
+    if cleaned_count > 0:
+        logger.info(f"Cleaned up {cleaned_count} redundant feature flag row(s)")

--- a/apps/dynamic_settings/utils.py
+++ b/apps/dynamic_settings/utils.py
@@ -148,131 +148,44 @@ def rollback_configuration_change(change_id, user):
         return {"success": False, "error": f"Failed to rollback: {str(e)}"}
 
 
-# Feature flags controlled by METRICS_SERVICE_FEATURE__<KEY>=value env-var overrides
-# (dynaconf nested-key syntax merges into the FEATURE dict in apps/settings/defaults.py).
-# AAP-77009: METRICS_COLLECTION and ANONYMIZED_DATA_COLLECTION are no longer seeded into the DB
-# by initialize_default_settings. They resolve from the FEATURE dict via get_feature_enabled_from_db,
-# so METRICS_SERVICE_FEATURE__METRICS_COLLECTION and METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION
-# take effect on fresh installs without a DB row overriding them — identical to DASHBOARD_COLLECTION.
-# Add entries here only for flags that must be DB-seeded for legacy compatibility reasons.
-DEFAULT_SETTINGS: dict = {}
+# uv run ./manage.py metrics_service remove-default-settings [--all-settings]
+def remove_default_settings(all_settings: bool = False, **_kwargs) -> int:
+    """
+    Remove settings from the database.
 
+    With all_settings=True removes every row. Without it this is a no-op —
+    there are no longer any known-default keys to target individually.
+    The **_kwargs absorbs legacy all_known= callers without raising.
+    """
+    if not all_settings:
+        logger.debug("No settings found to remove")
+        return 0
 
-def _remove_all_settings():
     deleted_count, _ = Setting.objects.all().delete()
+    if deleted_count > 0:
+        logger.info(f"Removed {deleted_count} settings from database")
     return deleted_count
 
 
-def _remove_known_settings(including_changed=False):
-    removed_count = 0
-
-    for setting_key in DEFAULT_SETTINGS:
-        if including_changed:
-            # remove all known defaults regardless of modification status
-            deleted_count, _ = Setting.objects.filter(setting_key=setting_key).delete()
-        else:
-            # default: only remove unchanged settings
-            deleted_count, _ = Setting.objects.filter(setting_key=setting_key, previous_value=None).delete()
-
-        if deleted_count > 0:
-            logger.info(f"Removed setting '{setting_key}'")
-            removed_count += deleted_count
-
-    return removed_count
-
-
-# uv run ./manage.py metrics_service remove-default-settings [--all-known] [--all-settings]
-def remove_default_settings(all_known: bool = False, all_settings: bool = False):
-    """
-    Remove default feature flag settings from the database.
-
-    Args:
-        all_known: If True, remove all known default settings (ignores previous_value logic)
-        all_settings: If True, remove all settings from database (ignores DEFAULT_SETTINGS known settings list)
-
-    Default behavior (both False):
-        Only removes settings that match DEFAULT_SETTINGS keys and have
-        previous_value=None (indicating they haven't been modified by a user).
-        Settings that have been modified (have a previous_value) are preserved.
-
-    With all_known=True:
-        Removes all settings in DEFAULT_SETTINGS, even if they have been modified.
-
-    With all_settings=True:
-        Removes ALL settings from the database, not just those in DEFAULT_SETTINGS.
-        Takes precedence over all_known.
-    """
-    removed_count = _remove_all_settings() if all_settings else _remove_known_settings(all_known)
-
-    if removed_count > 0:
-        logger.info(f"Removed {removed_count} settings from database")
-    else:
-        logger.debug("No settings found to remove")
-
-    return removed_count
-
-
 # uv run ./manage.py metrics_service init-default-settings
-def initialize_default_settings(overwrite: bool = False):
+def initialize_default_settings(**_kwargs) -> None:
     """
-    Initialize or update default feature flag settings in the database.
+    Upgrade hook for FEATURE flag DB rows.
 
-    Args:
-        overwrite: If True, remove all known default settings before reinitializing
-                   (passes all_known=True to remove_default_settings)
+    No flags are pre-seeded into the database. Feature flags resolve at runtime
+    from the ``settings.FEATURE`` dict (env var overrides via
+    ``METRICS_SERVICE_FEATURE__*`` merge in via dynaconf) with ``false`` DB rows
+    as explicit opt-outs.
 
-    This function removes unchanged default settings (those with previous_value=None)
-    and recreates them with current values from configuration. Modified settings
-    (those with a previous_value) are preserved and never overwritten, unless
-    overwrite=True is specified.
+    On each call, any ``true`` DB row for a FEATURE flag key is deleted — a
+    ``true`` row is redundant (the static default and env var both produce
+    ``true`` when no row exists) and blocks env var overrides.  ``false`` rows
+    are kept: they represent an explicit opt-out that must survive upgrades.
 
-    This ensures default settings stay in sync with configuration while respecting
-    user modifications.
+    The **_kwargs absorbs legacy overwrite= callers without raising.
     """
     from django.conf import settings as django_settings
 
-    # Remove existing defaults (all known if overwrite=True, otherwise just unchanged)
-    remove_default_settings(all_known=overwrite)
-
-    created_count = 0
-    skipped_count = 0
-
-    for setting_key, config in DEFAULT_SETTINGS.items():
-        # Check if setting already exists
-        existing = Setting.objects.filter(setting_key=setting_key).first()
-
-        if existing:
-            logger.debug(f"Setting '{setting_key}' already exists with value: {existing.current_value}")
-            skipped_count += 1
-            continue
-
-        # Get default value from Django settings FEATURE dict, or use hardcoded default
-        feature_enabled = getattr(django_settings, "FEATURE", {})
-        default_value = feature_enabled.get(setting_key, config["default_value"])
-
-        # Create the setting
-        Setting.objects.create(
-            setting_key=setting_key,
-            current_value=json.dumps(default_value),
-            previous_value=None,
-            last_modified_by=None,  # System initialization
-        )
-
-        logger.info(
-            f"Initialized setting '{setting_key}' with default value: {default_value} ({config['description']})"
-        )
-        created_count += 1
-
-    if created_count > 0:
-        logger.info(f"Initialized {created_count} default settings in database")
-    if skipped_count > 0:
-        logger.debug(f"Skipped {skipped_count} existing settings")
-
-    # On upgrade, delete any `true` DB rows for FEATURE flags.
-    # A `true` row is always redundant — the static default and env var both produce
-    # `true` when no row exists, so keeping it only blocks env var overrides (e.g.
-    # METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION=false).
-    # `false` rows are kept: they represent an explicit opt-out that must survive.
     feature_dict = getattr(django_settings, "FEATURE", {})
     cleaned_count = 0
     for flag_key in feature_dict:

--- a/apps/dynamic_settings/utils.py
+++ b/apps/dynamic_settings/utils.py
@@ -148,18 +148,14 @@ def rollback_configuration_change(change_id, user):
         return {"success": False, "error": f"Failed to rollback: {str(e)}"}
 
 
-# Define default feature flags - same as in initialize_default_settings
-# default_value is the fallback, set the actual default in apps/settings/defaults.py
-DEFAULT_SETTINGS = {
-    "METRICS_COLLECTION": {
-        "default_value": True,
-        "description": "Enable local metrics collection (hourly/daily collectors), daily rollup, and metrics data cleanup",
-    },
-    "ANONYMIZED_DATA_COLLECTION": {
-        "default_value": True,
-        "description": "Enable anonymization of daily rollup and transmission to Red Hat (Segment); does not gate local metrics collection",
-    },
-}
+# Feature flags controlled by METRICS_SERVICE_FEATURE__<KEY>=value env-var overrides
+# (dynaconf nested-key syntax merges into the FEATURE dict in apps/settings/defaults.py).
+# AAP-77009: METRICS_COLLECTION and ANONYMIZED_DATA_COLLECTION are no longer seeded into the DB
+# by initialize_default_settings. They resolve from the FEATURE dict via get_feature_enabled_from_db,
+# so METRICS_SERVICE_FEATURE__METRICS_COLLECTION and METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION
+# take effect on fresh installs without a DB row overriding them — identical to DASHBOARD_COLLECTION.
+# Add entries here only for flags that must be DB-seeded for legacy compatibility reasons.
+DEFAULT_SETTINGS: dict = {}
 
 
 def _remove_all_settings():
@@ -250,8 +246,8 @@ def initialize_default_settings(overwrite: bool = False):
             skipped_count += 1
             continue
 
-        # Get default value from Django settings FEATURE_ENABLED dict, or use hardcoded default
-        feature_enabled = getattr(django_settings, "FEATURE_ENABLED", {})
+        # Get default value from Django settings FEATURE dict, or use hardcoded default
+        feature_enabled = getattr(django_settings, "FEATURE", {})
         default_value = feature_enabled.get(setting_key, config["default_value"])
 
         # Create the setting

--- a/apps/dynamic_settings/utils.py
+++ b/apps/dynamic_settings/utils.py
@@ -268,13 +268,11 @@ def initialize_default_settings(overwrite: bool = False):
     if skipped_count > 0:
         logger.debug(f"Skipped {skipped_count} existing settings")
 
-    # On upgrade, delete system-seeded `true` rows for FEATURE flags.
-    # A `true` row is redundant — the static default and env var both produce `true`
-    # when no row exists, so keeping it only blocks env var overrides (e.g. an
-    # operator setting METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION=false).
+    # On upgrade, delete any `true` DB rows for FEATURE flags.
+    # A `true` row is always redundant — the static default and env var both produce
+    # `true` when no row exists, so keeping it only blocks env var overrides (e.g.
+    # METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION=false).
     # `false` rows are kept: they represent an explicit opt-out that must survive.
-    # Rows changed via the settings API (previous_value != None) are left untouched
-    # regardless of their value — they are intentional runtime toggles.
     feature_dict = getattr(django_settings, "FEATURE", {})
     cleaned_count = 0
     for flag_key in feature_dict:
@@ -282,10 +280,9 @@ def initialize_default_settings(overwrite: bool = False):
             deleted, _ = Setting.objects.filter(
                 setting_key=flag_key,
                 current_value=json.dumps(True),
-                previous_value=None,
             ).delete()
             if deleted:
-                logger.info(f"Removed redundant system-seeded 'true' row for '{flag_key}'; env var now applies")
+                logger.info(f"Removed redundant 'true' row for '{flag_key}'; env var now applies")
                 cleaned_count += deleted
         except Exception as e:
             logger.warning(f"Failed to clean up feature flag row for '{flag_key}': {e}")

--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -118,18 +118,17 @@ DATABASES = {
     },
 }
 
-# Feature flag defaults
-# only used by `metrics_service init-default-settings` (and `... run`)
-# and only used when not already changed in the settings DB table
-# also used by tasks - unless set in the db.
-FEATURE_ENABLED = {
+# Feature flag defaults — controlled at runtime via METRICS_SERVICE_FEATURE__<KEY>=value env vars
+# (dynaconf nested-key syntax merges into this dict) or via the dynamic_settings DB API.
+# Keys present here provide the static default used by get_feature_enabled_from_db when no DB row
+# exists. DASHBOARD_COLLECTION is intentionally omitted because it defaults to False (opt-in) and
+# is controlled via METRICS_SERVICE_FEATURE__DASHBOARD_COLLECTION, the installer top-level
+# FEATURE_DASHBOARD_COLLECTION_ENABLED attribute, or a DAB AAPFlag — see get_feature_enabled_from_db.
+FEATURE = {
     # Local hourly/daily collectors, rollup, cleanup_metrics_data — see METRICS_COLLECTION_GROUP.
     "METRICS_COLLECTION": True,
     # Anonymization and Segment transmission only — does not gate METRICS_COLLECTION_GROUP.
     "ANONYMIZED_DATA_COLLECTION": True,
-    # DASHBOARD_COLLECTION is intentionally omitted: set via METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION,
-    # FEATURE_DASHBOARD_COLLECTION_ENABLED (top-level, installer convention), DAB AAPFlag
-    # FEATURE_DASHBOARD_COLLECTION_ENABLED, or dynamic_settings.Setting — see get_feature_enabled_from_db.
 }
 
 # Used when generating API URLs in views, example "/api/metrics/"; None means "/api/"

--- a/apps/settings/test.py
+++ b/apps/settings/test.py
@@ -76,8 +76,8 @@ DISPATCHERD_ENABLED = False
 
 # Disable feature enables during tests
 # NOTE: relies on get_feature_enabled_from_db falling back to directly using these settings when not in DB...
-# ...and on init-default-settings never happening during tests. If it does, @override_setings won't work.
-FEATURE_ENABLED = {
+# ...and on init-default-settings never happening during tests. If it does, @override_settings won't work.
+FEATURE = {
     "ANONYMIZED_DATA_COLLECTION": False,
 }
 

--- a/apps/tasks/management/commands/metrics_service.py
+++ b/apps/tasks/management/commands/metrics_service.py
@@ -123,23 +123,13 @@ class Command(BaseCommand):
 
     def _add_init_settings_arguments(self, parser):
         """Add arguments for the init-default-settings command."""
-        parser.add_argument(
-            "--overwrite",
-            action="store_true",
-            help="Remove all known default settings before reinitializing (passes all_known=True to remove)",
-        )
 
     def _add_remove_settings_arguments(self, parser):
         """Add arguments for the remove-default-settings command."""
         parser.add_argument(
-            "--all-known",
-            action="store_true",
-            help="Remove all known default settings (ignores previous_value logic, removes even modified settings)",
-        )
-        parser.add_argument(
             "--all-settings",
             action="store_true",
-            help="Remove all settings from database (ignores DEFAULT_SETTINGS known settings list)",
+            help="Remove all settings from the database",
         )
 
     def _add_init_tasks_arguments(self, parser):
@@ -230,8 +220,7 @@ class Command(BaseCommand):
             from apps.dynamic_settings.utils import initialize_default_settings
             from apps.tasks.apps import load_task_feature_flags, sync_flag_values_from_settings
 
-            overwrite = options.get("overwrite", False) if options else False
-            initialize_default_settings(overwrite=overwrite)
+            initialize_default_settings()
             # Seed metrics-specific AAPFlags from feature_flags.yaml. This
             # mirrors what the post_migrate signal does during `migrate`, but
             # must also run here because init-default-settings is called in
@@ -254,10 +243,9 @@ class Command(BaseCommand):
         try:
             from apps.dynamic_settings.utils import remove_default_settings
 
-            all_known = options.get("all_known", False)
             all_settings = options.get("all_settings", False)
 
-            removed_count = remove_default_settings(all_known=all_known, all_settings=all_settings)
+            removed_count = remove_default_settings(all_settings=all_settings)
             self.output.success(f"Removed {removed_count} settings")
         except Exception as e:
             raise CommandError(f"Failed to remove default settings: {e}") from e

--- a/apps/tasks/management/commands/metrics_service.py
+++ b/apps/tasks/management/commands/metrics_service.py
@@ -183,7 +183,7 @@ class Command(BaseCommand):
             if command == "run":
                 self._handle_run_command(options)
             elif command == "init-default-settings":
-                self._handle_init_default_settings_command(options)
+                self._handle_init_default_settings_command()
             elif command == "remove-default-settings":
                 self._handle_remove_default_settings_command(options)
             elif command == "init-service-id":
@@ -214,7 +214,7 @@ class Command(BaseCommand):
         except ValueError as e:
             raise CommandError(f"Configuration error: {e}") from e
 
-    def _handle_init_default_settings_command(self, options: dict[str, Any] | None = None) -> None:
+    def _handle_init_default_settings_command(self) -> None:
         """Handle the init-default-settings command."""
         try:
             from apps.dynamic_settings.utils import initialize_default_settings

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -6,7 +6,7 @@ a centralized way to manage different categories of tasks.
 
 Feature enabled settings are stored in the database using the Setting model, allowing
 runtime configuration without code changes. Values resolve in order: Setting row,
-then settings.FEATURE_ENABLED when the key is present (including env overrides),
+then settings.FEATURE when the key is present (including env overrides via METRICS_SERVICE_FEATURE__*),
 then the direct top-level settings attribute FEATURE_<name>_ENABLED (set by the installer
 via settings.yaml), then DAB AAPFlag FEATURE_<name>_ENABLED, then the function default.
 
@@ -28,12 +28,12 @@ def get_feature_enabled_from_db(setting_name: str, default: bool = False) -> boo
     """
     Get a feature enabled value from database settings.
 
-    Order: ``Setting`` row → ``FEATURE_ENABLED[setting_name]`` if that key exists
-    (Dynaconf merges ``METRICS_SERVICE_FEATURE_ENABLED__*``) → top-level
+    Order: ``Setting`` row → ``FEATURE[setting_name]`` if that key exists
+    (Dynaconf merges ``METRICS_SERVICE_FEATURE__*``) → top-level
     ``FEATURE_<setting_name>_ENABLED`` settings attribute (set directly in settings.yaml
     by the installer) → boolean ``AAPFlag`` ``FEATURE_<setting_name>_ENABLED`` → ``default``.
 
-    Feature keys omitted from ``FEATURE_ENABLED`` in defaults (e.g. ``DASHBOARD_COLLECTION``)
+    Feature keys omitted from ``FEATURE`` in defaults (e.g. ``DASHBOARD_COLLECTION``)
     use the direct-attribute / AAPFlag / default path so platform toggles work without a
     duplicate static default.
 
@@ -57,7 +57,7 @@ def get_feature_enabled_from_db(setting_name: str, default: bool = False) -> boo
                 value = setting.current_value.lower() in ("true", "1", "yes", "on")
             return bool(value)
 
-        feature_enabled = getattr(settings, "FEATURE_ENABLED", {})
+        feature_enabled = getattr(settings, "FEATURE", {})
         if setting_name in feature_enabled:
             return bool(feature_enabled[setting_name])
 
@@ -82,7 +82,7 @@ def get_feature_enabled_from_db(setting_name: str, default: bool = False) -> boo
 
     except Exception as e:
         logger.warning(f"Error reading feature enabled setting {setting_name} from database: {e}")
-        feature_enabled = getattr(settings, "FEATURE_ENABLED", {})
+        feature_enabled = getattr(settings, "FEATURE", {})
         return bool(feature_enabled[setting_name]) if setting_name in feature_enabled else default
 
 
@@ -122,7 +122,7 @@ class TaskGroup:
         First checks the group-level feature flag (if present).
         Then filters out tasks with enabled=False.
 
-        Feature flag defaults are defined in Django settings (FEATURE_ENABLED dict).
+        Feature flag defaults are defined in Django settings (FEATURE dict).
 
         Returns:
             List of task configurations that are enabled
@@ -304,7 +304,7 @@ ANONYMIZATION_GROUP = TaskGroup(
 
 # Dashboard Collection Group - automation-reports integration
 # Feature flag: DASHBOARD_COLLECTION (default: False — customer opt-in)
-# Enable via METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION, DAB AAPFlag
+# Enable via METRICS_SERVICE_FEATURE__DASHBOARD_COLLECTION, DAB AAPFlag
 # FEATURE_DASHBOARD_COLLECTION_ENABLED, or dynamic_settings.Setting — see get_feature_enabled_from_db.
 DASHBOARD_COLLECTION_GROUP = TaskGroup(
     name="dashboard_collection",

--- a/apps/tasks/tests/test_feature_flag_runtime_check.py
+++ b/apps/tasks/tests/test_feature_flag_runtime_check.py
@@ -104,7 +104,7 @@ class TestFeatureFlagRuntimeCheck:
         mock_submit.assert_called_once()
 
     @pytest.mark.django_db
-    @override_settings(FEATURE_ENABLED={"METRICS_COLLECTION": True, "ANONYMIZED_DATA_COLLECTION": True})
+    @override_settings(FEATURE={"METRICS_COLLECTION": True, "ANONYMIZED_DATA_COLLECTION": True})
     def test_get_all_enabled_tasks_includes_feature_flag(self):
         """get_all_enabled_tasks propagates each group's feature_flag into task configs."""
         from apps.tasks.task_groups import ANONYMIZATION_GROUP, METRICS_COLLECTION_GROUP, get_all_enabled_tasks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       METRICS_SERVICE_DATABASES__default__HOST: postgres
       METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
       METRICS_SERVICE_MODE: development
-      METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION: "true"
+      METRICS_SERVICE_FEATURE__DASHBOARD_COLLECTION: "true"
       METRICS_SERVICE_DASHBOARD_COLLECTION__COLLECTION_SCHEDULE_CRON: "*/5 * * * *" # Every 5 minutes for testing
     networks:
       - metrics-service
@@ -105,9 +105,9 @@ services:
       # at runtime to create the follow-up task — the cron is evaluated from settings at import
       # time, so without this var it falls back to the default "0 */6 * * *" instead of 5-min.
       METRICS_SERVICE_DASHBOARD_COLLECTION__COLLECTION_SCHEDULE_CRON: "*/5 * * * *"
-      # Required: get_feature_enabled_from_db falls back to settings.FEATURE_ENABLED when the
+      # Required: get_feature_enabled_from_db falls back to settings.FEATURE when the
       # DB setting is absent; without this the flag defaults to False and tasks are skipped.
-      METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION: "true"
+      METRICS_SERVICE_FEATURE__DASHBOARD_COLLECTION: "true"
     networks:
       - metrics-service
 
@@ -134,10 +134,10 @@ services:
       METRICS_SERVICE_DATABASES__default__HOST: postgres
       METRICS_SERVICE_DATABASES__default__PASSWORD: metrics_service
       METRICS_SERVICE_MODE: development
-      # Required: get_feature_enabled_from_db falls back to settings.FEATURE_ENABLED when the
+      # Required: get_feature_enabled_from_db falls back to settings.FEATURE when the
       # DB setting is absent; without this the flag defaults to False and tasks are skipped.
       # (Cron is not needed here — the scheduler reads cron_expression from the DB Task record.)
-      METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION: "true"
+      METRICS_SERVICE_FEATURE__DASHBOARD_COLLECTION: "true"
     networks:
       - metrics-service
 

--- a/metrics_service/tools/dashboard_collection_performance_tests/README.md
+++ b/metrics_service/tools/dashboard_collection_performance_tests/README.md
@@ -75,7 +75,7 @@ export METRICS_UTILITY_DB_PASSWORD=<awx-db-password>
 
 # General
 export METRICS_SERVICE_LOG_LEVEL=WARNING
-export METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION=true
+export METRICS_SERVICE_FEATURE__DASHBOARD_COLLECTION=true
 ```
 
 If `metrics-utility` is not checked out as a sibling of `metrics-service` (at `../metrics-utility`
@@ -377,7 +377,7 @@ Phase 3: One day collection ...
 
 - **postgres not running** — `docker-compose up -d postgres` / `docker-compose ps`
 - **`JobData` table missing** — run `python manage.py migrate`
-- **Feature flag error** — verify `METRICS_SERVICE_FEATURE_ENABLED__DASHBOARD_COLLECTION=true`
+- **Feature flag error** — verify `METRICS_SERVICE_FEATURE__DASHBOARD_COLLECTION=true`
 - **`fill_data.py` — scripts directory not found** — set `METRICS_UTILITY_PATH` to your `metrics-utility` checkout
 - **401 Unauthorized (API benchmark)** — wrong `BENCHMARK_USER` / `PASSWORD`; user must be a superuser
 - **Task stays pending (API benchmark)** — dispatcherd is not running

--- a/tests/coverage/dashboard_reports/test_dashboard_reports_tasks.py
+++ b/tests/coverage/dashboard_reports/test_dashboard_reports_tasks.py
@@ -65,6 +65,7 @@ def test_collect_data_success():
     mock_jobs_result = {"results": [], "count": 0}
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
+        patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
         patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
     ):
         result = _collect_data("test_task", since=since, until=now.isoformat())
@@ -109,6 +110,7 @@ def test_collect_dashboard_reports_initial_data_success():
 
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
+        patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
         patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
     ):
         result = collect_dashboard_reports_initial_data(
@@ -130,6 +132,7 @@ def test_collect_dashboard_reports_data_incremental():
     mock_jobs_result = {"results": [], "count": 0}
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
+        patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
         patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
     ):
         result = collect_dashboard_reports_data(incremental=True)
@@ -147,6 +150,7 @@ def test_collect_dashboard_reports_data_full():
 
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
+        patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
         patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
     ):
         result = collect_dashboard_reports_data(

--- a/tests/coverage/dashboard_reports/test_dashboard_reports_tasks.py
+++ b/tests/coverage/dashboard_reports/test_dashboard_reports_tasks.py
@@ -65,7 +65,7 @@ def test_collect_data_success():
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
         patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
-        patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
+        patch("apps.dashboard_reports.tasks._collect_jobs", return_value={"results": [], "count": 0}),
     ):
         result = _collect_data("test_task", since=since, until=now.isoformat())
 
@@ -109,7 +109,7 @@ def test_collect_dashboard_reports_initial_data_success():
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
         patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
-        patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
+        patch("apps.dashboard_reports.tasks._collect_jobs", return_value={"results": [], "count": 5}),
     ):
         result = collect_dashboard_reports_initial_data(
             since=(now - timedelta(days=1)).isoformat(),
@@ -130,7 +130,7 @@ def test_collect_dashboard_reports_data_incremental():
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
         patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
-        patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
+        patch("apps.dashboard_reports.tasks._collect_jobs", return_value={"results": [], "count": 0}),
     ):
         result = collect_dashboard_reports_data(incremental=True)
 
@@ -147,7 +147,7 @@ def test_collect_dashboard_reports_data_full():
     with (
         patch("apps.dashboard_reports.tasks.get_db_connection", return_value=MagicMock()),
         patch("apps.dashboard_reports.tasks._get_job_id_range", return_value=(None, None)),
-        patch("apps.dashboard_reports.tasks._collect_jobs", return_value=mock_jobs_result),
+        patch("apps.dashboard_reports.tasks._collect_jobs", return_value={"results": [], "count": 0}),
     ):
         result = collect_dashboard_reports_data(
             incremental=False,

--- a/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
+++ b/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
@@ -109,6 +109,33 @@ def test_initialize_default_settings_overwrite_recreates():
         assert Setting.objects.filter(setting_key=key).exists()
 
 
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_initialize_default_settings_reads_value_from_feature_dict():
+    """Loop body reads from settings.FEATURE when DEFAULT_SETTINGS has an entry."""
+    from unittest.mock import patch
+
+    from django.test import override_settings
+
+    from apps.dynamic_settings.models import Setting
+    from apps.dynamic_settings.utils import initialize_default_settings
+
+    test_defaults = {"TEST_INIT_FLAG": {"default_value": False, "description": "test"}}
+    Setting.objects.filter(setting_key="TEST_INIT_FLAG").delete()
+
+    with (
+        patch("apps.dynamic_settings.utils.DEFAULT_SETTINGS", test_defaults),
+        override_settings(FEATURE={"TEST_INIT_FLAG": True}),
+    ):
+        initialize_default_settings()
+
+    setting = Setting.objects.filter(setting_key="TEST_INIT_FLAG").first()
+    assert setting is not None
+    import json
+
+    assert json.loads(setting.current_value) is True  # sourced from FEATURE dict, not hardcoded default
+
+
 # ---------------------------------------------------------------------------
 # remove_default_settings
 # ---------------------------------------------------------------------------

--- a/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
+++ b/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
@@ -143,8 +143,8 @@ def test_initialize_default_settings_reads_value_from_feature_dict():
 @pytest.mark.unit
 @pytest.mark.django_db
 def test_initialize_default_settings_deletes_redundant_true_row():
-    """Upgrade failsafe: a system-seeded `true` row (previous_value=None) is deleted
-    so that METRICS_SERVICE_FEATURE__<KEY>=false takes effect without a DB update."""
+    """Upgrade failsafe: any `true` row for a FEATURE flag is deleted so that
+    METRICS_SERVICE_FEATURE__<KEY>=false takes effect without a DB update."""
     import json
 
     from django.test import override_settings
@@ -155,7 +155,7 @@ def test_initialize_default_settings_deletes_redundant_true_row():
     # Simulate old init-default-settings having written True into the DB
     Setting.objects.update_or_create(
         setting_key="ANONYMIZED_DATA_COLLECTION",
-        defaults={"current_value": json.dumps(True), "previous_value": None},
+        defaults={"current_value": json.dumps(True)},
     )
 
     with override_settings(FEATURE={"ANONYMIZED_DATA_COLLECTION": True}):
@@ -168,7 +168,7 @@ def test_initialize_default_settings_deletes_redundant_true_row():
 @pytest.mark.unit
 @pytest.mark.django_db
 def test_initialize_default_settings_keeps_false_row():
-    """A system-seeded `false` row is an explicit opt-out and must survive upgrade."""
+    """`false` rows are an explicit opt-out and must survive upgrade."""
     import json
 
     from django.test import override_settings
@@ -178,7 +178,7 @@ def test_initialize_default_settings_keeps_false_row():
 
     Setting.objects.update_or_create(
         setting_key="ANONYMIZED_DATA_COLLECTION",
-        defaults={"current_value": json.dumps(False), "previous_value": None},
+        defaults={"current_value": json.dumps(False)},
     )
 
     with override_settings(FEATURE={"ANONYMIZED_DATA_COLLECTION": True}):
@@ -186,31 +186,6 @@ def test_initialize_default_settings_keeps_false_row():
 
     row = Setting.objects.get(setting_key="ANONYMIZED_DATA_COLLECTION")
     assert json.loads(row.current_value) is False  # opt-out preserved
-
-
-@pytest.mark.unit
-@pytest.mark.django_db
-def test_initialize_default_settings_keeps_api_changed_true_row():
-    """API-changed rows (previous_value != None) are intentional runtime toggles
-    and must not be touched regardless of their value."""
-    import json
-
-    from django.test import override_settings
-
-    from apps.dynamic_settings.models import Setting
-    from apps.dynamic_settings.utils import initialize_default_settings
-
-    # Admin explicitly set it to True via the settings API
-    Setting.objects.update_or_create(
-        setting_key="ANONYMIZED_DATA_COLLECTION",
-        defaults={"current_value": json.dumps(True), "previous_value": json.dumps(False)},
-    )
-
-    with override_settings(FEATURE={"ANONYMIZED_DATA_COLLECTION": True}):
-        initialize_default_settings()
-
-    row = Setting.objects.get(setting_key="ANONYMIZED_DATA_COLLECTION")
-    assert json.loads(row.current_value) is True  # API change preserved
 
 
 # ---------------------------------------------------------------------------

--- a/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
+++ b/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
@@ -115,6 +115,8 @@ def test_initialize_default_settings_overwrite_recreates():
 @pytest.mark.unit
 @pytest.mark.django_db
 def test_remove_default_settings_removes_unchanged():
+    """AAP-77009: remove_default_settings is a no-op for keys not in DEFAULT_SETTINGS.
+    Use all_settings=True to remove all settings regardless."""
     from apps.dynamic_settings.models import Setting
     from apps.dynamic_settings.utils import remove_default_settings
 
@@ -122,9 +124,15 @@ def test_remove_default_settings_removes_unchanged():
         setting_key="METRICS_COLLECTION", defaults={"current_value": "true", "previous_value": None}
     )
 
+    # DEFAULT_SETTINGS is empty — nothing removed by the "known defaults" path
     removed = remove_default_settings()
-    assert removed >= 1
-    assert not Setting.objects.filter(setting_key="METRICS_COLLECTION", previous_value=None).exists()
+    assert removed == 0
+    assert Setting.objects.filter(setting_key="METRICS_COLLECTION").exists()
+
+    # all_settings=True removes everything unconditionally
+    removed_all = remove_default_settings(all_settings=True)
+    assert removed_all >= 1
+    assert not Setting.objects.filter(setting_key="METRICS_COLLECTION").exists()
 
 
 @pytest.mark.unit
@@ -146,6 +154,8 @@ def test_remove_default_settings_preserves_modified():
 @pytest.mark.unit
 @pytest.mark.django_db
 def test_remove_default_settings_all_known_removes_modified():
+    """AAP-77009: all_known=True only removes keys present in DEFAULT_SETTINGS.
+    Since DEFAULT_SETTINGS is empty, METRICS_COLLECTION is left untouched."""
     from apps.dynamic_settings.models import Setting
     from apps.dynamic_settings.utils import remove_default_settings
 
@@ -154,8 +164,10 @@ def test_remove_default_settings_all_known_removes_modified():
         defaults={"current_value": "false", "previous_value": '"true"'},
     )
 
-    remove_default_settings(all_known=True)
-    assert not Setting.objects.filter(setting_key="METRICS_COLLECTION").exists()
+    removed = remove_default_settings(all_known=True)
+    assert removed == 0
+    # Not in DEFAULT_SETTINGS → not touched
+    assert Setting.objects.filter(setting_key="METRICS_COLLECTION").exists()
 
 
 @pytest.mark.unit

--- a/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
+++ b/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
@@ -65,79 +65,12 @@ def test_parse_setting_value_empty_string_returns_none():
 # ---------------------------------------------------------------------------
 @pytest.mark.unit
 @pytest.mark.django_db
-def test_initialize_default_settings_creates_records():
-    from apps.dynamic_settings.models import Setting
-    from apps.dynamic_settings.utils import DEFAULT_SETTINGS, initialize_default_settings
-
-    # Ensure fresh state
-    Setting.objects.filter(setting_key__in=DEFAULT_SETTINGS.keys()).delete()
-
-    initialize_default_settings()
-
-    for key in DEFAULT_SETTINGS:
-        assert Setting.objects.filter(setting_key=key).exists(), f"Missing setting: {key}"
-
-
-@pytest.mark.unit
-@pytest.mark.django_db
-def test_initialize_default_settings_skips_existing():
-    from apps.dynamic_settings.models import Setting
-    from apps.dynamic_settings.utils import DEFAULT_SETTINGS, initialize_default_settings
-
-    Setting.objects.filter(setting_key__in=DEFAULT_SETTINGS.keys()).delete()
-    initialize_default_settings()
-    count_after_first = Setting.objects.filter(setting_key__in=DEFAULT_SETTINGS.keys()).count()
-
-    # Second call should not duplicate
-    initialize_default_settings()
-    count_after_second = Setting.objects.filter(setting_key__in=DEFAULT_SETTINGS.keys()).count()
-    assert count_after_second == count_after_first
-
-
-@pytest.mark.unit
-@pytest.mark.django_db
-def test_initialize_default_settings_overwrite_recreates():
-    from apps.dynamic_settings.models import Setting
-    from apps.dynamic_settings.utils import DEFAULT_SETTINGS, initialize_default_settings
-
-    Setting.objects.filter(setting_key__in=DEFAULT_SETTINGS.keys()).delete()
-    initialize_default_settings()
-    # Should complete without error
-    initialize_default_settings(overwrite=True)
-    # Settings should still exist
-    for key in DEFAULT_SETTINGS:
-        assert Setting.objects.filter(setting_key=key).exists()
-
-
-@pytest.mark.unit
-@pytest.mark.django_db
-def test_initialize_default_settings_reads_value_from_feature_dict():
-    """Loop body reads from settings.FEATURE when DEFAULT_SETTINGS has an entry."""
-    from unittest.mock import patch
-
-    from django.test import override_settings
-
-    from apps.dynamic_settings.models import Setting
+def test_initialize_default_settings_runs_without_error():
+    """initialize_default_settings completes without raising (no-op when no true rows exist)."""
     from apps.dynamic_settings.utils import initialize_default_settings
 
-    # Hardcoded default is True; FEATURE dict says False — the row must be created
-    # with False, proving the loop reads FEATURE over the hardcoded default.
-    # Using False also means the cleanup step won't delete the row (only true rows
-    # are removed as redundant).
-    test_defaults = {"TEST_INIT_FLAG": {"default_value": True, "description": "test"}}
-    Setting.objects.filter(setting_key="TEST_INIT_FLAG").delete()
-
-    with (
-        patch("apps.dynamic_settings.utils.DEFAULT_SETTINGS", test_defaults),
-        override_settings(FEATURE={"TEST_INIT_FLAG": False}),
-    ):
-        initialize_default_settings()
-
-    setting = Setting.objects.filter(setting_key="TEST_INIT_FLAG").first()
-    assert setting is not None
-    import json
-
-    assert json.loads(setting.current_value) is False  # sourced from FEATURE dict, not hardcoded True default
+    initialize_default_settings()  # idempotent — safe to call multiple times
+    initialize_default_settings()
 
 
 @pytest.mark.unit

--- a/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
+++ b/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
@@ -121,6 +121,23 @@ def test_initialize_default_settings_keeps_false_row():
     assert json.loads(row.current_value) is False  # opt-out preserved
 
 
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_initialize_default_settings_cleanup_exception_does_not_propagate():
+    """DB errors during cleanup are swallowed and logged — they must not raise."""
+    from unittest.mock import patch
+
+    from django.test import override_settings
+
+    from apps.dynamic_settings.utils import initialize_default_settings
+
+    with (
+        override_settings(FEATURE={"SOME_FLAG": True}),
+        patch("apps.dynamic_settings.utils.Setting.objects.filter", side_effect=Exception("db error")),
+    ):
+        initialize_default_settings()  # must not raise
+
+
 # ---------------------------------------------------------------------------
 # remove_default_settings
 # ---------------------------------------------------------------------------

--- a/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
+++ b/tests/coverage/dynamic_settings/test_dynamic_settings_utils.py
@@ -120,12 +120,16 @@ def test_initialize_default_settings_reads_value_from_feature_dict():
     from apps.dynamic_settings.models import Setting
     from apps.dynamic_settings.utils import initialize_default_settings
 
-    test_defaults = {"TEST_INIT_FLAG": {"default_value": False, "description": "test"}}
+    # Hardcoded default is True; FEATURE dict says False — the row must be created
+    # with False, proving the loop reads FEATURE over the hardcoded default.
+    # Using False also means the cleanup step won't delete the row (only true rows
+    # are removed as redundant).
+    test_defaults = {"TEST_INIT_FLAG": {"default_value": True, "description": "test"}}
     Setting.objects.filter(setting_key="TEST_INIT_FLAG").delete()
 
     with (
         patch("apps.dynamic_settings.utils.DEFAULT_SETTINGS", test_defaults),
-        override_settings(FEATURE={"TEST_INIT_FLAG": True}),
+        override_settings(FEATURE={"TEST_INIT_FLAG": False}),
     ):
         initialize_default_settings()
 
@@ -133,7 +137,80 @@ def test_initialize_default_settings_reads_value_from_feature_dict():
     assert setting is not None
     import json
 
-    assert json.loads(setting.current_value) is True  # sourced from FEATURE dict, not hardcoded default
+    assert json.loads(setting.current_value) is False  # sourced from FEATURE dict, not hardcoded True default
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_initialize_default_settings_deletes_redundant_true_row():
+    """Upgrade failsafe: a system-seeded `true` row (previous_value=None) is deleted
+    so that METRICS_SERVICE_FEATURE__<KEY>=false takes effect without a DB update."""
+    import json
+
+    from django.test import override_settings
+
+    from apps.dynamic_settings.models import Setting
+    from apps.dynamic_settings.utils import initialize_default_settings
+
+    # Simulate old init-default-settings having written True into the DB
+    Setting.objects.update_or_create(
+        setting_key="ANONYMIZED_DATA_COLLECTION",
+        defaults={"current_value": json.dumps(True), "previous_value": None},
+    )
+
+    with override_settings(FEATURE={"ANONYMIZED_DATA_COLLECTION": True}):
+        initialize_default_settings()
+
+    # Row is gone — env var (or static default) now applies at runtime
+    assert not Setting.objects.filter(setting_key="ANONYMIZED_DATA_COLLECTION").exists()
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_initialize_default_settings_keeps_false_row():
+    """A system-seeded `false` row is an explicit opt-out and must survive upgrade."""
+    import json
+
+    from django.test import override_settings
+
+    from apps.dynamic_settings.models import Setting
+    from apps.dynamic_settings.utils import initialize_default_settings
+
+    Setting.objects.update_or_create(
+        setting_key="ANONYMIZED_DATA_COLLECTION",
+        defaults={"current_value": json.dumps(False), "previous_value": None},
+    )
+
+    with override_settings(FEATURE={"ANONYMIZED_DATA_COLLECTION": True}):
+        initialize_default_settings()
+
+    row = Setting.objects.get(setting_key="ANONYMIZED_DATA_COLLECTION")
+    assert json.loads(row.current_value) is False  # opt-out preserved
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+def test_initialize_default_settings_keeps_api_changed_true_row():
+    """API-changed rows (previous_value != None) are intentional runtime toggles
+    and must not be touched regardless of their value."""
+    import json
+
+    from django.test import override_settings
+
+    from apps.dynamic_settings.models import Setting
+    from apps.dynamic_settings.utils import initialize_default_settings
+
+    # Admin explicitly set it to True via the settings API
+    Setting.objects.update_or_create(
+        setting_key="ANONYMIZED_DATA_COLLECTION",
+        defaults={"current_value": json.dumps(True), "previous_value": json.dumps(False)},
+    )
+
+    with override_settings(FEATURE={"ANONYMIZED_DATA_COLLECTION": True}):
+        initialize_default_settings()
+
+    row = Setting.objects.get(setting_key="ANONYMIZED_DATA_COLLECTION")
+    assert json.loads(row.current_value) is True  # API change preserved
 
 
 # ---------------------------------------------------------------------------

--- a/tests/coverage/general/test_sonar_gaps.py
+++ b/tests/coverage/general/test_sonar_gaps.py
@@ -478,15 +478,9 @@ def test_rollback_configuration_change_exception(user):
 @pytest.mark.unit
 @pytest.mark.django_db
 def test_initialize_default_settings_skips_count():
-    """initialize_default_settings logs skipped count when settings already exist."""
-    from apps.dynamic_settings.models import Setting
-    from apps.dynamic_settings.utils import DEFAULT_SETTINGS, initialize_default_settings
+    """initialize_default_settings completes without raising."""
+    from apps.dynamic_settings.utils import initialize_default_settings
 
-    # Create settings so they're skipped
-    for key in DEFAULT_SETTINGS:
-        Setting.objects.get_or_create(setting_key=key, defaults={"current_value": "true"})
-
-    # Should not raise and should skip all
     initialize_default_settings()
 
 

--- a/tests/coverage/tasks/test_management_commands_2.py
+++ b/tests/coverage/tasks/test_management_commands_2.py
@@ -16,24 +16,12 @@ from django.core.management import call_command
 @pytest.mark.django_db
 def test_metrics_service_init_default_settings():
     with (
-        patch("apps.dynamic_settings.utils.initialize_default_settings"),
-        patch("apps.tasks.apps.load_task_feature_flags", return_value=True),
-        patch("apps.tasks.apps.sync_flag_values_from_settings"),
-    ):
-        call_command("metrics_service", "init-default-settings")
-
-
-@pytest.mark.unit
-@pytest.mark.django_db
-def test_metrics_service_init_default_settings_overwrite():
-    with (
         patch("apps.dynamic_settings.utils.initialize_default_settings") as mock_init,
         patch("apps.tasks.apps.load_task_feature_flags", return_value=True),
         patch("apps.tasks.apps.sync_flag_values_from_settings"),
     ):
-        call_command("metrics_service", "init-default-settings", "--overwrite")
-    # overwrite=True should be passed to initialize_default_settings
-    mock_init.assert_called_with(overwrite=True)
+        call_command("metrics_service", "init-default-settings")
+    mock_init.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------
@@ -49,18 +37,10 @@ def test_metrics_service_remove_default_settings():
 
 @pytest.mark.unit
 @pytest.mark.django_db
-def test_metrics_service_remove_default_settings_all_known():
-    with patch("apps.dynamic_settings.utils.remove_default_settings", return_value=3) as mock_remove:
-        call_command("metrics_service", "remove-default-settings", "--all-known")
-    mock_remove.assert_called_with(all_known=True, all_settings=False)
-
-
-@pytest.mark.unit
-@pytest.mark.django_db
 def test_metrics_service_remove_default_settings_all_settings():
     with patch("apps.dynamic_settings.utils.remove_default_settings", return_value=5) as mock_remove:
         call_command("metrics_service", "remove-default-settings", "--all-settings")
-    mock_remove.assert_called_with(all_known=False, all_settings=True)
+    mock_remove.assert_called_with(all_settings=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/coverage/tasks/test_task_groups.py
+++ b/tests/coverage/tasks/test_task_groups.py
@@ -47,7 +47,7 @@ def test_get_feature_enabled_from_db_fallback_settings_dict():
     from apps.tasks.task_groups import get_feature_enabled_from_db
 
     with patch("apps.tasks.task_groups.settings") as mock_settings:
-        mock_settings.FEATURE_ENABLED = {"MY_FLAG": True}
+        mock_settings.FEATURE = {"MY_FLAG": True}
         mock_settings.FEATURE_MY_FLAG_ENABLED = None
         result = get_feature_enabled_from_db("MY_FLAG", default=False)
     assert result is True
@@ -59,7 +59,7 @@ def test_get_feature_enabled_from_db_fallback_direct_attr():
     from apps.tasks.task_groups import get_feature_enabled_from_db
 
     with patch("apps.tasks.task_groups.settings") as mock_settings:
-        mock_settings.FEATURE_ENABLED = {}
+        mock_settings.FEATURE = {}
         mock_settings.FEATURE_DIRECT_FLAG_ENABLED = True
         result = get_feature_enabled_from_db("DIRECT_FLAG", default=False)
     assert result is True
@@ -71,7 +71,7 @@ def test_get_feature_enabled_from_db_returns_default():
     from apps.tasks.task_groups import get_feature_enabled_from_db
 
     with patch("apps.tasks.task_groups.settings") as mock_settings:
-        mock_settings.FEATURE_ENABLED = {}
+        mock_settings.FEATURE = {}
         mock_settings.FEATURE_UNKNOWN_FLAG_ENABLED = None
         with patch("ansible_base.feature_flags.models.AAPFlag") as mock_flag:
             mock_flag.objects.filter.return_value.first.return_value = None
@@ -87,7 +87,7 @@ def test_get_feature_enabled_db_exception_falls_back_to_settings():
         patch("apps.dynamic_settings.models.Setting.objects.filter", side_effect=Exception("DB error")),
         patch("apps.tasks.task_groups.settings") as mock_settings,
     ):
-        mock_settings.FEATURE_ENABLED = {"FALLBACK_FLAG": True}
+        mock_settings.FEATURE = {"FALLBACK_FLAG": True}
         result = get_feature_enabled_from_db("FALLBACK_FLAG", default=False)
     assert result is True
 
@@ -100,7 +100,7 @@ def test_get_feature_enabled_db_exception_returns_default():
         patch("apps.dynamic_settings.models.Setting.objects.filter", side_effect=Exception("DB error")),
         patch("apps.tasks.task_groups.settings") as mock_settings,
     ):
-        mock_settings.FEATURE_ENABLED = {}
+        mock_settings.FEATURE = {}
         result = get_feature_enabled_from_db("NO_FALLBACK", default=False)
     assert result is False
 

--- a/tests/unit/core/test_metrics_service_command.py
+++ b/tests/unit/core/test_metrics_service_command.py
@@ -11,10 +11,10 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase, override_settings
 
-pytestmark = pytest.mark.unit
-
 from apps.tasks.management.commands.metrics_service import Command
 from tests.unit.core.test_metrics_service_helpers import create_mock_processes_with_exit, get_default_config
+
+pytestmark = pytest.mark.unit
 
 
 class BaseCommandTestCase(TestCase):

--- a/tests/unit/core/test_metrics_service_command.py
+++ b/tests/unit/core/test_metrics_service_command.py
@@ -398,8 +398,7 @@ class TestInitDefaultSettingsCommand(BaseCommandTestCase):
         self.create_test_setting("ANONYMIZED_DATA_COLLECTION", False, True)
 
         self.setup_command_output()
-        options = {"overwrite": True}
-        self.command._handle_init_default_settings_command(options)
+        self.command._handle_init_default_settings_command()
 
         # ANONYMIZED_DATA_COLLECTION is not in DEFAULT_SETTINGS → not removed, not re-created
         setting = Setting.objects.get(setting_key="ANONYMIZED_DATA_COLLECTION")

--- a/tests/unit/core/test_metrics_service_command.py
+++ b/tests/unit/core/test_metrics_service_command.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase, override_settings
 
+pytestmark = pytest.mark.unit
+
 from apps.tasks.management.commands.metrics_service import Command
 from tests.unit.core.test_metrics_service_helpers import create_mock_processes_with_exit, get_default_config
 

--- a/tests/unit/core/test_metrics_service_command.py
+++ b/tests/unit/core/test_metrics_service_command.py
@@ -287,44 +287,37 @@ class TestInitDefaultSettingsCommand(BaseCommandTestCase):
         assert callable(initialize_default_settings)
 
     def test_handle_init_default_settings_creates_settings(self):
-        """Test that _handle_init_default_settings_command creates settings when they don't exist."""
+        """AAP-77009: init-default-settings is a no-op for feature flags — they resolve from
+        the FEATURE dict (env-var driven) rather than being pre-seeded into the DB."""
         from apps.dynamic_settings.models import Setting
 
-        # Ensure no settings exist
         Setting.objects.all().delete()
 
-        # Run the command
         self.setup_command_output()
         self.command._handle_init_default_settings_command()
 
-        # Verify settings were created
-        assert Setting.objects.count() > 0
-        assert Setting.objects.filter(setting_key="ANONYMIZED_DATA_COLLECTION").exists()
-        assert Setting.objects.filter(setting_key="METRICS_COLLECTION").exists()
+        # DEFAULT_SETTINGS is empty: no rows created, flags resolve from FEATURE dict
+        assert Setting.objects.count() == 0
 
-        # Check output
         output = self.out.getvalue()
         assert "Initialized default settings" in output
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True, "METRICS_COLLECTION": True})
-    def test_handle_init_default_settings_updates_unchanged_defaults(self):
-        """Test that init updates unchanged default settings to match current config."""
+    def test_handle_init_default_settings_does_not_touch_existing_settings(self):
+        """AAP-77009: init-default-settings leaves existing settings untouched when no keys
+        are in DEFAULT_SETTINGS — feature flags are env-var driven, not DB-seeded."""
         from apps.dynamic_settings.models import Setting
 
-        # Create an unchanged default setting with non-default value
+        # Manually-created setting (unchanged, previous_value=None)
         self.create_test_setting("ANONYMIZED_DATA_COLLECTION", False, None)
 
-        # Run the command
         self.setup_command_output()
         self.command._handle_init_default_settings_command()
 
-        # Verify setting was updated to default value (True)
+        # Setting is not in DEFAULT_SETTINGS, so init leaves it as-is
         assert Setting.objects.filter(setting_key="ANONYMIZED_DATA_COLLECTION").count() == 1
         setting = Setting.objects.get(setting_key="ANONYMIZED_DATA_COLLECTION")
-        # Value should be reset to default (True)
-        assert json.loads(setting.current_value) is True
+        assert json.loads(setting.current_value) is False
 
-        # Check output
         output = self.out.getvalue()
         assert "Initialized default settings" in output
 
@@ -355,18 +348,13 @@ class TestInitDefaultSettingsCommand(BaseCommandTestCase):
         """Test that init-default-settings command works via handle method."""
         from apps.dynamic_settings.models import Setting
 
-        # Ensure no settings exist
         Setting.objects.all().delete()
 
-        # Run via handle method
         self.setup_command_output()
         options = {"command": "init-default-settings"}
         self.command.handle(**options)
 
-        # Verify settings were created
-        assert Setting.objects.count() > 0
-
-        # Check output
+        # DEFAULT_SETTINGS is empty — no rows seeded, command still succeeds
         output = self.out.getvalue()
         assert "Initialized default settings" in output
 
@@ -399,27 +387,23 @@ class TestInitDefaultSettingsCommand(BaseCommandTestCase):
         assert "Failed to initialize default settings" in str(exc_info.value)
         assert "Database error" in str(exc_info.value)
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True, "METRICS_COLLECTION": True})
     def test_handle_init_default_settings_with_overwrite(self):
-        """Test that _handle_init_default_settings_command with --overwrite removes even modified settings."""
+        """AAP-77009: --overwrite is a no-op when DEFAULT_SETTINGS is empty — manually-created
+        settings (including feature flags written via the API) are left untouched."""
         from apps.dynamic_settings.models import Setting
 
-        # Create a modified default setting (has previous_value)
+        # Setting that exists in the DB (written manually, e.g. via API or dbshell)
         self.create_test_setting("ANONYMIZED_DATA_COLLECTION", False, True)
 
-        # Run the command with --overwrite
         self.setup_command_output()
         options = {"overwrite": True}
         self.command._handle_init_default_settings_command(options)
 
-        # Verify setting was recreated with default value
-        assert Setting.objects.filter(setting_key="ANONYMIZED_DATA_COLLECTION").exists()
+        # ANONYMIZED_DATA_COLLECTION is not in DEFAULT_SETTINGS → not removed, not re-created
         setting = Setting.objects.get(setting_key="ANONYMIZED_DATA_COLLECTION")
-        # Value should be reset to default (True) and previous_value should be None
-        assert json.loads(setting.current_value) is True
-        assert setting.previous_value is None
+        assert json.loads(setting.current_value) is False
+        assert json.loads(setting.previous_value) is True
 
-        # Check output
         output = self.out.getvalue()
         assert "Initialized default settings" in output
 
@@ -436,32 +420,22 @@ class TestInitDefaultSettingsCommand(BaseCommandTestCase):
         self.assert_subcommand_exists(parser, "remove-default-settings")
 
     def test_handle_remove_default_settings_removes_unchanged_settings(self):
-        """Test that _handle_remove_default_settings_command only removes unchanged default settings."""
+        """AAP-77009: remove-default-settings is a no-op when DEFAULT_SETTINGS is empty.
+        Feature flags are env-var driven; only all_settings=True removes DB rows."""
         from apps.dynamic_settings.models import Setting
 
-        # Create unchanged default setting (previous_value is None)
         self.create_test_setting("ANONYMIZED_DATA_COLLECTION", True, None)
-
-        # Create a non-default setting
         self.create_test_setting("CUSTOM_SETTING", "test", None)
+        assert Setting.objects.count() == 2
 
-        initial_count = Setting.objects.count()
-        assert initial_count == 2
-
-        # Run the command
         self.setup_command_output()
         options = {"all_known": False, "all_settings": False}
         self.command._handle_remove_default_settings_command(options)
 
-        # Verify only unchanged default settings were removed
-        assert Setting.objects.count() == 1
-        assert not Setting.objects.filter(setting_key="ANONYMIZED_DATA_COLLECTION").exists()
-        # Custom setting should remain
-        assert Setting.objects.filter(setting_key="CUSTOM_SETTING").exists()
-
-        # Check output
+        # DEFAULT_SETTINGS is empty — neither setting is "known", so nothing is removed
+        assert Setting.objects.count() == 2
         output = self.out.getvalue()
-        assert "Removed 1 settings" in output
+        assert "Removed 0 settings" in output
 
     def test_handle_remove_default_settings_when_none_exist(self):
         """Test that _handle_remove_default_settings_command handles no settings gracefully."""
@@ -480,21 +454,18 @@ class TestInitDefaultSettingsCommand(BaseCommandTestCase):
         assert "Removed 0 settings" in output
 
     def test_handle_remove_default_settings_via_handle(self):
-        """Test that remove-default-settings command works via handle method."""
+        """AAP-77009: remove-default-settings via handle is a no-op when DEFAULT_SETTINGS is empty."""
         from apps.dynamic_settings.models import Setting
 
-        # Create a default setting
         self.create_test_setting("ANONYMIZED_DATA_COLLECTION", True, None)
 
-        # Run via handle method
         self.setup_command_output()
         options = {"command": "remove-default-settings", "all_known": False, "all_settings": False}
         self.command.handle(**options)
 
-        # Verify setting was removed
-        assert not Setting.objects.filter(setting_key="ANONYMIZED_DATA_COLLECTION").exists()
+        # Not in DEFAULT_SETTINGS → not removed
+        assert Setting.objects.filter(setting_key="ANONYMIZED_DATA_COLLECTION").exists()
 
-        # Check output
         output = self.out.getvalue()
         assert "Removed" in output
 
@@ -515,32 +486,22 @@ class TestInitDefaultSettingsCommand(BaseCommandTestCase):
         assert "Database error" in str(exc_info.value)
 
     def test_handle_remove_default_settings_with_all_known(self):
-        """Test that _handle_remove_default_settings_command with --all-known removes even modified settings."""
+        """AAP-77009: --all-known only removes keys in DEFAULT_SETTINGS. Since DEFAULT_SETTINGS
+        is empty, all settings are left untouched regardless of all_known=True."""
         from apps.dynamic_settings.models import Setting
 
-        # Create unchanged default setting
         self.create_test_setting("ANONYMIZED_DATA_COLLECTION", True, None)
-
-        # Create a non-default setting
         self.create_test_setting("CUSTOM_SETTING", "test", None)
+        assert Setting.objects.count() == 2
 
-        initial_count = Setting.objects.count()
-        assert initial_count == 2
-
-        # Run the command with --all-known
         self.setup_command_output()
         options = {"all_known": True, "all_settings": False}
         self.command._handle_remove_default_settings_command(options)
 
-        # Verify default setting was removed
-        assert Setting.objects.count() == 1
-        assert not Setting.objects.filter(setting_key="ANONYMIZED_DATA_COLLECTION").exists()
-        # Custom setting should remain
-        assert Setting.objects.filter(setting_key="CUSTOM_SETTING").exists()
-
-        # Check output
+        # Nothing in DEFAULT_SETTINGS → nothing removed by all_known path
+        assert Setting.objects.count() == 2
         output = self.out.getvalue()
-        assert "Removed 1 settings" in output
+        assert "Removed 0 settings" in output
 
     def test_handle_remove_default_settings_with_all_settings(self):
         """Test that _handle_remove_default_settings_command with --all-settings removes all settings."""

--- a/tests/unit/tasks/test_feature_enabled_db.py
+++ b/tests/unit/tasks/test_feature_enabled_db.py
@@ -37,7 +37,7 @@ class TestFeatureEnabledDB(TestCase):
         result = get_feature_enabled_from_db("NONEXISTENT_SETTING", default=False)
         assert result is False
 
-    @override_settings(FEATURE_ENABLED={"TEST_SETTING": True})
+    @override_settings(FEATURE={"TEST_SETTING": True})
     def test_get_feature_enabled_from_django_settings(self):
         """Test getting feature enabled from Django settings when no DB setting."""
         result = get_feature_enabled_from_db("TEST_SETTING", default=False)
@@ -111,7 +111,7 @@ class TestFeatureEnabledAAPFlagFallback(TestCase):
 
     Priority chain:
       1. dynamic_settings.Setting         (runtime DB override)
-      2. settings.FEATURE_ENABLED         (when the key is present, e.g. env overrides)
+      2. settings.FEATURE         (when the key is present, e.g. env overrides)
       3. settings.FEATURE_<name>_ENABLED  (top-level attr, set directly by installer settings.yaml)
       4. AAPFlag.value                    (YAML-seeded platform default)
       5. default argument
@@ -170,7 +170,7 @@ class TestFeatureEnabledAAPFlagFallback(TestCase):
         )
 
     # ------------------------------------------------------------------
-    # Priority: Setting > FEATURE_ENABLED (if key present) > AAPFlag > default
+    # Priority: Setting > FEATURE (if key present) > AAPFlag > default
     # ------------------------------------------------------------------
 
     def test_dynamic_setting_takes_precedence_over_aap_flag(self):
@@ -188,55 +188,55 @@ class TestFeatureEnabledAAPFlagFallback(TestCase):
 
         assert result is True  # Setting wins
 
-    @override_settings(FEATURE_ENABLED={"FALLBACK_FLAG": True})
+    @override_settings(FEATURE={"FALLBACK_FLAG": True})
     def test_feature_enabled_takes_precedence_over_aap_flag(self):
-        """settings.FEATURE_ENABLED wins when the key is present (e.g. deployment env)."""
+        """settings.FEATURE wins when the key is present (e.g. deployment env)."""
         # AAPFlag says False; settings says True — settings wins
         with self._patch_aap_flag(self._make_mock_flag("False")):
             result = get_feature_enabled_from_db("FALLBACK_FLAG", default=True)
 
         assert result is True
 
-    @override_settings(FEATURE_ENABLED={"DASHBOARD_COLLECTION": True})
+    @override_settings(FEATURE={"DASHBOARD_COLLECTION": True})
     def test_dashboard_collection_feature_enabled_overrides_false_aap_flag(self):
-        """Env-style FEATURE_ENABLED must win over a false AAPFlag for dashboard collection."""
+        """Env-style FEATURE must win over a false AAPFlag for dashboard collection."""
         with self._patch_aap_flag(self._make_mock_flag("False")):
             assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=False) is True
 
     def test_dashboard_collection_uses_aap_flag_when_omitted_from_feature_enabled(self):
-        """When the key is absent from FEATURE_ENABLED, the platform AAPFlag applies."""
-        with self._patch_aap_flag(self._make_mock_flag("True")), override_settings(FEATURE_ENABLED={}):
+        """When the key is absent from FEATURE, the platform AAPFlag applies."""
+        with self._patch_aap_flag(self._make_mock_flag("True")), override_settings(FEATURE={}):
             assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=False) is True
 
-    @override_settings(FEATURE_ENABLED={}, FEATURE_DASHBOARD_COLLECTION_ENABLED=True)
+    @override_settings(FEATURE={}, FEATURE_DASHBOARD_COLLECTION_ENABLED=True)
     def test_direct_top_level_attr_overrides_false_aap_flag(self):
         """FEATURE_<name>_ENABLED top-level attr (installer convention) wins over a false AAPFlag."""
         with self._patch_aap_flag(self._make_mock_flag("False")):
             assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=False) is True
 
-    @override_settings(FEATURE_ENABLED={}, FEATURE_DASHBOARD_COLLECTION_ENABLED=False)
+    @override_settings(FEATURE={}, FEATURE_DASHBOARD_COLLECTION_ENABLED=False)
     def test_direct_top_level_attr_false_overrides_true_aap_flag(self):
         """FEATURE_<name>_ENABLED=False suppresses a true AAPFlag."""
         with self._patch_aap_flag(self._make_mock_flag("True")):
             assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=True) is False
 
-    @override_settings(FEATURE_ENABLED={"DASHBOARD_COLLECTION": True}, FEATURE_DASHBOARD_COLLECTION_ENABLED=False)
+    @override_settings(FEATURE={"DASHBOARD_COLLECTION": True}, FEATURE_DASHBOARD_COLLECTION_ENABLED=False)
     def test_feature_enabled_dict_takes_precedence_over_direct_attr(self):
-        """FEATURE_ENABLED dict (tier 2) beats the top-level attr (tier 3)."""
+        """FEATURE dict (tier 2) beats the top-level attr (tier 3)."""
         with self._patch_aap_flag(self._make_mock_flag("False")):
             assert get_feature_enabled_from_db("DASHBOARD_COLLECTION", default=False) is True
 
-    @override_settings(FEATURE_ENABLED={"SETTINGS_FLAG": True})
+    @override_settings(FEATURE={"SETTINGS_FLAG": True})
     def test_feature_enabled_settings_used_when_no_aap_flag(self):
-        """settings.FEATURE_ENABLED is used when AAPFlag returns None."""
+        """settings.FEATURE is used when AAPFlag returns None."""
         with self._patch_aap_flag(None):
             result = get_feature_enabled_from_db("SETTINGS_FLAG", default=False)
 
         assert result is True
 
     def test_default_used_when_nothing_found(self):
-        """default argument is returned when Setting, FEATURE_ENABLED key, and AAPFlag all miss."""
-        with self._patch_aap_flag(None), override_settings(FEATURE_ENABLED={}):
+        """default argument is returned when Setting, FEATURE key, and AAPFlag all miss."""
+        with self._patch_aap_flag(None), override_settings(FEATURE={}):
             assert get_feature_enabled_from_db("NONEXISTENT", default=True) is True
             assert get_feature_enabled_from_db("NONEXISTENT", default=False) is False
 
@@ -251,7 +251,7 @@ class TestFeatureEnabledAAPFlagFallback(TestCase):
 
         with (
             patch("ansible_base.feature_flags.models.AAPFlag", mock_aap_flag_class),
-            override_settings(FEATURE_ENABLED={}),
+            override_settings(FEATURE={}),
         ):
             result = get_feature_enabled_from_db("ERR_FLAG", default=True)
 

--- a/tests/unit/tasks/test_feature_enabled_db.py
+++ b/tests/unit/tasks/test_feature_enabled_db.py
@@ -8,8 +8,11 @@ with fallback to Django settings and defaults.
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
+
+pytestmark = pytest.mark.unit
 
 from apps.tasks.task_groups import (
     get_feature_enabled_from_db,

--- a/tests/unit/tasks/test_feature_enabled_db.py
+++ b/tests/unit/tasks/test_feature_enabled_db.py
@@ -12,12 +12,12 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 
-pytestmark = pytest.mark.unit
-
 from apps.tasks.task_groups import (
     get_feature_enabled_from_db,
 )
 from tests.test_utils import get_test_password
+
+pytestmark = pytest.mark.unit
 
 User = get_user_model()
 

--- a/tests/unit/tasks/test_task_groups.py
+++ b/tests/unit/tasks/test_task_groups.py
@@ -10,8 +10,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.test import TestCase, override_settings
 
-pytestmark = pytest.mark.unit
-
 from apps.tasks.task_groups import (
     ANONYMIZATION_GROUP,
     METRICS_COLLECTION_GROUP,
@@ -20,6 +18,8 @@ from apps.tasks.task_groups import (
     get_all_enabled_tasks,
     get_all_tasks_for_init,
 )
+
+pytestmark = pytest.mark.unit
 
 # override_settings replaces the entire FEATURE dict; include both keys when tests need
 # metrics collectors plus anonymization tasks from get_all_enabled_tasks().

--- a/tests/unit/tasks/test_task_groups.py
+++ b/tests/unit/tasks/test_task_groups.py
@@ -18,7 +18,7 @@ from apps.tasks.task_groups import (
     get_all_tasks_for_init,
 )
 
-# override_settings replaces the entire FEATURE_ENABLED dict; include both keys when tests need
+# override_settings replaces the entire FEATURE dict; include both keys when tests need
 # metrics collectors plus anonymization tasks from get_all_enabled_tasks().
 _FLAGS_METRICS_AND_ANON_ON = {"METRICS_COLLECTION": True, "ANONYMIZED_DATA_COLLECTION": True}
 _FLAGS_METRICS_ON_ANON_OFF = {"METRICS_COLLECTION": True, "ANONYMIZED_DATA_COLLECTION": False}
@@ -47,7 +47,7 @@ class TestTaskGroup(TestCase):
         assert group.description == "Test group"
         assert len(group.tasks) == 1
 
-    @override_settings(FEATURE_ENABLED={"TEST_FLAG": True})
+    @override_settings(FEATURE={"TEST_FLAG": True})
     def test_get_enabled_tasks_with_flag_true(self):
         """Test tasks are enabled when group's feature flag is True."""
         group = TaskGroup(
@@ -66,7 +66,7 @@ class TestTaskGroup(TestCase):
         enabled_tasks = group.get_enabled_tasks()
         assert len(enabled_tasks) == 1
 
-    @override_settings(FEATURE_ENABLED={"TEST_FLAG": False})
+    @override_settings(FEATURE={"TEST_FLAG": False})
     def test_get_enabled_tasks_with_flag_false(self):
         """Test tasks are disabled when group's feature flag is False."""
         group = TaskGroup(
@@ -127,7 +127,7 @@ class TestTaskGroup(TestCase):
         assert len(enabled_tasks) == 1
         assert enabled_tasks[0]["task_id"] == "task1"
 
-    @override_settings(FEATURE_ENABLED={"TEST_FLAG": True})
+    @override_settings(FEATURE={"TEST_FLAG": True})
     def test_get_enabled_tasks_with_task_enabled_false(self):
         """Test that individual tasks can be disabled via enabled field."""
         tasks = [
@@ -169,7 +169,7 @@ class TestPredefinedTaskGroups(TestCase):
         assert "daily_task_cleanup" in task_ids
         assert "hourly_health_check" in task_ids
 
-    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_ON_ANON_OFF)
+    @override_settings(FEATURE=_FLAGS_METRICS_ON_ANON_OFF)
     def test_metrics_collection_group_respects_feature_flag(self):
         """Test metrics collection group is gated by METRICS_COLLECTION (default-on in production settings)."""
         assert METRICS_COLLECTION_GROUP.name == "metrics_collection"
@@ -192,7 +192,7 @@ class TestPredefinedTaskGroups(TestCase):
         assert "daily_anonymize" not in task_ids
         assert "send_to_segment_daily" not in task_ids
 
-    @override_settings(FEATURE_ENABLED={"METRICS_COLLECTION": False})
+    @override_settings(FEATURE={"METRICS_COLLECTION": False})
     def test_metrics_collection_group_disabled(self):
         """When METRICS_COLLECTION is false, the group contributes no enabled tasks."""
         assert METRICS_COLLECTION_GROUP.get_enabled_tasks() == []
@@ -205,19 +205,19 @@ class TestPredefinedTaskGroups(TestCase):
         task_ids = [task["task_id"] for task in ANONYMIZATION_GROUP.tasks]
         assert set(task_ids) == {"daily_anonymize"}
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": True})
+    @override_settings(FEATURE={"ANONYMIZED_DATA_COLLECTION": True})
     def test_anonymization_group_enabled(self):
         """Test ANONYMIZATION_GROUP returns both tasks when flag is enabled."""
         task_ids = [task["task_id"] for task in ANONYMIZATION_GROUP.get_enabled_tasks()]
         assert "daily_anonymize" in task_ids
         assert "send_to_segment_daily" not in task_ids
 
-    @override_settings(FEATURE_ENABLED={"ANONYMIZED_DATA_COLLECTION": False})
+    @override_settings(FEATURE={"ANONYMIZED_DATA_COLLECTION": False})
     def test_anonymization_group_disabled(self):
         """Test ANONYMIZATION_GROUP returns no tasks when flag is disabled."""
         assert ANONYMIZATION_GROUP.get_enabled_tasks() == []
 
-    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_AND_ANON_ON)
+    @override_settings(FEATURE=_FLAGS_METRICS_AND_ANON_ON)
     def test_no_duplicate_cron_slots(self):
         """Assert that no two enabled tasks across all groups share the same cron hour:minute slot.
 
@@ -257,7 +257,7 @@ class TestPredefinedTaskGroups(TestCase):
 class TestTaskGroupFunctions(TestCase):
     """Test utility functions for task groups."""
 
-    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_ON_ANON_OFF)
+    @override_settings(FEATURE=_FLAGS_METRICS_ON_ANON_OFF)
     def test_get_all_enabled_tasks_flag_false(self):
         """Metrics collection tasks stay on; anonymization tasks absent when ANONYMIZED_DATA_COLLECTION is false."""
         all_tasks = get_all_enabled_tasks()
@@ -281,7 +281,7 @@ class TestTaskGroupFunctions(TestCase):
             assert "group" in task_config
             assert "group_description" in task_config
 
-    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_AND_ANON_ON)
+    @override_settings(FEATURE=_FLAGS_METRICS_AND_ANON_ON)
     def test_get_all_enabled_tasks_flag_true(self):
         """All tasks including anonymize/send are present when flag is true."""
         all_tasks = get_all_enabled_tasks()
@@ -291,7 +291,7 @@ class TestTaskGroupFunctions(TestCase):
         assert "hourly_job_host_summary" in task_ids
         assert "daily_metrics_rollup" in task_ids
 
-    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_ON_ANON_OFF)
+    @override_settings(FEATURE=_FLAGS_METRICS_ON_ANON_OFF)
     def test_get_all_tasks_for_init_includes_flagged_tasks(self):
         """get_all_tasks_for_init() returns anonymize and metrics tasks regardless of flag values."""
         all_tasks = get_all_tasks_for_init()
@@ -315,7 +315,7 @@ class TestTaskGroupFunctions(TestCase):
         # hourly_job_events has enabled=False in METRICS_COLLECTION_GROUP
         assert "hourly_job_events" not in all_tasks
 
-    @override_settings(FEATURE_ENABLED={"METRICS_COLLECTION": False, "ANONYMIZED_DATA_COLLECTION": True})
+    @override_settings(FEATURE={"METRICS_COLLECTION": False, "ANONYMIZED_DATA_COLLECTION": True})
     def test_get_all_enabled_tasks_metrics_collection_false_excludes_pipeline(self):
         """When METRICS_COLLECTION is false, hourly/daily collectors and rollup/cleanup are omitted."""
         all_tasks = get_all_enabled_tasks()
@@ -345,7 +345,7 @@ class TestTaskGroupIntegration(TestCase):
         assert scheduler == mock_scheduler
         assert scheduler.running is True
 
-    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_AND_ANON_ON)
+    @override_settings(FEATURE=_FLAGS_METRICS_AND_ANON_ON)
     def test_all_flags_enabled(self):
         """Test that all tasks are present when ANONYMIZED_DATA_COLLECTION is enabled."""
         all_tasks = get_all_enabled_tasks()
@@ -361,7 +361,7 @@ class TestTaskGroupIntegration(TestCase):
         # Anonymization tasks (from ANONYMIZATION_GROUP, enabled when flag is true)
         assert "daily_anonymize" in task_ids
 
-    @override_settings(FEATURE_ENABLED=_FLAGS_METRICS_ON_ANON_OFF)
+    @override_settings(FEATURE=_FLAGS_METRICS_ON_ANON_OFF)
     def test_flag_false_stops_only_anonymize_send(self):
         """When ANONYMIZED_DATA_COLLECTION is false but METRICS_COLLECTION is true, only anonymize is absent."""
         all_tasks = get_all_enabled_tasks()

--- a/tests/unit/tasks/test_task_groups.py
+++ b/tests/unit/tasks/test_task_groups.py
@@ -7,7 +7,10 @@ task categorization, and integration with the cron scheduler.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.test import TestCase, override_settings
+
+pytestmark = pytest.mark.unit
 
 from apps.tasks.task_groups import (
     ANONYMIZATION_GROUP,


### PR DESCRIPTION
## Summary

Fixes [AAP-77009](https://redhat.atlassian.net/browse/AAP-77009) — `MetricsService` CR fields `spec.metrics_service.anonymized_data` and `spec.metrics_service.metrics_collection` had no effect on the feature flags that actually gate task execution.

### Root cause

`METRICS_COLLECTION` and `ANONYMIZED_DATA_COLLECTION` were listed in `DEFAULT_SETTINGS` in `apps/dynamic_settings/utils.py`, which caused `init-default-settings` to pre-seed them into the `dynamic_settings_setting` DB table with hardcoded `True` defaults. Once a row existed in the DB, `get_feature_enabled_from_db` returned the DB value unconditionally — any operator env var override was ignored at runtime.

### Fix

Two changes:

**1. Rename `FEATURE_ENABLED` → `FEATURE`**

The Django settings dict is renamed from `FEATURE_ENABLED` to `FEATURE`. The dynaconf env var prefix changes accordingly:

| Old prefix | New prefix |
|---|---|
| `METRICS_SERVICE_FEATURE_ENABLED__*` | `METRICS_SERVICE_FEATURE__*` |

**2. Remove `METRICS_COLLECTION` and `ANONYMIZED_DATA_COLLECTION` from `DEFAULT_SETTINGS`**

These flags are no longer pre-seeded into the DB by `init-default-settings`. They resolve from the `FEATURE` dict (step 2 of `get_feature_enabled_from_db`) — identical to the existing `DASHBOARD_COLLECTION` pattern that already works correctly.

---

## Feature flag env vars (post-change)

| Flag | Env var | Default |
|---|---|---|
| Disable local metrics collection | `METRICS_SERVICE_FEATURE__METRICS_COLLECTION=false` | `true` |
| Opt out of anonymized data transmission to Red Hat | `METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION=false` | `true` |
| Enable dashboard collection (automation-reports) | `METRICS_SERVICE_FEATURE__DASHBOARD_COLLECTION=true` | `false` |

Set these in the operator-managed ConfigMap (`extra_settings`) or directly in the container environment. Changes take effect on pod restart; no DB manipulation required.

---

## Backwards compatibility

| Scenario | Behaviour |
|---|---|
| **Existing deployment, DB row present** (including customers who used the `dbshell` workaround) | **Unchanged.** `get_feature_enabled_from_db` checks the DB first (step 1). Any existing row — whether seeded by the old `init-default-settings`, written via the API, or set via `dbshell` — continues to be respected. |
| **Existing deployment, DB row present, `init-default-settings` re-run after upgrade** | **Improved.** Previously, re-running `init-default-settings` would delete unchanged rows (those with `previous_value=None`, which includes `dbshell`-written rows) and re-seed them with `True`. Now `init-default-settings` no longer touches these rows at all — the dbshell-set value survives upgrades. |
| **Fresh install, no env var** | `FEATURE["METRICS_COLLECTION"]` and `FEATURE["ANONYMIZED_DATA_COLLECTION"]` both default to `True` — no behavioural change. |
| **Fresh install, env var set** | `METRICS_SERVICE_FEATURE__ANONYMIZED_DATA_COLLECTION=false` now correctly disables the flag. Previously this was silently ignored. |

The `remove-default-settings` management command is also now a no-op for these two flags (since they are no longer "known defaults"). Use `--all-settings` to clear all DB rows unconditionally.

---

## Files changed

- `apps/settings/defaults.py` — `FEATURE_ENABLED` → `FEATURE`, updated comment
- `apps/settings/test.py` — same rename
- `apps/tasks/task_groups.py` — `getattr(settings, "FEATURE_ENABLED", {})` → `FEATURE`; docstrings updated
- `apps/dynamic_settings/utils.py` — removed `METRICS_COLLECTION` and `ANONYMIZED_DATA_COLLECTION` from `DEFAULT_SETTINGS` (now `{}`); updated `getattr` call
- `docker-compose.yml`, `README.md`, `CLAUDE.md`, performance test README — env var prefix updated
- Tests — `override_settings(FEATURE_ENABLED=...)` → `override_settings(FEATURE=...)`; assertions updated to reflect no DB seeding

---

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.