### PR TITLE
use logger.exception more, but disable rule forcing it over logger.error

### DIFF
--- a/apps/dashboard_reports/tasks.py
+++ b/apps/dashboard_reports/tasks.py
@@ -101,7 +101,7 @@ def _sync_jobs_atomically(job_results: list) -> list:
                 try:
                     JobData.create_or_update_from_awx(job)
                 except Exception as e:
-                    logger.error(f"Error creating/updating JobData for job {job['id']}: {str(e)}")
+                    logger.exception(f"Error creating/updating JobData for job {job['id']}: {str(e)}")
                     failed_jobs.append(job["id"])
             if failed_jobs:
                 raise _PartialSyncRollbackError()
@@ -417,5 +417,5 @@ def cleanup_dashboard_reports_old_data(**kwargs) -> dict[str, Any]:
             },
         )
     except Exception as e:
-        logger.error(f"Error during cleanup of old JobData records: {str(e)}")
+        logger.exception(f"Error during cleanup of old JobData records: {str(e)}")
         return create_task_result("error", error=f"Cleanup failed: {str(e)}")

--- a/apps/dynamic_settings/management/commands/reload_config.py
+++ b/apps/dynamic_settings/management/commands/reload_config.py
@@ -51,6 +51,6 @@ class Command(BaseCommand):
 
         except Exception as e:
             error_msg = f"Failed to reload configuration: {str(e)}"
-            logger.error(error_msg)
+            logger.exception(error_msg)
             self.stdout.write(self.style.ERROR(f"{error_msg}"))
             raise

--- a/apps/dynamic_settings/utils.py
+++ b/apps/dynamic_settings/utils.py
@@ -82,7 +82,7 @@ def log_setting_change(user, setting_key: str, new_value, old_value=None):
         return setting
 
     except Exception as e:
-        logger.error(f"Failed to log setting change for {setting_key}: {str(e)}")
+        logger.exception(f"Failed to log setting change for {setting_key}: {str(e)}")
         return None
 
 
@@ -144,7 +144,7 @@ def rollback_configuration_change(change_id, user):
         }
 
     except Exception as e:
-        logger.error(f"Failed to rollback configuration change {change_id}: {str(e)}")
+        logger.exception(f"Failed to rollback configuration change {change_id}: {str(e)}")
         return {"success": False, "error": f"Failed to rollback: {str(e)}"}
 
 

--- a/apps/tasks/cleanup/cleanup_metrics_data.py
+++ b/apps/tasks/cleanup/cleanup_metrics_data.py
@@ -108,5 +108,5 @@ def cleanup_metrics_data(**kwargs) -> dict[str, Any]:
         )
 
     except Exception as e:
-        logger.error(f"Error in cleanup_metrics_data: {str(e)}")
+        logger.exception(f"Error in cleanup_metrics_data: {str(e)}")
         return create_task_result("error", error=f"Cleanup failed: {str(e)}")

--- a/apps/tasks/collectors/daily_metrics_rollup.py
+++ b/apps/tasks/collectors/daily_metrics_rollup.py
@@ -301,5 +301,5 @@ def daily_metrics_rollup(**kwargs) -> dict[str, Any]:
         )
 
     except Exception as e:
-        logger.error(f"Error in daily_metrics_rollup: {str(e)}")
+        logger.exception(f"Error in daily_metrics_rollup: {str(e)}")
         return create_task_result("error", error=f"Rollup failed: {str(e)}")

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -106,7 +106,7 @@ class UnifiedTaskScheduler:
                 logger.info(f"Periodic database sync will run every {self.check_interval} seconds")
 
             except Exception as e:
-                logger.error(f"Failed to start cron scheduler: {str(e)}")
+                logger.exception(f"Failed to start cron scheduler: {str(e)}")
                 raise
 
     def stop(self):
@@ -121,7 +121,7 @@ class UnifiedTaskScheduler:
                 self._db_task_jobs.clear()
                 logger.info("Task scheduler stopped")
             except Exception as e:
-                logger.error(f"Error stopping cron scheduler: {str(e)}")
+                logger.exception(f"Error stopping cron scheduler: {str(e)}")
 
     def _task_feature_flag_enabled(self, task) -> bool:
         """Return False if the task carries a feature flag that is currently disabled."""
@@ -159,7 +159,7 @@ class UnifiedTaskScheduler:
             logger.info(f"Synchronized {added_scheduled} scheduled and {added_recurring} recurring database tasks")
 
         except Exception as e:
-            logger.error(f"Error synchronizing database tasks: {e}")
+            logger.exception(f"Error synchronizing database tasks: {e}")
 
     def _periodic_database_sync(self):
         """Periodically check for new database tasks and add them to the scheduler."""
@@ -322,7 +322,7 @@ class UnifiedTaskScheduler:
             logger.info(f"Added scheduled database task: {task.name} (ID: {task.id}) at {task.scheduled_time}")
 
         except Exception as e:
