### PR TITLE
Reconnect after dead connection

### DIFF
--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -303,14 +303,11 @@ def get_db_connection(db_name: str = "awx"):
     to use the raw connection for metrics-utility collectors that use COPY
     for efficient data extraction.
 
-    This function ensures the connection is healthy by calling close_old_connections()
-    which closes stale/unusable connections and respects CONN_MAX_AGE settings.
-
     Args:
         db_name: Database name from Django settings (default: 'awx')
 
     Returns:
-        Raw database connection object (psycopg2 connection)
+        Raw database connection object (psycopg3 connection)
 
     Note:
         DO NOT CLOSE the returned connection. It is a Django-managed singleton
@@ -324,10 +321,21 @@ def get_db_connection(db_name: str = "awx"):
     # including the default connection that may be holding advisory locks in run_with_lock()
     django_connection = connections[db_name]
 
-    # Ensure the connection is open
+    # Django's ensure_connection() only reconnects when self.connection is None.
+    # A connection dropped by the server is not None — it is a stale psycopg3
+    # object. Probe it with SELECT 1 before handing it to the collector:
+    #   - catches connections already marked closed (.closed == True)
+    #   - catches silent network drops where .closed is still False
+    # Five collectors run per hour so the round-trip overhead is negligible.
+    if django_connection.connection is not None:
+        try:
+            django_connection.connection.execute("SELECT 1")
+        except Exception:
+            logger.warning(f"Database connection '{db_name}' is stale, reconnecting")
+            django_connection.close()
+
     django_connection.ensure_connection()
 
-    # Return the raw psycopg2 connection
     return django_connection.connection
 
 

--- a/tests/unit/tasks/test_tasks_utils_comprehensive.py
+++ b/tests/unit/tasks/test_tasks_utils_comprehensive.py
@@ -275,6 +275,7 @@ class TestGetDbConnection(TestCase):
         close_old_connections() should only be called at task entry points like run_with_lock().
         """
         mock_raw_conn = MagicMock()
+        mock_raw_conn.closed = False
         mock_django_conn = MagicMock()
         mock_django_conn.connection = mock_raw_conn
         mock_connections.__getitem__.return_value = mock_django_conn
@@ -286,6 +287,93 @@ class TestGetDbConnection(TestCase):
         # Verify ensure_connection was still called
         mock_django_conn.ensure_connection.assert_called_once()
         self.assertEqual(result, mock_raw_conn)
+
+    @patch("django.db.connections")
+    def test_get_db_connection_live_connection_not_reconnected(self, mock_connections):
+        """Live connection (SELECT 1 succeeds) is returned as-is without closing."""
+        mock_raw_conn = MagicMock()
+        mock_django_conn = MagicMock()
+        mock_django_conn.connection = mock_raw_conn
+        mock_connections.__getitem__.return_value = mock_django_conn
+
+        result = utils.get_db_connection()
+
+        mock_raw_conn.execute.assert_called_once_with("SELECT 1")
+        mock_django_conn.close.assert_not_called()
+        mock_django_conn.ensure_connection.assert_called_once()
+        self.assertEqual(result, mock_django_conn.connection)
+
+    @patch("django.db.connections")
+    def test_get_db_connection_no_existing_connection_skips_probe(self, mock_connections):
+        """When no connection exists yet (None), SELECT 1 is not attempted."""
+        mock_django_conn = MagicMock()
+        mock_django_conn.connection = None
+        mock_connections.__getitem__.return_value = mock_django_conn
+
+        utils.get_db_connection()
+
+        mock_django_conn.close.assert_not_called()
+        mock_django_conn.ensure_connection.assert_called_once()
+
+    @patch("django.db.connections")
+    def test_get_db_connection_stale_connection_reconnects(self, mock_connections):
+        """When SELECT 1 raises, the stale connection is discarded and a fresh one opened."""
+        stale_conn = MagicMock()
+        stale_conn.execute.side_effect = Exception("connection closed")
+
+        fresh_conn = MagicMock()
+
+        mock_django_conn = MagicMock()
+        mock_django_conn.connection = stale_conn
+
+        # After close(), connection becomes the fresh one
+        def set_fresh_after_close():
+            mock_django_conn.connection = fresh_conn
+
+        mock_django_conn.close.side_effect = lambda: set_fresh_after_close()
+        mock_connections.__getitem__.return_value = mock_django_conn
+
+        result = utils.get_db_connection()
+
+        stale_conn.execute.assert_called_once_with("SELECT 1")
+        mock_django_conn.close.assert_called_once()
+        mock_django_conn.ensure_connection.assert_called_once()
+        self.assertEqual(result, fresh_conn)
+
+    @patch("apps.tasks.utils.logger")
+    @patch("django.db.connections")
+    def test_get_db_connection_stale_connection_logs_warning(self, mock_connections, mock_logger):
+        """A stale connection triggers a WARNING log before reconnecting."""
+        mock_raw_conn = MagicMock()
+        mock_raw_conn.execute.side_effect = Exception("server closed the connection unexpectedly")
+        mock_django_conn = MagicMock()
+        mock_django_conn.connection = mock_raw_conn
+        mock_connections.__getitem__.return_value = mock_django_conn
+
+        utils.get_db_connection("awx")
+
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        self.assertIn("awx", warning_msg)
+        self.assertIn("stale", warning_msg)
+
+    @patch("django.db.connections")
+    def test_get_db_connection_reconnect_failure_propagates(self, mock_connections):
+        """If ensure_connection() raises after a stale probe, the exception propagates cleanly."""
+        from django.db.utils import OperationalError
+
+        mock_raw_conn = MagicMock()
+        mock_raw_conn.execute.side_effect = Exception("connection closed")
+        mock_django_conn = MagicMock()
+        mock_django_conn.connection = mock_raw_conn
+        mock_django_conn.ensure_connection.side_effect = OperationalError("could not connect to server")
+        mock_connections.__getitem__.return_value = mock_django_conn
+
+        with self.assertRaises(OperationalError):
+            utils.get_db_connection()
+
+        mock_django_conn.close.assert_called_once()
+        mock_django_conn.ensure_connection.assert_called_once()
 
 
 class TestRunWithLock(TestCase):


### PR DESCRIPTION
# [AAP-76920] Recconect after dead connection

If connection drops, task will fail and it will never reconnect.