### PR TITLE
[LOCAL-001] fix: update modified timestamp when failing stuck tasks via bulk update

### DIFF
--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -219,10 +219,10 @@ class UnifiedTaskScheduler:
                 error_msg = "Task timed out — worker died before completion"
                 with transaction.atomic():
                     TaskExecution.objects.filter(task__id__in=ids, status="running").update(
-                        status="failed", error_message=error_msg, completed_at=now
+                        status="failed", error_message=error_msg, completed_at=now, modified=now
                     )
                     Task.objects.filter(id__in=ids, status="running").update(
-                        status="failed", error_message=error_msg, completed_at=now
+                        status="failed", error_message=error_msg, completed_at=now, modified=now
                     )
                 logger.warning(f"Failed {len(ids)} stuck task(s): {ids}")
 

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -605,3 +605,25 @@ class TestStuckTaskDetection:
         execution.refresh_from_db()
         assert execution.status == "failed"
         assert execution.completed_at is not None
+
+    def test_updates_modified_when_failing_stuck_task(self, user):
+        """QuerySet.update() bypasses auto_now — modified must be set explicitly."""
+        from apps.tasks.models import Task
+
+        old_time = timezone.now() - timedelta(hours=2)
+        task = Task.objects.create(
+            name="Stuck Task Modified",
+            function_name="hello_world",
+            task_data={},
+            created_by=user,
+            status="running",
+        )
+        Task.objects.filter(id=task.id).update(started_at=old_time, modified=old_time)
+        task.refresh_from_db()
+        pre_sync_modified = task.modified
+
+        self._run_sync(UnifiedTaskScheduler())
+
+        task.refresh_from_db()
+        assert task.status == "failed"
+        assert task.modified > pre_sync_modified


### PR DESCRIPTION
## Summary

- `_periodic_database_sync()` detects tasks stuck in `running` beyond `TASK_TIMEOUT` and fails them via `QuerySet.update()`.
- `QuerySet.update()` bypasses Django's `auto_now=True`, so the `modified` field on both `Task` and `TaskExecution` was left stale — showing the last normal `save()` time, not when the watchdog acted.
- Fix: pass `modified=now` explicitly in both `update()` calls so auditing and any downstream code filtering by `modified` sees the correct timestamp.

## Test plan

- [ ] New unit test `test_updates_modified_when_failing_stuck_task` in `TestStuckTaskDetection` forces `modified` into the past, runs `_periodic_database_sync`, and asserts `task.modified` advanced past its old value.
- [ ] All existing `TestStuckTaskDetection` tests should continue to pass.
- [ ] Run `pytest tests/unit/tasks/test_cron_scheduler.py -k StuckTask` locally to verify.

---
*Assisted-by: Debuggernaut (claude-opus-4-6) <noreply@anthropic.com> | Review carefully before merging.*