### PR TITLE
feat: add hourly indirect managed nodes collector task

### DIFF
--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -27,12 +27,14 @@ def _get_hourly_collectors():
     from metrics_utility.anonymized_rollups import (
         CredentialsAnonymizedRollup,
         EventModulesAnonymizedRollup,
+        IndirectManagedNodesAnonymizedRollup,
         JobHostSummaryAnonymizedRollup,
         JobsAnonymizedRollup,
     )
     from metrics_utility.library.collectors.controller import (
         credentials_service,
         job_host_summary_service,
+        main_indirectmanagednodeaudit,
         main_jobevent_service,
         unified_jobs_dashboard,
     )
@@ -62,6 +64,11 @@ def _get_hourly_collectors():
             "collector_func": main_jobevent_service,
             "rollup_processor": EventModulesAnonymizedRollup,
             "description": "Job events (event modules) metrics",
+        },
+        "indirect_managed_nodes": {
+            "collector_func": main_indirectmanagednodeaudit,
+            "rollup_processor": IndirectManagedNodesAnonymizedRollup,
+            "description": "Indirect managed node audit metrics",
         },
     }
 

--- a/apps/tasks/models.py
+++ b/apps/tasks/models.py
@@ -343,6 +343,7 @@ class HourlyMetricsCollection(CommonModel, AuditableModel):
         ("unified_jobs", "Unified Jobs"),
         ("credentials_service", "Credentials Service"),
         ("main_jobevent_service", "Job Events (Event Modules)"),
+        ("indirect_managed_nodes", "Indirect Managed Nodes"),
         ("execution_environments", "Execution Environments"),
         ("controller_version_service", "Controller Version Service"),
         ("table_metadata", "Table Metadata"),

--- a/apps/tasks/models.py
+++ b/apps/tasks/models.py
@@ -343,7 +343,6 @@ class HourlyMetricsCollection(CommonModel, AuditableModel):
         ("unified_jobs", "Unified Jobs"),
         ("credentials_service", "Credentials Service"),
         ("main_jobevent_service", "Job Events (Event Modules)"),
-        ("indirect_managed_nodes", "Indirect Managed Nodes"),
         ("execution_environments", "Execution Environments"),
         ("controller_version_service", "Controller Version Service"),
         ("table_metadata", "Table Metadata"),

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -208,6 +208,14 @@ METRICS_COLLECTION_GROUP = TaskGroup(
             "enabled": False,  # NOT enabled by default, for performance
             "description": "Collect job events (event modules) metrics every hour",
         },