-            logger.error(f"Failed to add scheduled database task {task.id}: {e}")
+            logger.exception(f"Failed to add scheduled database task {task.id}: {e}")
 
     def _add_database_recurring_task(self, task):
         """Add a recurring database task to the scheduler."""
@@ -350,7 +350,7 @@ class UnifiedTaskScheduler:
             logger.info(f"Added recurring database task: {task.name} (ID: {task.id}) with cron: {task.cron_expression}")
 
         except Exception as e:
-            logger.error(f"Failed to add recurring database task {task.id}: {e}")
+            logger.exception(f"Failed to add recurring database task {task.id}: {e}")
 
     def _execute_database_task(self, task_id: int):
         """Execute a database task by submitting it to dispatcherd."""
@@ -427,7 +427,7 @@ class UnifiedTaskScheduler:
             self._remove_database_task(task_id)
 
         except Exception as e:
-            logger.error(f"Failed to execute database task {task_id}: {e}")
+            logger.exception(f"Failed to execute database task {task_id}: {e}")
 
     def _remove_database_task(self, task_id: int):
         """Remove a database task from the scheduler."""

--- a/apps/tasks/dispatcherd_config.py
+++ b/apps/tasks/dispatcherd_config.py
@@ -69,7 +69,7 @@ def setup_dispatcherd_config() -> None:
         logger.error(f"Failed to import dispatcherd: {e}")
         raise
     except Exception as e:
-        logger.error(f"Failed to configure dispatcherd: {e}")
+        logger.exception(f"Failed to configure dispatcherd: {e}")
         raise
 
 
@@ -176,7 +176,7 @@ def build_config_from_django_settings() -> dict[str, Any]:
         return config
 
     except Exception as e:
-        logger.error(f"Failed to build config from Django settings: {e}")
+        logger.exception(f"Failed to build config from Django settings: {e}")
         raise
 
 
@@ -199,5 +199,5 @@ def ensure_dispatcherd_configured() -> None:
         logger.error("Dispatcherd not available")
         raise
     except Exception as e:
-        logger.error(f"Failed to ensure dispatcherd configuration: {e}")
+        logger.exception(f"Failed to ensure dispatcherd configuration: {e}")
         raise

--- a/apps/tasks/models.py
+++ b/apps/tasks/models.py
@@ -184,7 +184,7 @@ class Task(NamedCommonModel, AuditableModel, StatusTrackingMixin):
                 submit_task_to_dispatcher(self)
             except Exception as e:
                 # If submission fails, update the task status
-                logger.error(f"Failed to submit retried task {self.id} to dispatcher: {str(e)}")
+                logger.exception(f"Failed to submit retried task {self.id} to dispatcher: {str(e)}")
                 self.status = "failed"
                 self.error_message = f"Failed to submit to dispatcher: {str(e)}"
                 self.save(update_fields=["status", "error_message", "modified"])

--- a/apps/tasks/tasks_system.py
+++ b/apps/tasks/tasks_system.py
@@ -247,7 +247,7 @@ def submit_task_to_dispatcher(task: Any) -> None:
         if task.can_retry():
             logger.warning(f"Error submitting task to dispatcher: {str(e)}")
         else:
-            logger.error(f"Error submitting task to dispatcher: {str(e)}")
+            logger.exception(f"Error submitting task to dispatcher: {str(e)}")
 
 
 # runs during `manage.py metrics_service init-system-tasks`
@@ -295,7 +295,7 @@ def create_system_tasks() -> dict[str, Any]:
             _create_task_from_group(task_id, config, results, Task)
         except Exception as e:
             results["tasks"].append(f"Error with {task_id}: {str(e)}")
-            logger.error(f"Failed to create task {task_id}: {e}")
+            logger.exception(f"Failed to create task {task_id}: {e}")
 
     return results
 

--- a/apps/tasks/utils.py
+++ b/apps/tasks/utils.py
@@ -36,8 +36,11 @@ def _fetch_task_by_id(task_id: int) -> Any:
         from .models import Task
 
         return Task.objects.get(id=task_id)
+    except Task.DoesNotExist:
+        logger.error(f"Task instance not found for task_id: {task_id}")
+        return None
     except Exception:
-        logger.error(f"Failed to get task instance for task_id: {task_id}")
+        logger.exception(f"Failed to get task instance for task_id: {task_id}")
         return None
 
 
@@ -47,8 +50,11 @@ def _fetch_execution_by_id(execution_id: int) -> Any:
         from .models import TaskExecution
 
         return TaskExecution.objects.get(id=execution_id)
+    except TaskExecution.DoesNotExist:
+        logger.error(f"Execution instance not found for execution_id: {execution_id}")
+        return None
     except Exception:
-        logger.error(f"Failed to get execution instance for execution_id: {execution_id}")
+        logger.exception(f"Failed to get execution instance for execution_id: {execution_id}")
         return None
 
 
