### PR TITLE
fix renovate cron schedule, add PR check to prevent wildcard minutes

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,6 +40,13 @@ jobs:
       - name: "Checkout metrics-service (${{ github.ref }})"
         uses: actions/checkout@v6
 
+      - name: "Check for wildcard cron minutes in renovate config"
+        run: |
+          if grep -Pn '"schedule".*"\* ' renovate.json; then
+            echo "::error::Cron schedules in renovate.json must not use * for minutes (runs every minute). Use a specific minute like 0."
+            exit 1
+          fi
+
       - name: "Install uv"
         uses: astral-sh/setup-uv@v7
 

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,6 @@
   "tekton": {
     "enabled": true,
     "automerge": true,
-    "schedule": ["* */12 * * 1-5"]
+    "schedule": ["0 */12 * * 1-5"]
   }
 }


### PR DESCRIPTION
#271 accidentally changed the renovate cron schedule from `0 */12` to `* */12`, making it run every minute instead of once every 12 hours (same thing happened before in #255).

Fixes the schedule back to `0 */12 * * 1-5` and adds a PR check step that greps renovate.json for wildcard minutes in schedule fields, so this can't sneak through again.