+        {
+            "task_id": "hourly_indirect_managed_nodes",
+            "function": "collect_hourly_metrics",
+            "cron": "25 * * * *",  # Every hour at XX:25
+            "args": {"collector_type": "indirect_managed_nodes"},
+            "enabled": True,
+            "description": "Collect indirect managed node audit metrics every hour",
+        },
         # Daily Snapshot Collection
         {
             "task_id": "daily_execution_environments",

--- a/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
@@ -1,0 +1,236 @@
+"""Unit tests for indirect_managed_nodes hourly collector."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from metrics_utility.metric_utils import INDIRECT
+from psycopg2 import errors as pg_errors
+
+from apps.tasks.collectors.collect_hourly_metrics import _get_hourly_collectors, collect_hourly_metrics
+from apps.tasks.models import HourlyMetricsCollection
+
+
+@pytest.mark.unit
+class TestIndirectManagedNodesCollector:
+    """Tests for indirect_managed_nodes hourly collector."""
+
+    def test_collector_registered_in_hourly_registry(self):
+        """indirect_managed_nodes is present in hourly collector registry."""
+        registry = _get_hourly_collectors()
+        assert "indirect_managed_nodes" in registry
+        entry = registry["indirect_managed_nodes"]
+        assert entry.get("collector_func") is not None
+        assert entry.get("rollup_processor") is not None
+        assert "indirect" in entry.get("description", "").lower()
+
+    @pytest.mark.django_db
+    def test_successful_collection_adds_managed_node_type_tag(self):
+        """Collector adds managed_node_type = INDIRECT to all records."""
+        sample_data = pd.DataFrame(
+            {
+                "id": [1, 2],
+                "host_name": ["host1", "host2"],
+                "created": [datetime(2024, 1, 1, tzinfo=UTC)] * 2,
+                "host_remote_id": ["remote1", "remote2"],
+            }
+        )
+
+        mock_collector = MagicMock()
+        mock_collector.gather.return_value = sample_data
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": MagicMock(return_value=mock_collector),
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+        assert result["status"] == "success"
+
+        collection = HourlyMetricsCollection.objects.get(id=result["collection_id"])
+        raw_data = collection.raw_data
+
+        # raw_data should be a list of records
+        assert isinstance(raw_data, list)
+        assert len(raw_data) == 2
+        assert all("managed_node_type" in record for record in raw_data)
+        assert all(record["managed_node_type"] == INDIRECT for record in raw_data)
+
+    @pytest.mark.django_db
+    def test_empty_result_set_succeeds(self):
+        """Empty DataFrame collection completes without error."""
+        empty_data = pd.DataFrame()
+
+        mock_collector = MagicMock()
+        mock_collector.gather.return_value = empty_data
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": MagicMock(return_value=mock_collector),
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+        assert result["status"] == "success"
+
+        collection = HourlyMetricsCollection.objects.get(id=result["collection_id"])
+        assert collection.status == "collected"
+
+    @pytest.mark.django_db
+    def test_missing_table_logs_error_and_fails_gracefully(self):
+        """When table doesn't exist, error is logged and collection fails gracefully."""
+
+        def raise_missing_table(**kwargs):
+            raise pg_errors.ProgrammingError('relation "main_indirectmanagednodeaudit" does not exist')
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": raise_missing_table,
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+        assert result["status"] == "error"
+
+        collection = HourlyMetricsCollection.objects.get(
+            collector_type="indirect_managed_nodes",
+            collection_timestamp=ts,
+        )
+        assert collection.status == "failed"
+        assert "main_indirectmanagednodeaudit" in collection.error_message
+
+    @pytest.mark.django_db
+    def test_retry_with_same_timestamp_uses_existing_record(self):
+        """Retry with same hour_timestamp returns existing collection due to unique constraint."""
+        sample_data = pd.DataFrame(
+            {
+                "id": [1],
+                "host_name": ["host1"],
+                "created": [datetime(2024, 1, 1, tzinfo=UTC)],
+            }
+        )
+
+        mock_collector = MagicMock()
+        mock_collector.gather.return_value = sample_data
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": MagicMock(return_value=mock_collector),
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result1 = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+            result2 = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+        assert result1["status"] == "success"
+        assert result2["status"] == "success"
+        assert result1["collection_id"] == result2["collection_id"]
+
+        collection_count = HourlyMetricsCollection.objects.filter(
+            collector_type="indirect_managed_nodes",
+            collection_timestamp=ts,
+        ).count()
+        assert collection_count == 1
+
+    @pytest.mark.django_db
+    def test_invalid_timestamp_format_returns_error(self):
+        """Invalid hour_timestamp format returns error without creating collection."""
+        result = collect_hourly_metrics(
+            collector_type="indirect_managed_nodes",
+            hour_timestamp="not-a-date",
+        )
+
+        assert result["status"] == "error"
+        assert "Invalid" in result["error"]
+
+    @pytest.mark.django_db
+    def test_missing_collector_type_returns_error(self):
+        """Missing collector_type parameter returns error."""
+        result = collect_hourly_metrics()
+
+        assert result["status"] == "error"
+        assert "collector_type" in result["error"]
+
+    @pytest.mark.django_db
+    def test_default_timestamp_when_not_provided(self):
+        """When no timestamp provided, collector uses previous full hour."""
+        sample_data = pd.DataFrame(
+            {
+                "id": [1],
+                "host_name": ["host1"],
+                "created": [datetime.now(UTC)],
+            }
+        )
+
+        mock_collector = MagicMock()
+        mock_collector.gather.return_value = sample_data
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": MagicMock(return_value=mock_collector),
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result = collect_hourly_metrics(collector_type="indirect_managed_nodes")
+
+        assert result["status"] == "success"
+
+        collection = HourlyMetricsCollection.objects.get(id=result["collection_id"])
+        assert collection.collection_timestamp.minute == 0
+        assert collection.collection_timestamp.second == 0
+        assert collection.collection_timestamp.microsecond == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = "==3.12.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "alabaster"
@@ -913,11 +918,12 @@ dev = [
 
 [[package]]
 name = "metrics-utility"
-version = "0.8.20260526"
+version = "0.8.20260621"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
+    { name = "cryptography" },
     { name = "distro" },
     { name = "django" },
     { name = "kubernetes" },
@@ -928,9 +934,9 @@ dependencies = [
     { name = "segment-analytics-python" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/4d/dd4cd1d42f6c2360ad0d753ca0fddf68d6415d963c54e79366e7811cd525/metrics_utility-0.8.20260526.tar.gz", hash = "sha256:5c308a9efe4448295b60174469965809f5bd9a127de97fd049004ef07ac55ed2", size = 1002481, upload-time = "2026-05-26T08:41:56.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/1c/55ece29c00de5732ac8c37e0445fa8fcfa0375b1d2e2ddf826fc129936d2/metrics_utility-0.8.20260621.tar.gz", hash = "sha256:739ceb4ad3caab765a4b6ac05a928aea2d7861a549d7b3266b38cb0763fb7f38", size = 1126344, upload-time = "2026-06-21T03:07:26.585Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/97/9d9d51b6317bdcb73ff78fe11780862552697abc01ac8f8bda16b07f44d3/metrics_utility-0.8.20260526-py3-none-any.whl", hash = "sha256:1b64a54845f82bfe7f8b875811b6085ba7616bddd383131d16c052dd09783b0d", size = 531829, upload-time = "2026-05-26T08:41:55.336Z" },
+    { url = "https://files.pythonhosted.org/packages/92/bf/3da4f8556a953697e54bb370696a26df8d0a3940dc90a2e43c1f98c9b600/metrics_utility-0.8.20260621-py3-none-any.whl", hash = "sha256:a0426e6c92a8302d529eea36428a78b6202a18026136a529b643a8a5296f8ae9", size = 584841, upload-time = "2026-06-21T03:07:25.301Z" },
 ]
 
 [[package]]
@@ -1030,14 +1036,14 @@ wheels = [
 
 [[package]]
 name = "openpyxl"
-version = "3.1.2"
+version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "et-xmlfile" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/e8/af028681d493814ca9c2ff8106fc62a4a32e4e0ae14602c2a98fc7b741c8/openpyxl-3.1.2.tar.gz", hash = "sha256:a6f5977418eff3b2d5500d54d9db50c8277a368436f4e4f8ddb1be3422870184", size = 185977, upload-time = "2023-03-11T16:58:38.78Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/94/a59521de836ef0da54aaf50da6c4da8fb4072fb3053fa71f052fd9399e7a/openpyxl-3.1.2-py2.py3-none-any.whl", hash = "sha256:f91456ead12ab3c6c2e9491cf33ba6d08357d802192379bb482f1033ade496f5", size = 249985, upload-time = "2023-03-11T16:58:36.257Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -1051,23 +1057,23 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "2.3.3"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
-    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
-    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
-    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
 ]
 
 [[package]]
@@ -1400,7 +1406,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1408,9 +1414,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
[AAP-78074] Add hourly indirect managed nodes collector task

## Description

- **What is being changed?** Added a new hourly collector task for indirect managed nodes that queries `main_indirectmanagednodeaudit` from the Controller database and stores the results in `HourlyMetricsCollection`.

- **Why is this change needed?** AAP-78074 Part 1 requires collecting indirect managed node data hourly for downstream anonymization and billing. The Controller's `main_indirectmanagednodeaudit` table (added in 4.6) tracks nodes managed indirectly through dynamic inventory.

- **How does this change address the issue?**
  - Registers `indirect_managed_nodes` collector in `_get_hourly_collectors()` registry
  - Uses existing `main_indirectmanagednodeaudit` collector from metrics-utility
  - Uses new `IndirectManagedNodesAnonymizedRollup` processor to tag records with `managed_node_type = INDIRECT`
  - Adds scheduled task to run at :25 every hour (staggered after other collectors)
  - Includes comprehensive unit test coverage (8 tests)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- metrics-utility PR with `IndirectManagedNodesAnonymizedRollup` must be merged first
- Python 3.12 environment
- PostgreSQL database
- metrics-service dependencies installed (with updated metrics-utility)

### Steps to Test

1. Run unit tests: `pytest tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py -v`
2. Sync tasks to database: `python manage.py metrics_service init-system-tasks`
3. Verify task is registered with correct schedule (cron: `25 * * * *`)

### Expected Results

- All 8 unit tests pass
- Registry contains `indirect_managed_nodes` with correct collector and rollup processor
- Manual collection completes successfully (status="success")
- Task is created in database with cron schedule "25 * * * *"
- If Controller database has `main_indirectmanagednodeaudit` table: data is collected and tagged with `managed_node_type = INDIRECT`
- If table doesn't exist: collection fails gracefully with error status (no crash)