### PR TITLE
Stale lock cleanup

### DIFF
--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -226,8 +226,47 @@ class UnifiedTaskScheduler:
                     )
                 logger.warning(f"Failed {len(ids)} stuck task(s): {ids}")
 
+            # Clean up advisory locks held by sessions that outlived their process
+            self._cleanup_stale_advisory_locks()
+
         except Exception as e:
             logger.error(f"Error in periodic database sync: {e}")
+
+    def _cleanup_stale_advisory_locks(self):
+        """Terminate database sessions holding advisory locks that appear stale.
+
+        A session is considered stale when it has been idle longer than the task
+        timeout — at that point the corresponding Task has already been marked
+        failed by the stuck-task detector above, but a network partition can keep
+        the PostgreSQL session (and its lock) alive for hours.
+        """
+        from django.db import connection
+
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT l.pid
+                    FROM pg_locks l
+                    JOIN pg_stat_activity a ON l.pid = a.pid
+                    WHERE l.locktype = 'advisory'
+                      AND l.granted = true
+                      AND a.pid != pg_backend_pid()
+                      AND a.state = 'idle'
+                      AND a.state_change < NOW() - interval '1 second' * %s
+                    """,
+                    [STUCK_TASK_TIMEOUT_SECONDS],
+                )
+                stale_pids = [row[0] for row in cursor.fetchall()]
+
+                for pid in stale_pids:
+                    cursor.execute("SELECT pg_terminate_backend(%s)", [pid])
+                    logger.warning(f"Terminated stale session {pid} holding an advisory lock")
+
+                if stale_pids:
+                    logger.warning(f"Cleaned up {len(stale_pids)} stale advisory lock(s)")
+        except Exception as e:
+            logger.error(f"Error cleaning up stale advisory locks: {e}")
 
     def _add_database_scheduled_task(self, task):
         """Add a one-time scheduled database task to the scheduler."""

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -214,7 +214,7 @@ class UnifiedTaskScheduler:
             self._cleanup_stale_advisory_locks()
 
         except Exception as e:
-            logger.error(f"Error in periodic database sync: {e}")
+            logger.exception(f"Error in periodic database sync: {e}")
 
     def _fail_stuck_tasks(self):
         """Mark tasks stuck in running status as failed after their timeout."""
@@ -281,7 +281,7 @@ class UnifiedTaskScheduler:
                 if stale_pids:
                     logger.warning(f"Cleaned up {len(stale_pids)} stale advisory lock(s)")
         except Exception as e:
-            logger.error(f"Error cleaning up stale advisory locks: {e}")
+            logger.exception(f"Error cleaning up stale advisory locks: {e}")
 
     def _add_database_scheduled_task(self, task):
         """Add a one-time scheduled database task to the scheduler."""

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -239,11 +239,21 @@ class UnifiedTaskScheduler:
         timeout — at that point the corresponding Task has already been marked
         failed by the stuck-task detector above, but a network partition can keep
         the PostgreSQL session (and its lock) alive for hours.
+
+        Only cleans up locks matching TASK_LOCKS function names, not arbitrary
+        advisory locks that other applications might hold.
         """
         from django.db import connection
 
+        from .tasks import TASK_LOCKS
+
         try:
             with connection.cursor() as cursor:
+                # Compute our lock IDs the same way lock.py does:
+                # hashtext(name)::bigint, then Python-style modulo 2**63
+                cursor.execute("SELECT hashtext(name)::bigint FROM unnest(%s::text[]) AS name", [list(TASK_LOCKS)])
+                our_lock_ids = [row[0] % (2**63) for row in cursor.fetchall()]
+
                 cursor.execute(
                     """
                     SELECT l.pid
@@ -254,8 +264,9 @@ class UnifiedTaskScheduler:
                       AND a.pid != pg_backend_pid()
                       AND a.state = 'idle'
                       AND a.state_change < NOW() - interval '1 second' * %s
+                      AND ((l.classid::bigint << 32) | (l.objid::bigint & x'ffffffff'::bigint)) = ANY(%s)
                     """,
-                    [STUCK_TASK_TIMEOUT_SECONDS],
+                    [STUCK_TASK_TIMEOUT_SECONDS, our_lock_ids],
                 )
                 stale_pids = [row[0] for row in cursor.fetchall()]
 

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -208,29 +208,33 @@ class UnifiedTaskScheduler:
                 )
 
             # Detect tasks stuck in running beyond their timeout
