### PR TITLE
fix tasks create passing NULL description to DB

### DIFF
--- a/apps/tasks/management/commands/metrics_service.py
+++ b/apps/tasks/management/commands/metrics_service.py
@@ -149,7 +149,7 @@ class Command(BaseCommand):
         create_parser.add_argument("--name", required=True, help="Task name")
         create_parser.add_argument("--function", required=True, help="Function name to execute")
         create_parser.add_argument("--data", help="JSON data for the task")
-        create_parser.add_argument("--description", help="Task description")
+        create_parser.add_argument("--description", default="", help="Task description")
         create_parser.add_argument("--scheduled-time", help="Schedule time (YYYY-MM-DD HH:MM:SS)")
         create_parser.add_argument("--cron", help="Cron expression for recurring tasks")
         create_parser.add_argument("--user", help="Username of task creator")

--- a/tests/coverage/tasks/test_management_commands_2.py
+++ b/tests/coverage/tasks/test_management_commands_2.py
@@ -112,16 +112,19 @@ def test_metrics_service_tasks_show(user):
 @pytest.mark.unit
 @pytest.mark.django_db
 def test_metrics_service_tasks_create(user):
+    from apps.tasks.models import Task
+
     with patch("apps.tasks.tasks_system.submit_task_to_dispatcher"):
-        try:
-            call_command(
-                "metrics_service",
-                "tasks",
-                "create",
-                "--function",
-                "hello_world",
-                "--name",
-                "test-created-task",
-            )
-        except (SystemExit, Exception):
-            pass  # May have different argument syntax
+        call_command(
+            "metrics_service",
+            "tasks",
+            "create",
+            "--function",
+            "hello_world",
+            "--name",
+            "test-created-task",
+        )
+
+    task = Task.objects.get(name="test-created-task")
+    assert task.function_name == "hello_world"
+    assert task.description == ""


### PR DESCRIPTION
Small test bug.

argparse sets --description to None when omitted
.get() fallback never triggers because the key exists

Add default="" to the argument and remove the broad exception swallow in the test so it actually verifies the task gets created.

---

previously failed to create anything and just logged 

```
[postgres]      | 2026-06-18 18:38:37.966 UTC [1011] ERROR:  null value in column "description" of relation "tasks_task" violates not-null constraint
[postgres]      | 2026-06-18 18:38:37.966 UTC [1011] DETAIL:  Failing row contains (66, 2026-06-18 18:38:37.966124+00, 2026-06-18 18:38:37.966133+00, test-created-task, null, null, , null, hello_world, {}, null, null, f, pending, 0, 3, {}, null, null).
[postgres]      | 2026-06-18 18:38:37.966 UTC [1011] STATEMENT:  INSERT INTO "tasks_task" ("modified", "modified_by_id", "created", "name", "started_at", "completed_at", "error_message", "description", "function_name", "task_data", "scheduled_time", "cron_expression", "is_system_task", "status", "attempts", "max_attempts", "result_data", "created_by_id") VALUES ('2026-06-18 18:38:37.966124+00:00'::timestamptz, NULL, '2026-06-18 18:38:37.966133+00:00'::timestamptz, 'test-created-task', NULL, NULL, '', NULL, 'hello_world', '{}'::jsonb, NULL, NULL, false, 'pending', 0, 3, '{}'::jsonb, NULL) RETURNING "tasks_task"."id"
```

which was not intentional for a test testing task creation