@@ -118,7 +124,7 @@ def handle_task_error(
                 )
 
     except Exception as save_error:
-        logger.error(f"Failed to update task status after error: {save_error}")
+        logger.exception(f"Failed to update task status after error: {save_error}")
 
     # Deferred past the transaction so status=="failed" and attempts are incremented before can_retry() is called.
     # Defaults to ERROR when no task context is available.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,7 +27,7 @@ sonar.coverage.exclusions=**/tests/**,**/tools**,**/migrations/**,**/settings/**
 # Manages code duplication sensitivity.  Default is 100.  Higher number means less sensitive.
 sonar.cpd.python.minimumTokens=150
 sonar.cpd.python.minimumLines=300
-sonar.issue.ignore.multicriteria=e1,e2,e3
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4
 # Ignore "should be a variable"
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S1192
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/migrations/**/*
@@ -40,6 +40,10 @@ sonar.issue.ignore.multicriteria.e2.ruleKey=python:S1192
 sonar.issue.ignore.multicriteria.e2.resourceKey=**/tests/**
 sonar.issue.ignore.multicriteria.e3.ruleKey=python:S1192
 sonar.issue.ignore.multicriteria.e3.resourceKey=**/report/**
+
+# Ignore "logging.exception() should be used instead of logging.error()" — not always appropriate
+sonar.issue.ignore.multicriteria.e4.ruleKey=python:S8572
+sonar.issue.ignore.multicriteria.e4.resourceKey=**/*
 
 sonar.cpd.exclusions=**/migrations/*.py,**/tests/**/*.py,**/report/*.py,**/tools/**/*.*,**/.github/**,*.md,*.yaml,*.yml,*.conf,*.html,*.sh
 sonar.test.exclusions=tests/**

--- a/tests/coverage/tasks/test_tasks_system.py
+++ b/tests/coverage/tasks/test_tasks_system.py
@@ -273,8 +273,8 @@ def test_submit_task_dispatcher_error_logs_error_when_exhausted(user, mock_dispa
 
     task.refresh_from_db()
     assert task.status == "failed"
-    mock_logger.error.assert_called_once()
-    error_msg = mock_logger.error.call_args[0][0]
+    mock_logger.exception.assert_called_once()
+    error_msg = mock_logger.exception.call_args[0][0]
     assert "broker gone" in error_msg
     # Must NOT log at WARNING level for the dispatcher error
     warning_calls = [str(call) for call in mock_logger.warning.call_args_list]

--- a/tests/unit/dynamic_settings/test_reload_config_command.py
+++ b/tests/unit/dynamic_settings/test_reload_config_command.py
@@ -158,7 +158,7 @@ class TestReloadConfigCommand(TestCase):
                 command.handle(verbose=False)
 
             # Verify error logging
-            mock_logger.error.assert_called_once_with("Failed to reload configuration: Invalid config")
+            mock_logger.exception.assert_called_once_with("Failed to reload configuration: Invalid config")
 
     def test_add_arguments_method(self):
         """Test that add_arguments properly configures the verbose flag."""

--- a/tests/unit/tasks/test_dispatcherd_config.py
+++ b/tests/unit/tasks/test_dispatcherd_config.py
@@ -147,8 +147,8 @@ class TestSetupDispatcherdConfig:
         ):
             setup_dispatcherd_config()
 
-        mock_logger.error.assert_called()
-        assert "Failed to configure dispatcherd" in str(mock_logger.error.call_args)
+        mock_logger.exception.assert_called()
+        assert "Failed to configure dispatcherd" in str(mock_logger.exception.call_args)
 
 
 class TestLoadConfigWithDjangoDb:
@@ -394,8 +394,8 @@ class TestBuildConfigFromDjangoSettings:
         with pytest.raises(KeyError):
             build_config_from_django_settings()
 
-        mock_logger.error.assert_called()
-        assert "Failed to build config from Django settings" in str(mock_logger.error.call_args)
+        mock_logger.exception.assert_called()
+        assert "Failed to build config from Django settings" in str(mock_logger.exception.call_args)
 
 
 class TestEnsureDispatcherdConfigured:
@@ -456,5 +456,5 @@ class TestEnsureDispatcherdConfigured:
         ):
             ensure_dispatcherd_configured()
 
-        mock_logger.error.assert_called()
-        assert "Failed to ensure dispatcherd configuration" in str(mock_logger.error.call_args)
+        mock_logger.exception.assert_called()
+        assert "Failed to ensure dispatcherd configuration" in str(mock_logger.exception.call_args)


### PR DESCRIPTION
Make sonarqube happy,
use `logger.exception` instead of `logger.error` in more generic exception handlers,
but stay with `logger.error` where this is a know expected situation.

And suppress the `S8572` rule in `sonar-project.properties` - not every except block needs a traceback.