-            from .models import TaskExecution
-
-            now = timezone.now()
-            stuck_to_fail = Task.objects.filter(
-                status="running", started_at__lt=now - timedelta(seconds=STUCK_TASK_TIMEOUT_SECONDS)
-            )
-            if stuck_to_fail:
-                ids = [t.id for t in stuck_to_fail]
-                error_msg = "Task timed out — worker died before completion"
-                with transaction.atomic():
-                    TaskExecution.objects.filter(task__id__in=ids, status="running").update(
-                        status="failed", error_message=error_msg, completed_at=now
-                    )
-                    Task.objects.filter(id__in=ids, status="running").update(
-                        status="failed", error_message=error_msg, completed_at=now
-                    )
-                logger.warning(f"Failed {len(ids)} stuck task(s): {ids}")
+            self._fail_stuck_tasks()
 
             # Clean up advisory locks held by sessions that outlived their process
             self._cleanup_stale_advisory_locks()
 
         except Exception as e:
             logger.error(f"Error in periodic database sync: {e}")
+
+    def _fail_stuck_tasks(self):
+        """Mark tasks stuck in running status as failed after their timeout."""
+        from .models import Task, TaskExecution
+
+        now = timezone.now()
+        stuck_to_fail = Task.objects.filter(
+            status="running", started_at__lt=now - timedelta(seconds=STUCK_TASK_TIMEOUT_SECONDS)
+        )
+        if stuck_to_fail:
+            ids = [t.id for t in stuck_to_fail]
+            error_msg = "Task timed out — worker died before completion"
+            with transaction.atomic():
+                TaskExecution.objects.filter(task__id__in=ids, status="running").update(
+                    status="failed", error_message=error_msg, completed_at=now
+                )
+                Task.objects.filter(id__in=ids, status="running").update(
+                    status="failed", error_message=error_msg, completed_at=now
+                )
+            logger.warning(f"Failed {len(ids)} stuck task(s): {ids}")
 
     def _cleanup_stale_advisory_locks(self):
         """Terminate database sessions holding advisory locks that appear stale.

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -456,8 +456,11 @@ class TestCleanupStaleAdvisoryLocks:
         """Sessions holding advisory locks idle beyond the timeout are terminated."""
         scheduler = UnifiedTaskScheduler()
 
+        fake_hash_values = [(999000,), (999001,)]
+        stale_pids = [(201,), (202,)]
+
         mock_cursor = MagicMock()
-        mock_cursor.fetchall.return_value = [(101,), (102,)]
+        mock_cursor.fetchall.side_effect = [fake_hash_values, stale_pids]
         mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
         mock_cursor.__exit__ = MagicMock(return_value=False)
 
@@ -466,15 +469,22 @@ class TestCleanupStaleAdvisoryLocks:
             scheduler._cleanup_stale_advisory_locks()
 
         calls = mock_cursor.execute.call_args_list
-        assert any("pg_terminate_backend" in str(c) and 101 in c[0][1] for c in calls)
-        assert any("pg_terminate_backend" in str(c) and 102 in c[0][1] for c in calls)
+        expected_lock_ids = [h % (2**63) for (h,) in fake_hash_values]
+        pid_query_call = [c for c in calls if "pg_locks" in str(c)]
+        assert len(pid_query_call) == 1
+        assert pid_query_call[0][0][1][1] == expected_lock_ids
+
+        assert any("pg_terminate_backend" in str(c) and 201 in c[0][1] for c in calls)
+        assert any("pg_terminate_backend" in str(c) and 202 in c[0][1] for c in calls)
 
     def test_skips_when_no_stale_locks(self):
         """No termination calls when there are no stale advisory locks."""
         scheduler = UnifiedTaskScheduler()
 
+        fake_hash_values = [(999000,)]
+
         mock_cursor = MagicMock()
-        mock_cursor.fetchall.return_value = []
+        mock_cursor.fetchall.side_effect = [fake_hash_values, []]
         mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
         mock_cursor.__exit__ = MagicMock(return_value=False)
 
@@ -484,6 +494,26 @@ class TestCleanupStaleAdvisoryLocks:
 
         calls = mock_cursor.execute.call_args_list
         assert not any("pg_terminate_backend" in str(c) for c in calls)
+
+    def test_only_targets_known_task_lock_names(self):
+        """The hashtext query is scoped to TASK_LOCKS names, not arbitrary locks."""
+        from apps.tasks.tasks import TASK_LOCKS
+
+        scheduler = UnifiedTaskScheduler()
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.side_effect = [[(1,)], []]
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+
+        with patch("django.db.connection") as mock_conn:
+            mock_conn.cursor.return_value = mock_cursor
+            scheduler._cleanup_stale_advisory_locks()
+
+        hashtext_call = mock_cursor.execute.call_args_list[0]
+        assert "hashtext" in hashtext_call[0][0]
+        passed_names = set(hashtext_call[0][1][0])
+        assert passed_names == TASK_LOCKS
 
     def test_handles_db_error_gracefully(self):
         """Database errors in lock cleanup are caught and logged, not raised."""

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -448,6 +448,53 @@ class TestRemoveDatabaseTask:
 
 
 @pytest.mark.unit
+@pytest.mark.django_db
+class TestCleanupStaleAdvisoryLocks:
+    """Test _cleanup_stale_advisory_locks in the scheduler."""
+
+    def test_terminates_stale_sessions(self):
+        """Sessions holding advisory locks idle beyond the timeout are terminated."""
+        scheduler = UnifiedTaskScheduler()
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [(101,), (102,)]
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+
+        with patch("django.db.connection") as mock_conn:
+            mock_conn.cursor.return_value = mock_cursor
+            scheduler._cleanup_stale_advisory_locks()
+
+        calls = mock_cursor.execute.call_args_list
+        assert any("pg_terminate_backend" in str(c) and 101 in c[0][1] for c in calls)
+        assert any("pg_terminate_backend" in str(c) and 102 in c[0][1] for c in calls)
+
+    def test_skips_when_no_stale_locks(self):
+        """No termination calls when there are no stale advisory locks."""
+        scheduler = UnifiedTaskScheduler()
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_cursor.__exit__ = MagicMock(return_value=False)
+
+        with patch("django.db.connection") as mock_conn:
+            mock_conn.cursor.return_value = mock_cursor
+            scheduler._cleanup_stale_advisory_locks()
+
+        calls = mock_cursor.execute.call_args_list
+        assert not any("pg_terminate_backend" in str(c) for c in calls)
+
+    def test_handles_db_error_gracefully(self):
+        """Database errors in lock cleanup are caught and logged, not raised."""
+        scheduler = UnifiedTaskScheduler()
+
+        with patch("django.db.connection") as mock_conn:
+            mock_conn.cursor.side_effect = Exception("connection lost")
+            scheduler._cleanup_stale_advisory_locks()
+
+
+@pytest.mark.unit
 class TestInjectDispatchTimestamps:
     """
     Test that _inject_dispatch_timestamps pins the correct time-window key into


### PR DESCRIPTION
Related to #265
Issue: AAP-75317

When an issue happens while a process is holding a postgres advisory lock and is unable to release it in exception handlers, the lock could stay in the DB, blocking other collectors.

It should get cleaned up in 6 hours by default by postgres,
it should also get cleaned up when the DB connection dies, or times out after 2 hours,
but we already have `TASK_TIMEOUT` to know how long a lock should be held maximum,
so our scheduler refresh can clean stale locks when they're older than that timeout and match one of the known locks we can hold.

This will only clean these locks:

| Function name                         | Lock ID             |
|---------------------------------------|---------------------|
| cleanup_dashboard_reports_old_data    | 9223372034720098221 |
| collect_dashboard_reports_initial_data| 316168686           |
| collect_hourly_metrics                | 1592025641          |
| collect_snapshot_metrics              | 9223372036244047883 |
| daily_anonymize_and_prepare           | 9223372036545846217 |
| daily_metrics_rollup                  | 1734558938          |
| send_anonymized_to_segment            | 87192764            |
| sync_dashboard_job_records            | 9223372036245273367 |
    
(not separately hardcoded, uses the task definition function names)