### PR TITLE
fix trends export test flake near midnight UTC

### DIFF
--- a/tests/unit/dashboard_reports/test_export_urls.py
+++ b/tests/unit/dashboard_reports/test_export_urls.py
@@ -74,8 +74,8 @@ def job_data(template_metadata):
     """
     now = get_now()
     job_configs = [
-        (1, 0, 1, 10, "Project A", JobStatusChoices.SUCCESSFUL, datetime.timedelta(minutes=5), 60, 10, 1, "test_user"),
-        (2, 0, 1, 10, "Project A", JobStatusChoices.FAILED, datetime.timedelta(minutes=1), 5, 10, 1, "test_user"),
+        (1, 0, 1, 10, "Project A", JobStatusChoices.SUCCESSFUL, datetime.timedelta(hours=3), 60, 10, 1, "test_user"),
+        (2, 0, 1, 10, "Project A", JobStatusChoices.FAILED, datetime.timedelta(hours=2), 5, 10, 1, "test_user"),
         (
             3,
             1,


### PR DESCRIPTION
job_data fixture used minute-scale offsets (5min, 1min) for recent jobs, so CI runs between 00:01-00:05 UTC split them across two calendar days, producing 3 date buckets instead of 2, failing.

Use hour-scale offsets (3h, 2h) so both jobs always land on the same calendar day.

(failed in https://github.com/ansible/metrics-utility/actions/runs/27796797245/attempts/1?pr=432, at 12:02 UTC,
but a straight restart worked again, because it was 20 minutes later)