### PR TITLE
Fix anonymize max attempts, adjust retry interval to not be multiple of 5

### DIFF
--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -295,7 +295,6 @@ ANONYMIZATION_GROUP = TaskGroup(
             "function": "daily_anonymize_and_prepare",
             "cron": "0 3 * * *",  # Daily at 3:00 AM
             "args": {},
-            "max_attempts": SEGMENT_MAX_ATTEMPTS,
             "enabled": True,
             "description": "Anonymize daily summary for Segment transmission",
         },

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -21,7 +21,7 @@ from .utils import (
 
 logger = logging.getLogger(__name__)
 
-RETRY_BASE_DELAY_SECONDS = 600  # 10 minutes - delay used for the first retry
+RETRY_BASE_DELAY_SECONDS = 480  # 8 minutes - must not be a multiple of 5 (task cron spacing) to avoid retry collisions
 RETRY_MAX_DELAY_SECONDS = 28800  # 8 hours - upper cap on any single retry delay
 
 


### PR DESCRIPTION
Noticed when reviewing #265, Cc @MilanPospisil, this might solve part of the other issue if I understand correctly?

The tasks are scheduled to start at multiples of 5 minutes, and the retry interval is set to 10 minutes, which *could* cause collisions (but probably ends up spaced 30s apart from that because of scheduler refresh).

Might as well ensure the retry is not a multiple of 5, thus going from theoretical:

| Task | Attempt 1 | Attempt 2 (+10m) | Attempt 3 (+30m) |
|---|---|---|---|
| `hourly_health_check` | **:00** | **:10** ⚠️ | **:30** |
| `hourly_job_host_summary` | **:05** | **:15** ⚠️ | **:35** |
| `hourly_unified_jobs` | **:10** ⚠️ | **:20** | **:40** |
| `hourly_credentials` | **:15** ⚠️ | **:25** | **:45** |
| `hourly_job_events` *(disabled)* | *:20* | *:30* | *:50* |

To (assuming failure randomly within 0-60s):

### option 1 - 8 minute retry

| Task | Attempt 1 | Retry 1 | Retry 2 |
|---|---|---|---|
| `hourly_health_check` | :00 | :08–:09 | :24–:26 |
| `hourly_job_host_summary` | :05 | :13–:14 | :29–:31 |
| `hourly_unified_jobs` | :10 | :18–:19 | :34–:36 |
| `hourly_credentials` | :15 | :23–:24 | :39–:41 |
| `hourly_job_events` *(disabled)* | *:20* | *:28–:29* | *:44–:46* |

No ranges overlap, two touch:

- **:24** — `credentials` retry 1 ends at :24, `health_check` retry 2 starts at :24
- **:29** — `job_events` retry 1 ends at :29, `job_host_summary` retry 2 starts at :29

### option 2 - 12 minute retry

| Task | Attempt 1 | Retry 1 | Retry 2 |
|---|---|---|---|
| `hourly_health_check` | :00 | :12–:13 | :36–:38 |
| `hourly_job_host_summary` | :05 | :17–:18 | :41–:43 |
| `hourly_unified_jobs` | :10 | :22–:23 | :46–:48 |
| `hourly_credentials` | :15 | :27–:28 | :51–:53 |
| `hourly_job_events` *(disabled)* | *:20* | *:32–:33* | *:56–:58* |

No overlaps, minimum gap is 2 minutes.

---

**Segment 7-attempt long tail:**

| | Old (10 min) | 8 min | 12 min |
|---|---|---|---|
| Retry 1 | +10m | +8m | +12m |
| Retry 2 | +30m | +24m | +36m |
| Retry 3 | +70m | +56m | +84m (1h24m) |
| Retry 4 | +150m (2h30m) | +120m (2h) | +180m (3h) |
| Retry 5 | +310m (5h10m) | +248m (4h8m) | +372m (6h12m) |
| Retry 6 | +630m (**10h30m**) | +504m (**8h24m**) | +756m (**12h36m**) |

---

And apply the segment max attempts only to the segment task, not the daily anonymize task too.

Related to #220, cc @pmflanagan - the timeout length also affects the total retry there, is 8.5 hours enough anyway or would it be better to go with the 12 option?