### PR TITLE
chore: update tekton pipeline bundle digest

### DIFF
--- a/.tekton/run-atf-tests-pull-request.yaml
+++ b/.tekton/run-atf-tests-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
       - name: name
         value: aap-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-api-tests:0.1@sha256:dd37bf732097b6fabde6a35bc732175484c77db919947d6fc1fe661a3bf4c705
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-api-tests:0.1@sha256:0c1621395487e9305fb7652feb6d65071018953a199b991dcf520bd50c0b05ef
       - name: kind
         value: pipeline
       - name: secret

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,6 @@
   "tekton": {
     "enabled": true,
     "automerge": true,
-    "schedule": ["0 */12 * * 1-5"]
+    "schedule": ["* */12 * * 1-5"]
   }
 }


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
- Why is this change needed?
- How does this change address the issue?
This PR manually updates the pipeline bundle digest ahead of mint maker to unblock pipeline runs (failing in the report-test-results-to-pr) task.

Closes #270 


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Test update