### PR TITLE
fix: treat empty string cron_expression as non-recurring in cleanup

### DIFF
--- a/apps/tasks/cleanup/cleanup_old_tasks.py
+++ b/apps/tasks/cleanup/cleanup_old_tasks.py
@@ -10,6 +10,7 @@ import logging
 from datetime import timedelta
 from typing import Any
 
+from django.db.models import Q
 from django.utils import timezone
 
 from ..utils import create_task_result, log_task_execution
@@ -58,10 +59,6 @@ def cleanup_old_tasks(**kwargs) -> dict[str, Any]:
         "completed_at__isnull": False,
     }
 
-    # Exclude recurring tasks if preserve_recurring is True (default)
-    if preserve_recurring:
-        old_tasks_filter["cron_expression__isnull"] = True
-
     old_tasks = Task.objects.filter(**old_tasks_filter)
 
     # Also include tasks that don't have completed_at but are old based on modified date
@@ -71,14 +68,14 @@ def cleanup_old_tasks(**kwargs) -> dict[str, Any]:
         "modified__lt": cutoff_date,
     }
 
-    # Exclude recurring tasks if preserve_recurring is True (default)
-    if preserve_recurring:
-        old_tasks_fallback_filter["cron_expression__isnull"] = True
-
     old_tasks_fallback = Task.objects.filter(**old_tasks_fallback_filter)
 
     # Combine querysets
     old_tasks = old_tasks | old_tasks_fallback
+
+    # Exclude genuine recurring tasks (non-null, non-empty cron_expression)
+    if preserve_recurring:
+        old_tasks = old_tasks.filter(Q(cron_expression__isnull=True) | Q(cron_expression=""))
 
     task_count = old_tasks.count()
     execution_count = 0

--- a/tests/unit/tasks/cleanup/test_cleanup_old_tasks.py
+++ b/tests/unit/tasks/cleanup/test_cleanup_old_tasks.py
@@ -356,14 +356,10 @@ class TestCleanupOldTasks:
         result = cleanup_old_tasks(days_old=30, dry_run=False, preserve_recurring=True)
 
         # Assert
-        # Empty string and NULL should be deleted, but valid cron should be preserved
-        # FIXME: This test will fail until we also update the cleanup filter
-        # For now, we're only fixing the serializer to prevent new tasks from having empty strings
-        assert result["tasks_deleted"] == 1  # Only task_with_null should be deleted
+        # Both NULL and empty string cron_expression are treated as non-recurring and deleted
+        assert result["tasks_deleted"] == 2
         assert not Task.objects.filter(id=task_with_null.id).exists()
-
-        # Empty string task still exists (bug) - will be fixed in cleanup filter
-        assert Task.objects.filter(id=task_with_empty_string.id).exists()
+        assert not Task.objects.filter(id=task_with_empty_string.id).exists()
 
         # Valid cron task should still exist
         assert Task.objects.filter(id=task_with_valid_cron.id).exists()


### PR DESCRIPTION
# fix: treat empty string cron_expression as non-recurring in cleanup

## Description
- **What:** The `cleanup_old_tasks` function was incorrectly preserving tasks with `cron_expression=""` (empty string), treating them as recurring scheduled tasks.
- **Why:** Tasks created via an older API bug could have an empty string instead of NULL for `cron_expression`. The filter used `cron_expression__isnull=True` which only excluded NULL values — empty strings slipped through and accumulated in the database indefinitely.
- **How:** Replaced the two separate pre-filter dict entries with a single `Q(cron_expression__isnull=True) | Q(cron_expression="")` filter applied after combining both querysets. Also updates the pre-existing `FIXME` test to assert the correct behavior.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases

## Testing Instructions
### Steps to Test
1. Run the unit test suite: `pytest tests/unit/tasks/cleanup/test_cleanup_old_tasks.py -v`
2. Verify `test_cleans_up_tasks_with_empty_cron_expression` passes (previously had a `FIXME` noting it documented buggy behavior)
3. Verify all other cleanup tests continue to pass

### Expected Results
All tests in `test_cleanup_old_tasks.py` pass, including the previously-broken `test_cleans_up_tasks_with_empty_cron_expression` which now correctly asserts both NULL and empty-string tasks are deleted while valid cron tasks are preserved.

## Additional Context

**Root cause:** `cron_expression__isnull=True` in a Django filter dict only generates `WHERE cron_expression IS NULL` — it does not match empty strings. Tasks with `cron_expression=""` were excluded from deletion when `preserve_recurring=True`.

**Risk assessment:** Low. The change only affects the cleanup path for tasks with an empty-string cron_expression, which should not exist in new data (the serializer was already fixed to prevent this). This clears out the stale accumulation from the old bug.

---
> This PR was created by **Debuggernaut** (autonomous bug-fixing agent).
> Root cause identified via FIXME in `tests/unit/tasks/cleanup/test_cleanup_old_tasks.py:360`.