### PR TITLE
AAP-79242: Add incremental JobHostSummary sync via job_host_summary_service hook

### DIFF
--- a/apps/dashboard_reports/tasks.py
+++ b/apps/dashboard_reports/tasks.py
@@ -393,8 +393,9 @@ def sync_dashboard_host_summaries(**kwargs) -> dict[str, Any]:
         except JobData.DoesNotExist:
             continue  # sync/non-terminal job — no matching JobData record
         try:
-            existing = {o.host_summary_id: o for o in JobHostSummary.objects.filter(job_data=job_data)}
-            JobData._sync_host_summaries(job_data, host_summaries, existing)
+            with transaction.atomic():
+                existing = {o.host_summary_id: o for o in JobHostSummary.objects.filter(job_data=job_data)}
+                JobData._sync_host_summaries(job_data, host_summaries, existing)
             synced += 1
         except Exception:
             logger.exception("Error syncing host summaries for job %s", job_remote_id)

--- a/apps/dashboard_reports/tasks.py
+++ b/apps/dashboard_reports/tasks.py
@@ -372,16 +372,19 @@ def sync_dashboard_host_summaries(**kwargs) -> dict[str, Any]:
         details=f"Syncing host summaries for {len(raw_host_summaries)} records ({hour_timestamp})",
     )
 
-    # Group by job_remote_id and remap host_remote_id → host_id to match _sync_host_summaries.
+    # Group by job_remote_id; the hook's serializer already maps host_remote_id → host_id.
     by_job: dict[int, list] = {}
     for row in raw_host_summaries:
         job_id = row.get("job_remote_id")
         if job_id is None:
             continue
+        summary_id = row.get("id")
+        if summary_id is None:
+            continue
         by_job.setdefault(job_id, []).append(
             {
-                "id": row["id"],
-                "host_id": row.get("host_remote_id"),
+                "id": summary_id,
+                "host_id": row.get("host_id"),
                 "host_name": row.get("host_name"),
             }
         )

--- a/apps/dashboard_reports/tasks.py
+++ b/apps/dashboard_reports/tasks.py
@@ -1,10 +1,11 @@
 """
 Background tasks for dashboard reports data collection and cleanup.
 
-Provides four dispatcherd tasks:
+Provides five dispatcherd tasks:
 - collect_dashboard_reports_initial_data: full historical backfill (default 90 days)
 - collect_dashboard_reports_data: incremental sync from last known timestamp (deprecated)
 - sync_dashboard_job_records: writes unified_jobs data from the hourly hook to JobData
+- sync_dashboard_host_summaries: writes host summary data from the hourly hook to JobHostSummary
 - cleanup_dashboard_reports_old_data: removes JobData records beyond retention period
 """
 
@@ -20,7 +21,7 @@ from metrics_utility.library.collectors.dashboard import (
     dashboard_jobs,
 )
 
-from apps.dashboard_reports.models import JobData
+from apps.dashboard_reports.models import JobData, JobHostSummary
 from apps.tasks.utils import create_task_result, get_db_connection, log_task_execution
 
 DEFAULT_DB_NAME = "awx"
@@ -350,6 +351,61 @@ def sync_dashboard_job_records(**kwargs) -> dict[str, Any]:
     )
     return create_task_result(
         "success", data={"task_type": task_name, "job_count": len(assembled), "hour_timestamp": hour_timestamp}
+    )
+
+
+def sync_dashboard_host_summaries(**kwargs) -> dict[str, Any]:
+    """Write job_host_summary_service data to JobHostSummary records in the dashboard tables.
+
+    Scheduled automatically by the hourly job_host_summary_service hook so no extra Controller
+    DB queries are needed — the raw data is passed in task_data. Jobs not present in JobData
+    (e.g. sync-type or non-terminal jobs filtered out by the dashboard collector) are silently
+    skipped.
+    """
+    task_name = "sync_dashboard_host_summaries"
+    hour_timestamp = kwargs.get("hour_timestamp", "unknown")
+    raw_host_summaries = kwargs.get("raw_host_summaries", [])
+
+    log_task_execution(
+        task_name=task_name,
+        operation="processing",
+        details=f"Syncing host summaries for {len(raw_host_summaries)} records ({hour_timestamp})",
+    )
+
+    # Group by job_remote_id and remap host_remote_id → host_id to match _sync_host_summaries.
+    by_job: dict[int, list] = {}
+    for row in raw_host_summaries:
+        job_id = row.get("job_remote_id")
+        if job_id is None:
+            continue
+        by_job.setdefault(job_id, []).append(
+            {
+                "id": row["id"],
+                "host_id": row.get("host_remote_id"),
+                "host_name": row.get("host_name"),
+            }
+        )
+
+    synced = 0
+    for job_remote_id, host_summaries in by_job.items():
+        try:
+            job_data = JobData.objects.get(job_id=job_remote_id)
+        except JobData.DoesNotExist:
+            continue  # sync/non-terminal job — no matching JobData record
+        try:
+            existing = {o.host_summary_id: o for o in JobHostSummary.objects.filter(job_data=job_data)}
+            JobData._sync_host_summaries(job_data, host_summaries, existing)
+            synced += 1
+        except Exception:
+            logger.exception("Error syncing host summaries for job %s", job_remote_id)
+
+    log_task_execution(
+        task_name=task_name,
+        operation="completed",
+        details=f"Synced host summaries for {synced} jobs ({hour_timestamp})",
+    )
+    return create_task_result(
+        "success", data={"task_type": task_name, "job_count": synced, "hour_timestamp": hour_timestamp}
     )
 
 

--- a/apps/dashboard_reports/tasks.py
+++ b/apps/dashboard_reports/tasks.py
@@ -386,15 +386,23 @@ def sync_dashboard_host_summaries(**kwargs) -> dict[str, Any]:
             }
         )
 
+    # Batch-fetch all matching JobData and their existing JobHostSummary records in two queries
+    # rather than 2N queries (one get + one filter per job).
+    job_data_by_id: dict[int, Any] = {}
+    existing_by_job_data_pk: dict[int, dict] = {}
+    if by_job:
+        job_data_by_id = {jd.job_id: jd for jd in JobData.objects.filter(job_id__in=by_job.keys())}
+        for hs in JobHostSummary.objects.filter(job_data__in=job_data_by_id.values()):
+            existing_by_job_data_pk.setdefault(hs.job_data_id, {})[hs.host_summary_id] = hs
+
     synced = 0
     for job_remote_id, host_summaries in by_job.items():
-        try:
-            job_data = JobData.objects.get(job_id=job_remote_id)
-        except JobData.DoesNotExist:
+        job_data = job_data_by_id.get(job_remote_id)
+        if job_data is None:
             continue  # sync/non-terminal job — no matching JobData record
         try:
             with transaction.atomic():
-                existing = {o.host_summary_id: o for o in JobHostSummary.objects.filter(job_data=job_data)}
+                existing = existing_by_job_data_pk.get(job_data.pk, {})
                 JobData._sync_host_summaries(job_data, host_summaries, existing)
             synced += 1
         except Exception:

--- a/apps/dashboard_reports/tasks.py
+++ b/apps/dashboard_reports/tasks.py
@@ -396,6 +396,7 @@ def sync_dashboard_host_summaries(**kwargs) -> dict[str, Any]:
             existing_by_job_data_pk.setdefault(hs.job_data_id, {})[hs.host_summary_id] = hs
 
     synced = 0
+    failed = 0
     for job_remote_id, host_summaries in by_job.items():
         job_data = job_data_by_id.get(job_remote_id)
         if job_data is None:
@@ -407,12 +408,18 @@ def sync_dashboard_host_summaries(**kwargs) -> dict[str, Any]:
             synced += 1
         except Exception:
             logger.exception("Error syncing host summaries for job %s", job_remote_id)
+            failed += 1
 
     log_task_execution(
         task_name=task_name,
         operation="completed",
-        details=f"Synced host summaries for {synced} jobs ({hour_timestamp})",
+        details=f"Synced host summaries for {synced} jobs, {failed} failed ({hour_timestamp})",
     )
+    if failed:
+        return create_task_result(
+            "error",
+            data={"task_type": task_name, "job_count": synced, "failed": failed, "hour_timestamp": hour_timestamp},
+        )
     return create_task_result(
         "success", data={"task_type": task_name, "job_count": synced, "hour_timestamp": hour_timestamp}
     )

--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -43,6 +43,7 @@ def _get_hourly_collectors():
             "collector_func": job_host_summary_service,
             "rollup_processor": JobHostSummaryAnonymizedRollup,
             "description": "Job host summary metrics (partition-optimized)",
+            "post_collect_hook_factory": _build_dashboard_host_summary_sync_hook,
         },
         "unified_jobs": {
             # unified_jobs_dashboard extends the base unified_jobs query with dashboard-specific
@@ -126,7 +127,9 @@ def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
     )
 
 
-_SYNC_TASK_CHUNK_SIZE = 500  # max records per sync_dashboard_job_records task
+_SYNC_TASK_CHUNK_SIZE = 500  # max jobs per sync_dashboard_* task
+
+_HOST_SUMMARY_COLUMNS = ("id", "host_name", "host_remote_id", "job_remote_id")
 
 _DASHBOARD_COLUMNS = [
     "id",
@@ -179,6 +182,90 @@ def _serialize_dashboard_record(row: dict) -> None:
         row["elapsed"] = None
     else:
         row["elapsed"] = float(val)
+
+
+def _serialize_host_summary_record(row: dict) -> dict:
+    """Coerce numpy/pandas types to Python natives for a single host summary row.
+
+    host_remote_id is nullable (None when the AWX host record has been deleted).
+    job_remote_id and id are always non-null integers from main_jobhostsummary.
+    """
+    result: dict = {}
+    for field in ("id", "job_remote_id"):
+        val = row.get(field)
+        result[field] = None if (val is None or (isinstance(val, float) and math.isnan(val))) else int(val)
+    val = row.get("host_remote_id")
+    result["host_remote_id"] = None if (val is None or (isinstance(val, float) and math.isnan(val))) else int(val)
+    result["host_name"] = str(row["host_name"]) if row.get("host_name") is not None else None
+    return result
+
+
+def _build_dashboard_host_summary_sync_hook(hour_timestamp):
+    """Return a post_collect_hook that schedules sync_dashboard_host_summaries tasks.
+
+    Reuses the raw DataFrame from job_host_summary_service to incrementally write
+    JobHostSummary records for post-backfill jobs without adding extra Controller
+    DB queries. Only schedules tasks when the DASHBOARD_COLLECTION feature flag is enabled.
+    """
+    # Lazy import: circular dependency (collect_hourly_metrics → task_groups → tasks → collect_hourly_metrics).
+    from apps.tasks.task_groups import get_feature_enabled_from_db
+
+    if not get_feature_enabled_from_db("DASHBOARD_COLLECTION"):
+        return None
+
+    def hook(raw_data):
+        if raw_data is None or raw_data.empty:
+            return
+
+        available = [c for c in _HOST_SUMMARY_COLUMNS if c in raw_data.columns]
+        missing = set(_HOST_SUMMARY_COLUMNS) - set(available)
+        if missing:
+            logger.warning(
+                "job_host_summary_service is missing expected columns for dashboard sync: %s",
+                sorted(missing),
+            )
+            return
+
+        rows = raw_data[list(available)].where(raw_data[list(available)].notna(), other=None).to_dict("records")
+
+        by_job: dict[int, list] = {}
+        for row in rows:
+            record = _serialize_host_summary_record(row)
+            job_id = record.get("job_remote_id")
+            if job_id is None:
+                continue
+            by_job.setdefault(job_id, []).append(record)
+
+        if not by_job:
+            return
+
+        # Lazy import inside closure: Task must be resolved at call time so tests can
+        # patch apps.tasks.models.Task after the hook is built (same circular-import reason).
+        from apps.tasks.models import Task
+
+        hour_ts_str = hour_timestamp.isoformat()
+        job_ids = list(by_job.keys())
+        for chunk_index, start in enumerate(range(0, len(job_ids), _SYNC_TASK_CHUNK_SIZE)):
+            chunk_job_ids = job_ids[start : start + _SYNC_TASK_CHUNK_SIZE]
+            chunk_summaries = [record for job_id in chunk_job_ids for record in by_job[job_id]]
+            Task.objects.update_or_create(
+                name=f"sync_dashboard_host_summaries_{hour_ts_str}_{chunk_index}",
+                defaults={
+                    "description": (
+                        f"Sync dashboard host summary records from job_host_summary_service"
+                        f" for {hour_ts_str} (chunk {chunk_index})"
+                    ),
+                    "function_name": "sync_dashboard_host_summaries",
+                    "task_data": {
+                        "raw_host_summaries": chunk_summaries,
+                        "hour_timestamp": hour_ts_str,
+                        "_feature_flag": "DASHBOARD_COLLECTION",
+                    },
+                    "is_system_task": False,
+                },
+            )
+
+    return hook
 
 
 def _build_dashboard_sync_hook(hour_timestamp):

--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -127,7 +127,8 @@ def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
     )
 
 
-_SYNC_TASK_CHUNK_SIZE = 500  # max jobs per sync_dashboard_* task
+_SYNC_TASK_CHUNK_SIZE = 500  # max jobs per sync_dashboard_job_records task
+_HOST_SUMMARY_RECORD_CHUNK_SIZE = 2000  # max host summary records per sync_dashboard_host_summaries task
 
 _HOST_SUMMARY_COLUMNS = ("id", "host_name", "host_remote_id", "job_remote_id")
 
@@ -242,30 +243,58 @@ def _build_dashboard_host_summary_sync_hook(hour_timestamp):
         # patch apps.tasks.models.Task after the hook is built (same circular-import reason).
         from apps.tasks.models import Task
 
+        # Chunk by total record count, keeping all records for a single job together.
+        # _sync_host_summaries deletes stale records, so splitting one job's records
+        # across tasks would cause the first chunk to delete the second chunk's records.
         hour_ts_str = hour_timestamp.isoformat()
-        job_ids = list(by_job.keys())
         new_names: set[str] = set()
-        for chunk_index, start in enumerate(range(0, len(job_ids), _SYNC_TASK_CHUNK_SIZE)):
-            chunk_job_ids = job_ids[start : start + _SYNC_TASK_CHUNK_SIZE]
-            chunk_summaries = [record for job_id in chunk_job_ids for record in by_job[job_id]]
-            chunk_name = f"sync_dashboard_host_summaries_{hour_ts_str}_{chunk_index}"
-            new_names.add(chunk_name)
-            Task.objects.update_or_create(
-                name=chunk_name,
-                defaults={
-                    "description": (
-                        f"Sync dashboard host summary records from job_host_summary_service"
-                        f" for {hour_ts_str} (chunk {chunk_index})"
-                    ),
-                    "function_name": "sync_dashboard_host_summaries",
-                    "task_data": {
-                        "raw_host_summaries": chunk_summaries,
-                        "hour_timestamp": hour_ts_str,
-                        "_feature_flag": "DASHBOARD_COLLECTION",
+        chunk_index = 0
+        current_chunk: list = []
+
+        for job_id in by_job:
+            job_records = by_job[job_id]
+            if current_chunk and len(current_chunk) + len(job_records) > _HOST_SUMMARY_RECORD_CHUNK_SIZE:
+                chunk_name = f"sync_dashboard_host_summaries_{hour_ts_str}_{chunk_index}"
+                new_names.add(chunk_name)
+                Task.objects.update_or_create(
+                    name=chunk_name,
+                    defaults={
+                        "description": (
+                            f"Sync dashboard host summary records from job_host_summary_service"
+                            f" for {hour_ts_str} (chunk {chunk_index})"
+                        ),
+                        "function_name": "sync_dashboard_host_summaries",
+                        "task_data": {
+                            "raw_host_summaries": current_chunk,
+                            "hour_timestamp": hour_ts_str,
+                            "_feature_flag": "DASHBOARD_COLLECTION",
+                        },
+                        "is_system_task": False,
                     },
-                    "is_system_task": False,
+                )
+                chunk_index += 1
+                current_chunk = []
+            current_chunk.extend(job_records)
+
+        # Flush the final (or only) chunk — always non-empty because by_job is non-empty.
+        chunk_name = f"sync_dashboard_host_summaries_{hour_ts_str}_{chunk_index}"
+        new_names.add(chunk_name)
+        Task.objects.update_or_create(
+            name=chunk_name,
+            defaults={
+                "description": (
+                    f"Sync dashboard host summary records from job_host_summary_service"
+                    f" for {hour_ts_str} (chunk {chunk_index})"
+                ),
+                "function_name": "sync_dashboard_host_summaries",
+                "task_data": {
+                    "raw_host_summaries": current_chunk,
+                    "hour_timestamp": hour_ts_str,
+                    "_feature_flag": "DASHBOARD_COLLECTION",
                 },
-            )
+                "is_system_task": False,
+            },
+        )
         # Remove pending chunks from a prior run that exceed the current chunk count.
         Task.objects.filter(
             name__startswith=f"sync_dashboard_host_summaries_{hour_ts_str}_",
@@ -339,6 +368,8 @@ def _build_dashboard_sync_hook(hour_timestamp):
                 },
             )
         # Remove pending chunks from a prior run that exceed the current chunk count.
+        if not new_names:
+            return
         Task.objects.filter(
             name__startswith=f"sync_dashboard_jobs_{hour_ts_str}_",
             status="pending",

--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -191,11 +191,9 @@ def _serialize_host_summary_record(row: dict) -> dict:
     job_remote_id and id are always non-null integers from main_jobhostsummary.
     """
     result: dict = {}
-    for field in ("id", "job_remote_id"):
+    for field in ("id", "job_remote_id", "host_remote_id"):
         val = row.get(field)
         result[field] = None if (val is None or (isinstance(val, float) and math.isnan(val))) else int(val)
-    val = row.get("host_remote_id")
-    result["host_remote_id"] = None if (val is None or (isinstance(val, float) and math.isnan(val))) else int(val)
     result["host_name"] = str(row["host_name"]) if row.get("host_name") is not None else None
     return result
 
@@ -226,7 +224,8 @@ def _build_dashboard_host_summary_sync_hook(hour_timestamp):
             )
             return
 
-        rows = raw_data[list(available)].where(raw_data[list(available)].notna(), other=None).to_dict("records")
+        subset = raw_data[list(available)]
+        rows = subset.where(subset.notna(), other=None).to_dict("records")
 
         by_job: dict[int, list] = {}
         for row in rows:
@@ -245,11 +244,14 @@ def _build_dashboard_host_summary_sync_hook(hour_timestamp):
 
         hour_ts_str = hour_timestamp.isoformat()
         job_ids = list(by_job.keys())
+        new_names: set[str] = set()
         for chunk_index, start in enumerate(range(0, len(job_ids), _SYNC_TASK_CHUNK_SIZE)):
             chunk_job_ids = job_ids[start : start + _SYNC_TASK_CHUNK_SIZE]
             chunk_summaries = [record for job_id in chunk_job_ids for record in by_job[job_id]]
+            chunk_name = f"sync_dashboard_host_summaries_{hour_ts_str}_{chunk_index}"
+            new_names.add(chunk_name)
             Task.objects.update_or_create(
-                name=f"sync_dashboard_host_summaries_{hour_ts_str}_{chunk_index}",
+                name=chunk_name,
                 defaults={
                     "description": (
                         f"Sync dashboard host summary records from job_host_summary_service"
@@ -264,6 +266,11 @@ def _build_dashboard_host_summary_sync_hook(hour_timestamp):
                     "is_system_task": False,
                 },
             )
+        # Remove pending chunks from a prior run that exceed the current chunk count.
+        Task.objects.filter(
+            name__startswith=f"sync_dashboard_host_summaries_{hour_ts_str}_",
+            status="pending",
+        ).exclude(name__in=new_names).delete()
 
     return hook
 
@@ -303,7 +310,8 @@ def _build_dashboard_sync_hook(hour_timestamp):
                 "unified_jobs_dashboard is missing expected columns: %s",
                 sorted(missing),
             )
-        records = filtered[available].where(filtered[available].notna(), other=None).to_dict("records")
+        subset = filtered[available]
+        records = subset.where(subset.notna(), other=None).to_dict("records")
         for row in records:
             _serialize_dashboard_record(row)
 
@@ -312,10 +320,13 @@ def _build_dashboard_sync_hook(hour_timestamp):
         from apps.tasks.models import Task
 
         hour_ts_str = hour_timestamp.isoformat()
+        new_names: set[str] = set()
         for chunk_index, start in enumerate(range(0, len(records), _SYNC_TASK_CHUNK_SIZE)):
             chunk = records[start : start + _SYNC_TASK_CHUNK_SIZE]
+            chunk_name = f"sync_dashboard_jobs_{hour_ts_str}_{chunk_index}"
+            new_names.add(chunk_name)
             Task.objects.update_or_create(
-                name=f"sync_dashboard_jobs_{hour_ts_str}_{chunk_index}",
+                name=chunk_name,
                 defaults={
                     "description": f"Sync dashboard job records from unified_jobs for {hour_ts_str} (chunk {chunk_index})",
                     "function_name": "sync_dashboard_job_records",
@@ -327,5 +338,10 @@ def _build_dashboard_sync_hook(hour_timestamp):
                     "is_system_task": False,
                 },
             )
+        # Remove pending chunks from a prior run that exceed the current chunk count.
+        Task.objects.filter(
+            name__startswith=f"sync_dashboard_jobs_{hour_ts_str}_",
+            status="pending",
+        ).exclude(name__in=new_names).delete()
 
     return hook

--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -188,15 +188,57 @@ def _serialize_dashboard_record(row: dict) -> None:
 def _serialize_host_summary_record(row: dict) -> dict:
     """Coerce numpy/pandas types to Python natives for a single host summary row.
 
-    host_remote_id is nullable (None when the AWX host record has been deleted).
-    job_remote_id and id are always non-null integers from main_jobhostsummary.
+    id and job_remote_id are always non-null integers from main_jobhostsummary.
+    host_remote_id (the AWX DB column name) is read from the input row and written
+    as host_id in the result — the canonical wire/model field name used by
+    _sync_host_summaries. host_id is nullable (None when the AWX host record has
+    been deleted).
     """
     result: dict = {}
-    for field in ("id", "job_remote_id", "host_remote_id"):
+    for field in ("id", "job_remote_id"):
         val = row.get(field)
         result[field] = None if (val is None or (isinstance(val, float) and math.isnan(val))) else int(val)
+    # host_remote_id (AWX column) → host_id (canonical wire/model field name).
+    val = row.get("host_remote_id")
+    result["host_id"] = None if (val is None or (isinstance(val, float) and math.isnan(val))) else int(val)
     result["host_name"] = str(row["host_name"]) if row.get("host_name") is not None else None
     return result
+
+
+def _group_host_summary_rows(rows: list[dict]) -> dict[int, list]:
+    """Group serialised host-summary rows by job_remote_id, dropping rows with a null job id."""
+    by_job: dict[int, list] = {}
+    for row in rows:
+        record = _serialize_host_summary_record(row)
+        job_id = record.get("job_remote_id")
+        if job_id is None:
+            continue
+        by_job.setdefault(job_id, []).append(record)
+    return by_job
+
+
+def _build_host_summary_task_chunks(by_job: dict[int, list], hour_ts_str: str) -> dict[str, list]:
+    """Partition host-summary records into named chunks for Task scheduling.
+
+    All records for a single job stay in the same chunk because _sync_host_summaries
+    deletes stale records — splitting a job across chunks would cause data loss.
+    """
+    chunks: dict[str, list] = {}
+    chunk_index = 0
+    current_chunk: list = []
+
+    for job_records in by_job.values():
+        if current_chunk and len(current_chunk) + len(job_records) > _HOST_SUMMARY_RECORD_CHUNK_SIZE:
+            name = f"sync_dashboard_host_summaries_{hour_ts_str}_{chunk_index}"
+            chunks[name] = current_chunk
+            chunk_index += 1
+            current_chunk = []
+        current_chunk.extend(job_records)
+
+    # Flush the final (or only) chunk — always non-empty because by_job is non-empty.
+    name = f"sync_dashboard_host_summaries_{hour_ts_str}_{chunk_index}"
+    chunks[name] = current_chunk
+    return chunks
 
 
 def _build_dashboard_host_summary_sync_hook(hour_timestamp):
@@ -209,6 +251,9 @@ def _build_dashboard_host_summary_sync_hook(hour_timestamp):
     # Lazy import: circular dependency (collect_hourly_metrics → task_groups → tasks → collect_hourly_metrics).
     from apps.tasks.task_groups import get_feature_enabled_from_db
 
+    # The flag is intentionally evaluated at hook-build time (when the hourly task starts),
+    # not when the hook executes after gather(). A flag change mid-task takes effect on the
+    # next collection cycle. This is acceptable — the window is the duration of one gather() call.
     if not get_feature_enabled_from_db("DASHBOARD_COLLECTION"):
         return None
 
@@ -227,15 +272,7 @@ def _build_dashboard_host_summary_sync_hook(hour_timestamp):
 
         subset = raw_data[list(available)]
         rows = subset.where(subset.notna(), other=None).to_dict("records")
-
-        by_job: dict[int, list] = {}
-        for row in rows:
-            record = _serialize_host_summary_record(row)
-            job_id = record.get("job_remote_id")
-            if job_id is None:
-                continue
-            by_job.setdefault(job_id, []).append(record)
-
+        by_job = _group_host_summary_rows(rows)
         if not by_job:
             return
 
@@ -243,59 +280,30 @@ def _build_dashboard_host_summary_sync_hook(hour_timestamp):
         # patch apps.tasks.models.Task after the hook is built (same circular-import reason).
         from apps.tasks.models import Task
 
-        # Chunk by total record count, keeping all records for a single job together.
-        # _sync_host_summaries deletes stale records, so splitting one job's records
-        # across tasks would cause the first chunk to delete the second chunk's records.
         hour_ts_str = hour_timestamp.isoformat()
+        chunks = _build_host_summary_task_chunks(by_job, hour_ts_str)
         new_names: set[str] = set()
-        chunk_index = 0
-        current_chunk: list = []
-
-        for job_id in by_job:
-            job_records = by_job[job_id]
-            if current_chunk and len(current_chunk) + len(job_records) > _HOST_SUMMARY_RECORD_CHUNK_SIZE:
-                chunk_name = f"sync_dashboard_host_summaries_{hour_ts_str}_{chunk_index}"
-                new_names.add(chunk_name)
-                Task.objects.update_or_create(
-                    name=chunk_name,
-                    defaults={
-                        "description": (
-                            f"Sync dashboard host summary records from job_host_summary_service"
-                            f" for {hour_ts_str} (chunk {chunk_index})"
-                        ),
-                        "function_name": "sync_dashboard_host_summaries",
-                        "task_data": {
-                            "raw_host_summaries": current_chunk,
-                            "hour_timestamp": hour_ts_str,
-                            "_feature_flag": "DASHBOARD_COLLECTION",
-                        },
-                        "is_system_task": False,
+        for chunk_index, (chunk_name, chunk) in enumerate(chunks.items()):
+            new_names.add(chunk_name)
+            Task.objects.update_or_create(
+                name=chunk_name,
+                defaults={
+                    "description": (
+                        f"Sync dashboard host summary records from job_host_summary_service"
+                        f" for {hour_ts_str} (chunk {chunk_index})"
+                    ),
+                    "function_name": "sync_dashboard_host_summaries",
+                    "task_data": {
+                        "raw_host_summaries": chunk,
+                        "hour_timestamp": hour_ts_str,
+                        "_feature_flag": "DASHBOARD_COLLECTION",
                     },
-                )
-                chunk_index += 1
-                current_chunk = []
-            current_chunk.extend(job_records)
-
-        # Flush the final (or only) chunk — always non-empty because by_job is non-empty.
-        chunk_name = f"sync_dashboard_host_summaries_{hour_ts_str}_{chunk_index}"
-        new_names.add(chunk_name)
-        Task.objects.update_or_create(
-            name=chunk_name,
-            defaults={
-                "description": (
-                    f"Sync dashboard host summary records from job_host_summary_service"
-                    f" for {hour_ts_str} (chunk {chunk_index})"
-                ),
-                "function_name": "sync_dashboard_host_summaries",
-                "task_data": {
-                    "raw_host_summaries": current_chunk,
-                    "hour_timestamp": hour_ts_str,
-                    "_feature_flag": "DASHBOARD_COLLECTION",
+                    "is_system_task": False,
                 },
-                "is_system_task": False,
-            },
-        )
+            )
         # Remove pending chunks from a prior run that exceed the current chunk count.
+        if not new_names:
+            return
         Task.objects.filter(
             name__startswith=f"sync_dashboard_host_summaries_{hour_ts_str}_",
             status="pending",

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -18,6 +18,7 @@ from ..dashboard_reports.tasks import (
     cleanup_dashboard_reports_old_data,
     collect_dashboard_reports_data,
     collect_dashboard_reports_initial_data,
+    sync_dashboard_host_summaries,
     sync_dashboard_job_records,
 )
 
@@ -61,6 +62,7 @@ TASK_FUNCTIONS = {
     "collect_dashboard_reports_initial_data": collect_dashboard_reports_initial_data,
     "cleanup_dashboard_reports_old_data": cleanup_dashboard_reports_old_data,
     "sync_dashboard_job_records": sync_dashboard_job_records,
+    "sync_dashboard_host_summaries": sync_dashboard_host_summaries,
 }
 
 # Tasks that require a PostgreSQL advisory lock during scheduled execution.
@@ -429,6 +431,37 @@ TASK_METADATA = {
             },
         ],
     },
+    "sync_dashboard_host_summaries": {
+        "queue": "dashboard",
+        "category": _DASHBOARD_REPORTS_CATEGORY,
+        "description": "Write job_host_summary_service data collected during the hourly rollup to the dashboard JobHostSummary table",
+        "parameters": {
+            "hour_timestamp": {
+                "type": "string",
+                "description": "ISO timestamp of the hour being synced",
+            },
+            "raw_host_summaries": {
+                "type": "array",
+                "description": "Serialised job_host_summary_service rows from the hourly collector hook",
+            },
+        },
+        "examples": [
+            {
+                "name": "Sync one hour of host summary records",
+                "data": {
+                    "hour_timestamp": "2024-01-01T00:00:00+00:00",
+                    "raw_host_summaries": [
+                        {
+                            "id": 1,
+                            "host_name": "web01",
+                            "host_remote_id": 10,
+                            "job_remote_id": 42,
+                        }
+                    ],
+                },
+            },
+        ],
+    },
     "cleanup_dashboard_reports_old_data": {
         "queue": "dashboard",
         "category": "Maintenance",  # dashboard report JobData
@@ -475,4 +508,6 @@ __all__ = [
     "collect_dashboard_reports_data",
     "collect_dashboard_reports_initial_data",
     "cleanup_dashboard_reports_old_data",
+    "sync_dashboard_job_records",
+    "sync_dashboard_host_summaries",
 ]

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -77,6 +77,7 @@ TASK_LOCKS = {
     "collect_dashboard_reports_initial_data",
     "cleanup_dashboard_reports_old_data",
     "sync_dashboard_job_records",
+    "sync_dashboard_host_summaries",
 }
 
 

--- a/tests/unit/dashboard_reports/test_tasks.py
+++ b/tests/unit/dashboard_reports/test_tasks.py
@@ -877,8 +877,9 @@ class TestSyncDashboardHostSummaries:
 
         assert mock_sync.call_count == 2
         args, kwargs = mock_result.call_args
-        assert args[0] == "success"
+        assert args[0] == "error"
         assert kwargs["data"]["job_count"] == 1  # only job_b succeeded
+        assert kwargs["data"]["failed"] == 1
 
     @patch("apps.dashboard_reports.tasks.create_task_result")
     @patch("apps.dashboard_reports.tasks.JobData._sync_host_summaries")

--- a/tests/unit/dashboard_reports/test_tasks.py
+++ b/tests/unit/dashboard_reports/test_tasks.py
@@ -812,6 +812,13 @@ class TestSyncDashboardHostSummaries:
             "job_remote_id": job_remote_id,
         }
 
+    def _make_job_data(self, job_id, pk=None):
+        """Return a MagicMock with job_id and pk set to avoid auto-spec surprises."""
+        jd = MagicMock()
+        jd.job_id = job_id
+        jd.pk = pk if pk is not None else job_id
+        return jd
+
     @patch("apps.dashboard_reports.tasks.create_task_result")
     @patch("apps.dashboard_reports.tasks.JobData._sync_host_summaries")
     @patch("apps.dashboard_reports.tasks.JobHostSummary")
@@ -820,8 +827,8 @@ class TestSyncDashboardHostSummaries:
     @patch("django.db.transaction.atomic", new=contextlib.nullcontext)
     def test_syncs_host_summaries_for_known_job(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
         """When JobData exists for job_remote_id, _sync_host_summaries is called with remapped fields."""
-        job_data = MagicMock()
-        mock_objects.get.return_value = job_data
+        job_data = self._make_job_data(job_id=123, pk=1)
+        mock_objects.filter.return_value = [job_data]
         mock_jhs.objects.filter.return_value = []
 
         record = self._raw_record(host_summary_id=7, host_name="db01", host_remote_id=99, job_remote_id=123)
@@ -837,11 +844,13 @@ class TestSyncDashboardHostSummaries:
         assert kwargs["data"]["job_count"] == 1
 
     @patch("apps.dashboard_reports.tasks.create_task_result")
+    @patch("apps.dashboard_reports.tasks.JobHostSummary")
     @patch("apps.dashboard_reports.tasks.JobData.objects")
     @patch("apps.dashboard_reports.tasks.log_task_execution")
-    def test_skips_silently_when_job_data_not_found(self, mock_log, mock_objects, mock_result):
-        """When JobData.DoesNotExist is raised, the job is skipped without error."""
-        mock_objects.get.side_effect = JobData.DoesNotExist
+    def test_skips_silently_when_job_data_not_found(self, mock_log, mock_objects, mock_jhs, mock_result):
+        """When no JobData matches job_remote_id, the job is skipped without error."""
+        mock_objects.filter.return_value = []
+        mock_jhs.objects.filter.return_value = []
 
         sync_dashboard_host_summaries(raw_host_summaries=[self._raw_record()], hour_timestamp="2024-01-01T00:00:00")
 
@@ -857,9 +866,9 @@ class TestSyncDashboardHostSummaries:
     @patch("django.db.transaction.atomic", new=contextlib.nullcontext)
     def test_continues_after_individual_job_failure(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
         """An exception on one job is logged and remaining jobs are still processed."""
-        job_a = MagicMock()
-        job_b = MagicMock()
-        mock_objects.get.side_effect = [job_a, job_b]
+        job_a = self._make_job_data(job_id=1, pk=1)
+        job_b = self._make_job_data(job_id=2, pk=2)
+        mock_objects.filter.return_value = [job_a, job_b]
         mock_jhs.objects.filter.return_value = []
         mock_sync.side_effect = [RuntimeError("oops"), None]
 
@@ -879,8 +888,8 @@ class TestSyncDashboardHostSummaries:
     @patch("django.db.transaction.atomic", new=contextlib.nullcontext)
     def test_groups_multiple_summaries_per_job(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
         """Multiple host summary records for the same job are grouped and passed together."""
-        job_data = MagicMock()
-        mock_objects.get.return_value = job_data
+        job_data = self._make_job_data(job_id=42, pk=1)
+        mock_objects.filter.return_value = [job_data]
         mock_jhs.objects.filter.return_value = []
 
         records = [
@@ -889,7 +898,8 @@ class TestSyncDashboardHostSummaries:
         ]
         sync_dashboard_host_summaries(raw_host_summaries=records, hour_timestamp="2024-01-01T00:00:00")
 
-        mock_objects.get.assert_called_once_with(job_id=42)
+        # One batch filter call for JobData (not one get per job).
+        mock_objects.filter.assert_called_once()
         passed_summaries = mock_sync.call_args[0][1]
         assert len(passed_summaries) == 2
         assert {s["host_name"] for s in passed_summaries} == {"web01", "web02"}
@@ -897,7 +907,7 @@ class TestSyncDashboardHostSummaries:
     @patch("apps.dashboard_reports.tasks.create_task_result")
     @patch("apps.dashboard_reports.tasks.log_task_execution")
     def test_empty_raw_host_summaries(self, mock_log, mock_result):
-        """Empty input returns success with job_count=0."""
+        """Empty input returns success with job_count=0 without querying the DB."""
         sync_dashboard_host_summaries(raw_host_summaries=[], hour_timestamp="2024-01-01T00:00:00")
         args, kwargs = mock_result.call_args
         assert args[0] == "success"
@@ -911,8 +921,8 @@ class TestSyncDashboardHostSummaries:
     @patch("django.db.transaction.atomic", new=contextlib.nullcontext)
     def test_null_host_remote_id_passed_as_none_host_id(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
         """host_remote_id=None is mapped to host_id=None in the dict passed to _sync_host_summaries."""
-        job_data = MagicMock()
-        mock_objects.get.return_value = job_data
+        job_data = self._make_job_data(job_id=42, pk=1)
+        mock_objects.filter.return_value = [job_data]
         mock_jhs.objects.filter.return_value = []
 
         record = self._raw_record(host_remote_id=None)
@@ -930,3 +940,27 @@ class TestSyncDashboardHostSummaries:
         args, kwargs = mock_result.call_args
         assert args[0] == "success"
         assert kwargs["data"]["job_count"] == 0
+
+    @patch("apps.dashboard_reports.tasks.create_task_result")
+    @patch("apps.dashboard_reports.tasks.JobData._sync_host_summaries")
+    @patch("apps.dashboard_reports.tasks.JobHostSummary")
+    @patch("apps.dashboard_reports.tasks.JobData.objects")
+    @patch("apps.dashboard_reports.tasks.log_task_execution")
+    @patch("django.db.transaction.atomic", new=contextlib.nullcontext)
+    def test_uses_pre_fetched_existing_host_summaries(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
+        """Existing JobHostSummary objects are pre-fetched in one query and passed per job."""
+        job_data = self._make_job_data(job_id=42, pk=10)
+        mock_objects.filter.return_value = [job_data]
+
+        existing_hs = MagicMock()
+        existing_hs.job_data_id = 10
+        existing_hs.host_summary_id = 99
+        mock_jhs.objects.filter.return_value = [existing_hs]
+
+        record = self._raw_record(host_summary_id=99, job_remote_id=42)
+        sync_dashboard_host_summaries(raw_host_summaries=[record], hour_timestamp="2024-01-01T00:00:00")
+
+        # Confirm the existing hs was passed in the dict keyed by host_summary_id.
+        passed_existing = mock_sync.call_args[0][2]
+        assert 99 in passed_existing
+        assert passed_existing[99] is existing_hs

--- a/tests/unit/dashboard_reports/test_tasks.py
+++ b/tests/unit/dashboard_reports/test_tasks.py
@@ -18,6 +18,7 @@ from apps.dashboard_reports.tasks import (
     cleanup_dashboard_reports_old_data,
     collect_dashboard_reports_data,
     collect_dashboard_reports_initial_data,
+    sync_dashboard_host_summaries,
     sync_dashboard_job_records,
 )
 
@@ -795,3 +796,132 @@ class TestProcessBatches:
         assert mock_collect.call_count == 2
         second_call_kwargs = mock_collect.call_args_list[1][1]
         assert second_call_kwargs["after_id"] == 105  # max id from batch1, not batch1["count"]
+
+
+@pytest.mark.unit
+class TestSyncDashboardHostSummaries:
+    """Tests for sync_dashboard_host_summaries — the hourly hook-driven host summary sync task."""
+
+    def _raw_record(self, host_summary_id=1, host_name="web01", host_remote_id=10, job_remote_id=42):
+        """Return a minimal raw host summary dict as produced by the hook."""
+        return {
+            "id": host_summary_id,
+            "host_name": host_name,
+            "host_remote_id": host_remote_id,
+            "job_remote_id": job_remote_id,
+        }
+
+    @patch("apps.dashboard_reports.tasks.create_task_result")
+    @patch("apps.dashboard_reports.tasks.JobData._sync_host_summaries")
+    @patch("apps.dashboard_reports.tasks.JobHostSummary")
+    @patch("apps.dashboard_reports.tasks.JobData.objects")
+    @patch("apps.dashboard_reports.tasks.log_task_execution")
+    def test_syncs_host_summaries_for_known_job(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
+        """When JobData exists for job_remote_id, _sync_host_summaries is called with remapped fields."""
+        job_data = MagicMock()
+        mock_objects.get.return_value = job_data
+        mock_jhs.objects.filter.return_value = []
+
+        record = self._raw_record(host_summary_id=7, host_name="db01", host_remote_id=99, job_remote_id=123)
+        sync_dashboard_host_summaries(raw_host_summaries=[record], hour_timestamp="2024-01-01T00:00:00")
+
+        mock_sync.assert_called_once_with(
+            job_data,
+            [{"id": 7, "host_id": 99, "host_name": "db01"}],
+            {},
+        )
+        args, kwargs = mock_result.call_args
+        assert args[0] == "success"
+        assert kwargs["data"]["job_count"] == 1
+
+    @patch("apps.dashboard_reports.tasks.create_task_result")
+    @patch("apps.dashboard_reports.tasks.JobData.objects")
+    @patch("apps.dashboard_reports.tasks.log_task_execution")
+    def test_skips_silently_when_job_data_not_found(self, mock_log, mock_objects, mock_result):
+        """When JobData.DoesNotExist is raised, the job is skipped without error."""
+        mock_objects.get.side_effect = JobData.DoesNotExist
+
+        sync_dashboard_host_summaries(raw_host_summaries=[self._raw_record()], hour_timestamp="2024-01-01T00:00:00")
+
+        args, kwargs = mock_result.call_args
+        assert args[0] == "success"
+        assert kwargs["data"]["job_count"] == 0
+
+    @patch("apps.dashboard_reports.tasks.create_task_result")
+    @patch("apps.dashboard_reports.tasks.JobData._sync_host_summaries")
+    @patch("apps.dashboard_reports.tasks.JobHostSummary")
+    @patch("apps.dashboard_reports.tasks.JobData.objects")
+    @patch("apps.dashboard_reports.tasks.log_task_execution")
+    def test_continues_after_individual_job_failure(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
+        """An exception on one job is logged and remaining jobs are still processed."""
+        job_a = MagicMock()
+        job_b = MagicMock()
+        mock_objects.get.side_effect = [job_a, job_b]
+        mock_jhs.objects.filter.return_value = []
+        mock_sync.side_effect = [RuntimeError("oops"), None]
+
+        records = [self._raw_record(job_remote_id=1), self._raw_record(job_remote_id=2)]
+        sync_dashboard_host_summaries(raw_host_summaries=records, hour_timestamp="2024-01-01T00:00:00")
+
+        assert mock_sync.call_count == 2
+        args, kwargs = mock_result.call_args
+        assert args[0] == "success"
+        assert kwargs["data"]["job_count"] == 1  # only job_b succeeded
+
+    @patch("apps.dashboard_reports.tasks.create_task_result")
+    @patch("apps.dashboard_reports.tasks.JobData._sync_host_summaries")
+    @patch("apps.dashboard_reports.tasks.JobHostSummary")
+    @patch("apps.dashboard_reports.tasks.JobData.objects")
+    @patch("apps.dashboard_reports.tasks.log_task_execution")
+    def test_groups_multiple_summaries_per_job(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
+        """Multiple host summary records for the same job are grouped and passed together."""
+        job_data = MagicMock()
+        mock_objects.get.return_value = job_data
+        mock_jhs.objects.filter.return_value = []
+
+        records = [
+            self._raw_record(host_summary_id=1, host_name="web01", job_remote_id=42),
+            self._raw_record(host_summary_id=2, host_name="web02", job_remote_id=42),
+        ]
+        sync_dashboard_host_summaries(raw_host_summaries=records, hour_timestamp="2024-01-01T00:00:00")
+
+        mock_objects.get.assert_called_once_with(job_id=42)
+        passed_summaries = mock_sync.call_args[0][1]
+        assert len(passed_summaries) == 2
+        assert {s["host_name"] for s in passed_summaries} == {"web01", "web02"}
+
+    @patch("apps.dashboard_reports.tasks.create_task_result")
+    @patch("apps.dashboard_reports.tasks.log_task_execution")
+    def test_empty_raw_host_summaries(self, mock_log, mock_result):
+        """Empty input returns success with job_count=0."""
+        sync_dashboard_host_summaries(raw_host_summaries=[], hour_timestamp="2024-01-01T00:00:00")
+        args, kwargs = mock_result.call_args
+        assert args[0] == "success"
+        assert kwargs["data"]["job_count"] == 0
+
+    @patch("apps.dashboard_reports.tasks.create_task_result")
+    @patch("apps.dashboard_reports.tasks.JobData._sync_host_summaries")
+    @patch("apps.dashboard_reports.tasks.JobHostSummary")
+    @patch("apps.dashboard_reports.tasks.JobData.objects")
+    @patch("apps.dashboard_reports.tasks.log_task_execution")
+    def test_null_host_remote_id_passed_as_none_host_id(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
+        """host_remote_id=None is mapped to host_id=None in the dict passed to _sync_host_summaries."""
+        job_data = MagicMock()
+        mock_objects.get.return_value = job_data
+        mock_jhs.objects.filter.return_value = []
+
+        record = self._raw_record(host_remote_id=None)
+        sync_dashboard_host_summaries(raw_host_summaries=[record], hour_timestamp="2024-01-01T00:00:00")
+
+        passed_summaries = mock_sync.call_args[0][1]
+        assert passed_summaries[0]["host_id"] is None
+
+    @patch("apps.dashboard_reports.tasks.create_task_result")
+    @patch("apps.dashboard_reports.tasks.log_task_execution")
+    def test_records_with_null_job_remote_id_are_dropped(self, mock_log, mock_result):
+        """Records where job_remote_id is None are ignored without error."""
+        record = {"id": 1, "host_name": "h1", "host_remote_id": 5, "job_remote_id": None}
+        sync_dashboard_host_summaries(raw_host_summaries=[record], hour_timestamp="2024-01-01T00:00:00")
+        args, kwargs = mock_result.call_args
+        assert args[0] == "success"
+        assert kwargs["data"]["job_count"] == 0

--- a/tests/unit/dashboard_reports/test_tasks.py
+++ b/tests/unit/dashboard_reports/test_tasks.py
@@ -803,12 +803,12 @@ class TestProcessBatches:
 class TestSyncDashboardHostSummaries:
     """Tests for sync_dashboard_host_summaries — the hourly hook-driven host summary sync task."""
 
-    def _raw_record(self, host_summary_id=1, host_name="web01", host_remote_id=10, job_remote_id=42):
-        """Return a minimal raw host summary dict as produced by the hook."""
+    def _raw_record(self, host_summary_id=1, host_name="web01", host_id=10, job_remote_id=42):
+        """Return a minimal raw host summary dict as produced by the hook (wire format)."""
         return {
             "id": host_summary_id,
             "host_name": host_name,
-            "host_remote_id": host_remote_id,
+            "host_id": host_id,
             "job_remote_id": job_remote_id,
         }
 
@@ -831,7 +831,7 @@ class TestSyncDashboardHostSummaries:
         mock_objects.filter.return_value = [job_data]
         mock_jhs.objects.filter.return_value = []
 
-        record = self._raw_record(host_summary_id=7, host_name="db01", host_remote_id=99, job_remote_id=123)
+        record = self._raw_record(host_summary_id=7, host_name="db01", host_id=99, job_remote_id=123)
         sync_dashboard_host_summaries(raw_host_summaries=[record], hour_timestamp="2024-01-01T00:00:00")
 
         mock_sync.assert_called_once_with(
@@ -920,13 +920,13 @@ class TestSyncDashboardHostSummaries:
     @patch("apps.dashboard_reports.tasks.JobData.objects")
     @patch("apps.dashboard_reports.tasks.log_task_execution")
     @patch("django.db.transaction.atomic", new=contextlib.nullcontext)
-    def test_null_host_remote_id_passed_as_none_host_id(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
-        """host_remote_id=None is mapped to host_id=None in the dict passed to _sync_host_summaries."""
+    def test_null_host_id_is_preserved(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
+        """host_id=None (deleted AWX host) is passed as None to _sync_host_summaries."""
         job_data = self._make_job_data(job_id=42, pk=1)
         mock_objects.filter.return_value = [job_data]
         mock_jhs.objects.filter.return_value = []
 
-        record = self._raw_record(host_remote_id=None)
+        record = self._raw_record(host_id=None)
         sync_dashboard_host_summaries(raw_host_summaries=[record], hour_timestamp="2024-01-01T00:00:00")
 
         passed_summaries = mock_sync.call_args[0][1]
@@ -936,7 +936,17 @@ class TestSyncDashboardHostSummaries:
     @patch("apps.dashboard_reports.tasks.log_task_execution")
     def test_records_with_null_job_remote_id_are_dropped(self, mock_log, mock_result):
         """Records where job_remote_id is None are ignored without error."""
-        record = {"id": 1, "host_name": "h1", "host_remote_id": 5, "job_remote_id": None}
+        record = {"id": 1, "host_name": "h1", "host_id": 5, "job_remote_id": None}
+        sync_dashboard_host_summaries(raw_host_summaries=[record], hour_timestamp="2024-01-01T00:00:00")
+        args, kwargs = mock_result.call_args
+        assert args[0] == "success"
+        assert kwargs["data"]["job_count"] == 0
+
+    @patch("apps.dashboard_reports.tasks.create_task_result")
+    @patch("apps.dashboard_reports.tasks.log_task_execution")
+    def test_records_with_null_id_are_dropped(self, mock_log, mock_result):
+        """Records where id is None are ignored without error."""
+        record = {"id": None, "host_name": "h1", "host_id": 5, "job_remote_id": 42}
         sync_dashboard_host_summaries(raw_host_summaries=[record], hour_timestamp="2024-01-01T00:00:00")
         args, kwargs = mock_result.call_args
         assert args[0] == "success"

--- a/tests/unit/dashboard_reports/test_tasks.py
+++ b/tests/unit/dashboard_reports/test_tasks.py
@@ -1,5 +1,6 @@
 # test_tasks.py - Unit tests for dashboard_reports tasks
 
+import contextlib
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -816,6 +817,7 @@ class TestSyncDashboardHostSummaries:
     @patch("apps.dashboard_reports.tasks.JobHostSummary")
     @patch("apps.dashboard_reports.tasks.JobData.objects")
     @patch("apps.dashboard_reports.tasks.log_task_execution")
+    @patch("django.db.transaction.atomic", new=contextlib.nullcontext)
     def test_syncs_host_summaries_for_known_job(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
         """When JobData exists for job_remote_id, _sync_host_summaries is called with remapped fields."""
         job_data = MagicMock()
@@ -852,6 +854,7 @@ class TestSyncDashboardHostSummaries:
     @patch("apps.dashboard_reports.tasks.JobHostSummary")
     @patch("apps.dashboard_reports.tasks.JobData.objects")
     @patch("apps.dashboard_reports.tasks.log_task_execution")
+    @patch("django.db.transaction.atomic", new=contextlib.nullcontext)
     def test_continues_after_individual_job_failure(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
         """An exception on one job is logged and remaining jobs are still processed."""
         job_a = MagicMock()
@@ -873,6 +876,7 @@ class TestSyncDashboardHostSummaries:
     @patch("apps.dashboard_reports.tasks.JobHostSummary")
     @patch("apps.dashboard_reports.tasks.JobData.objects")
     @patch("apps.dashboard_reports.tasks.log_task_execution")
+    @patch("django.db.transaction.atomic", new=contextlib.nullcontext)
     def test_groups_multiple_summaries_per_job(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
         """Multiple host summary records for the same job are grouped and passed together."""
         job_data = MagicMock()
@@ -904,6 +908,7 @@ class TestSyncDashboardHostSummaries:
     @patch("apps.dashboard_reports.tasks.JobHostSummary")
     @patch("apps.dashboard_reports.tasks.JobData.objects")
     @patch("apps.dashboard_reports.tasks.log_task_execution")
+    @patch("django.db.transaction.atomic", new=contextlib.nullcontext)
     def test_null_host_remote_id_passed_as_none_host_id(self, mock_log, mock_objects, mock_jhs, mock_sync, mock_result):
         """host_remote_id=None is mapped to host_id=None in the dict passed to _sync_host_summaries."""
         job_data = MagicMock()

--- a/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
@@ -675,7 +675,9 @@ class TestBuildHostSummaryTaskChunks:
         from apps.tasks.collectors.collect_hourly_metrics import _HOST_SUMMARY_RECORD_CHUNK_SIZE
 
         # Each job has exactly 1 record; limit + 1 jobs → 2 chunks
-        by_job = {i: [{"id": i, "host_id": i, "host_name": f"h{i}"}] for i in range(_HOST_SUMMARY_RECORD_CHUNK_SIZE + 1)}
+        by_job = {
+            i: [{"id": i, "host_id": i, "host_name": f"h{i}"}] for i in range(_HOST_SUMMARY_RECORD_CHUNK_SIZE + 1)
+        }
         result = _build_host_summary_task_chunks(by_job, "2024-01-01T00:00:00+00:00")
         assert len(result) == 2
         names = list(result.keys())

--- a/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
@@ -159,6 +159,24 @@ class TestBuildDashboardSyncHook:
         assert len(first_call[1]["defaults"]["task_data"]["raw_jobs"]) == _SYNC_TASK_CHUNK_SIZE
         assert len(second_call[1]["defaults"]["task_data"]["raw_jobs"]) == 1
 
+    def test_hook_deletes_stale_pending_chunks_on_retry(self):
+        """After upsert, pending tasks for the same hour outside the new chunk set are deleted."""
+        df = _make_df([{"status": "successful", "launch_type": "manual"}])  # 1 record → 1 chunk
+        hook = self._enabled_hook()
+        hour_ts_str = HOUR_TS.isoformat()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            mock_task.objects.update_or_create.return_value = (MagicMock(), True)
+            hook(df)
+
+        filter_call = mock_task.objects.filter.call_args
+        assert filter_call is not None
+        assert filter_call[1]["name__startswith"] == f"sync_dashboard_jobs_{hour_ts_str}_"
+        assert filter_call[1]["status"] == "pending"
+        expected_new_name = f"sync_dashboard_jobs_{hour_ts_str}_0"
+        exclude_call = mock_task.objects.filter.return_value.exclude.call_args
+        assert exclude_call[1]["name__in"] == {expected_new_name}
+        mock_task.objects.filter.return_value.exclude.return_value.delete.assert_called_once()
+
 
 @pytest.mark.unit
 class TestSerializeDashboardRecord:
@@ -519,6 +537,26 @@ class TestBuildDashboardHostSummarySyncHook:
         with patch(TASK_MODEL_PATH) as mock_task:
             hook(df)
         mock_task.objects.update_or_create.assert_not_called()
+
+    def test_hook_deletes_stale_pending_chunks_on_retry(self):
+        """After upsert, pending tasks for the same hour outside the new chunk set are deleted."""
+        df = _make_host_summary_df([{}])  # 1 job → 1 chunk (_0 only)
+        hook = self._enabled_hook()
+        hour_ts_str = HOUR_TS.isoformat()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            mock_task.objects.update_or_create.return_value = (MagicMock(), True)
+            hook(df)
+
+        # filter().exclude().delete() chain must be called to purge stale chunks.
+        filter_call = mock_task.objects.filter.call_args
+        assert filter_call is not None
+        assert filter_call[1]["name__startswith"] == f"sync_dashboard_host_summaries_{hour_ts_str}_"
+        assert filter_call[1]["status"] == "pending"
+        # exclude must receive only the new chunk name
+        expected_new_name = f"sync_dashboard_host_summaries_{hour_ts_str}_0"
+        exclude_call = mock_task.objects.filter.return_value.exclude.call_args
+        assert exclude_call[1]["name__in"] == {expected_new_name}
+        mock_task.objects.filter.return_value.exclude.return_value.delete.assert_called_once()
 
 
 @pytest.mark.unit

--- a/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
@@ -7,9 +7,11 @@ import pandas as pd
 import pytest
 
 from apps.tasks.collectors.collect_hourly_metrics import (
+    _build_dashboard_host_summary_sync_hook,
     _build_dashboard_sync_hook,
     _get_hourly_collectors,
     _serialize_dashboard_record,
+    _serialize_host_summary_record,
 )
 
 
@@ -387,3 +389,165 @@ class TestHourlyCollectorRegistry:
         assert entry.get("post_collect_hook_factory") is _build_dashboard_sync_hook, (
             "unified_jobs registry entry must wire _build_dashboard_sync_hook as post_collect_hook_factory"
         )
+
+    def test_job_host_summary_service_has_host_summary_hook_factory(self):
+        """job_host_summary_service entry must register _build_dashboard_host_summary_sync_hook."""
+        registry = _get_hourly_collectors()
+        entry = registry.get("job_host_summary_service")
+        assert entry is not None, "job_host_summary_service key missing from hourly collector registry"
+        assert entry.get("post_collect_hook_factory") is _build_dashboard_host_summary_sync_hook, (
+            "job_host_summary_service must wire _build_dashboard_host_summary_sync_hook"
+        )
+
+
+def _make_host_summary_df(rows: list[dict]) -> pd.DataFrame:
+    """Build a minimal DataFrame matching the job_host_summary_service schema."""
+    defaults = {
+        "id": 1,
+        "host_name": "web01",
+        "host_remote_id": 10,
+        "job_remote_id": 42,
+        # Extra columns present in the real collector — hook must ignore these.
+        "changed": 0,
+        "failures": 0,
+        "ok": 5,
+    }
+    return pd.DataFrame([{**defaults, **r} for r in rows])
+
+
+@pytest.mark.unit
+class TestBuildDashboardHostSummarySyncHook:
+    """Tests for _build_dashboard_host_summary_sync_hook and its returned inner hook."""
+
+    def test_returns_none_when_feature_disabled(self):
+        """When DASHBOARD_COLLECTION is off, the factory returns None."""
+        with patch(FEATURE_FLAG_PATH, return_value=False):
+            result = _build_dashboard_host_summary_sync_hook(HOUR_TS)
+        assert result is None
+
+    def test_returns_callable_when_feature_enabled(self):
+        """When DASHBOARD_COLLECTION is on, the factory returns a callable hook."""
+        with patch(FEATURE_FLAG_PATH, return_value=True):
+            hook = _build_dashboard_host_summary_sync_hook(HOUR_TS)
+        assert callable(hook)
+
+    def _enabled_hook(self):
+        """Build a hook with DASHBOARD_COLLECTION enabled."""
+        with patch(FEATURE_FLAG_PATH, return_value=True):
+            return _build_dashboard_host_summary_sync_hook(HOUR_TS)
+
+    def test_hook_returns_early_when_raw_data_none(self):
+        """hook(None) exits immediately without touching Task."""
+        hook = self._enabled_hook()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            hook(None)
+        mock_task.objects.update_or_create.assert_not_called()
+
+    def test_hook_returns_early_when_dataframe_empty(self):
+        """hook(empty_df) exits without creating a Task."""
+        hook = self._enabled_hook()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            hook(pd.DataFrame())
+        mock_task.objects.update_or_create.assert_not_called()
+
+    def test_hook_returns_early_when_required_columns_missing(self):
+        """If the DataFrame is missing any required column, no Task is created (schema drift guard)."""
+        df = pd.DataFrame([{"id": 1, "host_name": "h1"}])  # missing host_remote_id, job_remote_id
+        hook = self._enabled_hook()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            hook(df)
+        mock_task.objects.update_or_create.assert_not_called()
+
+    def test_hook_creates_task_with_correct_function_name(self):
+        """A valid DataFrame causes update_or_create with function_name='sync_dashboard_host_summaries'."""
+        df = _make_host_summary_df([{}])
+        hook = self._enabled_hook()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            mock_task.objects.update_or_create.return_value = (MagicMock(), True)
+            hook(df)
+        mock_task.objects.update_or_create.assert_called_once()
+        call_kwargs = mock_task.objects.update_or_create.call_args[1]
+        assert call_kwargs["defaults"]["function_name"] == "sync_dashboard_host_summaries"
+
+    def test_hook_serialises_raw_host_summaries_into_task_data(self):
+        """raw_host_summaries in task_data contains id, host_name, host_remote_id, job_remote_id."""
+        df = _make_host_summary_df([{"id": 7, "host_name": "db01", "host_remote_id": 99, "job_remote_id": 123}])
+        hook = self._enabled_hook()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            mock_task.objects.update_or_create.return_value = (MagicMock(), True)
+            hook(df)
+        task_data = mock_task.objects.update_or_create.call_args[1]["defaults"]["task_data"]
+        records = task_data["raw_host_summaries"]
+        assert len(records) == 1
+        assert records[0]["id"] == 7
+        assert records[0]["host_name"] == "db01"
+        assert records[0]["host_remote_id"] == 99
+        assert records[0]["job_remote_id"] == 123
+
+    def test_hook_uses_update_or_create_for_idempotency(self):
+        """Task creation uses update_or_create so retry is safe."""
+        df = _make_host_summary_df([{}])
+        hook = self._enabled_hook()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            mock_task.objects.update_or_create.return_value = (MagicMock(), True)
+            hook(df)
+        assert mock_task.objects.update_or_create.called
+
+    def test_hook_chunks_by_job(self):
+        """Records for more than _SYNC_TASK_CHUNK_SIZE unique jobs are split across multiple Tasks."""
+        from apps.tasks.collectors.collect_hourly_metrics import _SYNC_TASK_CHUNK_SIZE
+
+        rows = [{"id": i, "job_remote_id": i} for i in range(_SYNC_TASK_CHUNK_SIZE + 1)]
+        df = _make_host_summary_df(rows)
+        hook = self._enabled_hook()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            mock_task.objects.update_or_create.return_value = (MagicMock(), True)
+            hook(df)
+
+        assert mock_task.objects.update_or_create.call_count == 2
+        first_call = mock_task.objects.update_or_create.call_args_list[0]
+        second_call = mock_task.objects.update_or_create.call_args_list[1]
+        assert first_call[1]["name"].endswith("_0")
+        assert second_call[1]["name"].endswith("_1")
+
+    def test_hook_skips_rows_with_null_job_remote_id(self):
+        """Rows where job_remote_id is None are dropped and no Task is created."""
+        df = _make_host_summary_df([{"job_remote_id": None}])
+        # pandas will store None as NaN for numeric column — force object dtype
+        df["job_remote_id"] = df["job_remote_id"].astype(object)
+        hook = self._enabled_hook()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            hook(df)
+        mock_task.objects.update_or_create.assert_not_called()
+
+
+@pytest.mark.unit
+class TestSerializeHostSummaryRecord:
+    """Branch-coverage tests for _serialize_host_summary_record."""
+
+    def test_basic_row_coerced_correctly(self):
+        """Standard row with all fields present is returned with Python-native types."""
+        import numpy as np
+
+        row = {"id": np.int64(5), "host_name": "web01", "host_remote_id": np.int64(10), "job_remote_id": np.int64(42)}
+        result = _serialize_host_summary_record(row)
+        assert result == {"id": 5, "host_name": "web01", "host_remote_id": 10, "job_remote_id": 42}
+        assert isinstance(result["id"], int)
+
+    def test_null_host_remote_id_stays_none(self):
+        """host_remote_id=None (deleted AWX host) is preserved as None."""
+        row = {"id": 1, "host_name": "h1", "host_remote_id": None, "job_remote_id": 7}
+        result = _serialize_host_summary_record(row)
+        assert result["host_remote_id"] is None
+
+    def test_nan_host_remote_id_becomes_none(self):
+        """NaN in host_remote_id (pandas float64 upcast of nullable int) is coerced to None."""
+        row = {"id": 1, "host_name": "h1", "host_remote_id": float("nan"), "job_remote_id": 7}
+        result = _serialize_host_summary_record(row)
+        assert result["host_remote_id"] is None
+
+    def test_null_host_name_stays_none(self):
+        """host_name=None is preserved as None."""
+        row = {"id": 1, "host_name": None, "host_remote_id": 10, "job_remote_id": 7}
+        result = _serialize_host_summary_record(row)
+        assert result["host_name"] is None

--- a/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
@@ -511,11 +511,12 @@ class TestBuildDashboardHostSummarySyncHook:
             hook(df)
         assert mock_task.objects.update_or_create.called
 
-    def test_hook_chunks_by_job(self):
-        """Records for more than _SYNC_TASK_CHUNK_SIZE unique jobs are split across multiple Tasks."""
-        from apps.tasks.collectors.collect_hourly_metrics import _SYNC_TASK_CHUNK_SIZE
+    def test_hook_chunks_by_record_count(self):
+        """Total records exceeding _HOST_SUMMARY_RECORD_CHUNK_SIZE are split across multiple Tasks."""
+        from apps.tasks.collectors.collect_hourly_metrics import _HOST_SUMMARY_RECORD_CHUNK_SIZE
 
-        rows = [{"id": i, "job_remote_id": i} for i in range(_SYNC_TASK_CHUNK_SIZE + 1)]
+        # One record per unique job so the boundary falls cleanly at the record limit.
+        rows = [{"id": i, "job_remote_id": i} for i in range(_HOST_SUMMARY_RECORD_CHUNK_SIZE + 1)]
         df = _make_host_summary_df(rows)
         hook = self._enabled_hook()
         with patch(TASK_MODEL_PATH) as mock_task:
@@ -527,6 +528,25 @@ class TestBuildDashboardHostSummarySyncHook:
         second_call = mock_task.objects.update_or_create.call_args_list[1]
         assert first_call[1]["name"].endswith("_0")
         assert second_call[1]["name"].endswith("_1")
+
+    def test_hook_keeps_single_job_records_in_one_chunk(self):
+        """All records for a single job stay in one chunk even if the count exceeds the record limit.
+
+        _sync_host_summaries deletes records not present in its batch, so splitting a job
+        across tasks would cause the first task to delete the second task's records.
+        """
+        from apps.tasks.collectors.collect_hourly_metrics import _HOST_SUMMARY_RECORD_CHUNK_SIZE
+
+        rows = [{"id": i, "job_remote_id": 42} for i in range(_HOST_SUMMARY_RECORD_CHUNK_SIZE + 10)]
+        df = _make_host_summary_df(rows)
+        hook = self._enabled_hook()
+        with patch(TASK_MODEL_PATH) as mock_task:
+            mock_task.objects.update_or_create.return_value = (MagicMock(), True)
+            hook(df)
+
+        assert mock_task.objects.update_or_create.call_count == 1
+        task_data = mock_task.objects.update_or_create.call_args[1]["defaults"]["task_data"]
+        assert len(task_data["raw_host_summaries"]) == _HOST_SUMMARY_RECORD_CHUNK_SIZE + 10
 
     def test_hook_skips_rows_with_null_job_remote_id(self):
         """Rows where job_remote_id is None are dropped and no Task is created."""

--- a/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
@@ -9,7 +9,9 @@ import pytest
 from apps.tasks.collectors.collect_hourly_metrics import (
     _build_dashboard_host_summary_sync_hook,
     _build_dashboard_sync_hook,
+    _build_host_summary_task_chunks,
     _get_hourly_collectors,
+    _group_host_summary_rows,
     _serialize_dashboard_record,
     _serialize_host_summary_record,
 )
@@ -488,7 +490,7 @@ class TestBuildDashboardHostSummarySyncHook:
         assert call_kwargs["defaults"]["function_name"] == "sync_dashboard_host_summaries"
 
     def test_hook_serialises_raw_host_summaries_into_task_data(self):
-        """raw_host_summaries in task_data contains id, host_name, host_remote_id, job_remote_id."""
+        """raw_host_summaries in task_data contains id, host_name, host_id, job_remote_id."""
         df = _make_host_summary_df([{"id": 7, "host_name": "db01", "host_remote_id": 99, "job_remote_id": 123}])
         hook = self._enabled_hook()
         with patch(TASK_MODEL_PATH) as mock_task:
@@ -499,7 +501,7 @@ class TestBuildDashboardHostSummarySyncHook:
         assert len(records) == 1
         assert records[0]["id"] == 7
         assert records[0]["host_name"] == "db01"
-        assert records[0]["host_remote_id"] == 99
+        assert records[0]["host_id"] == 99
         assert records[0]["job_remote_id"] == 123
 
     def test_hook_uses_update_or_create_for_idempotency(self):
@@ -589,23 +591,110 @@ class TestSerializeHostSummaryRecord:
 
         row = {"id": np.int64(5), "host_name": "web01", "host_remote_id": np.int64(10), "job_remote_id": np.int64(42)}
         result = _serialize_host_summary_record(row)
-        assert result == {"id": 5, "host_name": "web01", "host_remote_id": 10, "job_remote_id": 42}
+        assert result == {"id": 5, "host_name": "web01", "host_id": 10, "job_remote_id": 42}
         assert isinstance(result["id"], int)
 
     def test_null_host_remote_id_stays_none(self):
-        """host_remote_id=None (deleted AWX host) is preserved as None."""
+        """host_id=None (deleted AWX host) is preserved as None."""
         row = {"id": 1, "host_name": "h1", "host_remote_id": None, "job_remote_id": 7}
         result = _serialize_host_summary_record(row)
-        assert result["host_remote_id"] is None
+        assert result["host_id"] is None
 
     def test_nan_host_remote_id_becomes_none(self):
         """NaN in host_remote_id (pandas float64 upcast of nullable int) is coerced to None."""
         row = {"id": 1, "host_name": "h1", "host_remote_id": float("nan"), "job_remote_id": 7}
         result = _serialize_host_summary_record(row)
-        assert result["host_remote_id"] is None
+        assert result["host_id"] is None
 
     def test_null_host_name_stays_none(self):
         """host_name=None is preserved as None."""
         row = {"id": 1, "host_name": None, "host_remote_id": 10, "job_remote_id": 7}
         result = _serialize_host_summary_record(row)
         assert result["host_name"] is None
+
+
+@pytest.mark.unit
+class TestGroupHostSummaryRows:
+    """Tests for _group_host_summary_rows."""
+
+    def test_basic_grouping(self):
+        """Rows with the same job_remote_id are grouped together."""
+        rows = [
+            {"id": 1, "host_name": "h1", "host_remote_id": 10, "job_remote_id": 42},
+            {"id": 2, "host_name": "h2", "host_remote_id": 11, "job_remote_id": 42},
+            {"id": 3, "host_name": "h3", "host_remote_id": 12, "job_remote_id": 99},
+        ]
+        result = _group_host_summary_rows(rows)
+        assert set(result.keys()) == {42, 99}
+        assert len(result[42]) == 2
+        assert len(result[99]) == 1
+
+    def test_drops_rows_with_null_job_remote_id(self):
+        """Rows where job_remote_id serialises to None are excluded."""
+        rows = [
+            {"id": 1, "host_name": "h1", "host_remote_id": 10, "job_remote_id": None},
+            {"id": 2, "host_name": "h2", "host_remote_id": 11, "job_remote_id": 42},
+        ]
+        result = _group_host_summary_rows(rows)
+        assert list(result.keys()) == [42]
+
+    def test_empty_input_returns_empty_dict(self):
+        """Empty rows list produces an empty by_job dict."""
+        assert _group_host_summary_rows([]) == {}
+
+    def test_output_records_use_host_id_key(self):
+        """Serialised records in the output use host_id, not host_remote_id."""
+        rows = [{"id": 5, "host_name": "h1", "host_remote_id": 77, "job_remote_id": 1}]
+        result = _group_host_summary_rows(rows)
+        record = result[1][0]
+        assert "host_id" in record
+        assert "host_remote_id" not in record
+        assert record["host_id"] == 77
+
+
+@pytest.mark.unit
+class TestBuildHostSummaryTaskChunks:
+    """Tests for _build_host_summary_task_chunks."""
+
+    def _make_records(self, n):
+        return [{"id": i, "host_id": i, "host_name": f"h{i}", "job_remote_id": i} for i in range(n)]
+
+    def test_single_chunk_when_below_limit(self):
+        """All records fit in one chunk when total count is below the limit."""
+        from apps.tasks.collectors.collect_hourly_metrics import _HOST_SUMMARY_RECORD_CHUNK_SIZE
+
+        by_job = {i: [{"id": i, "host_id": i, "host_name": f"h{i}", "job_remote_id": i}] for i in range(5)}
+        result = _build_host_summary_task_chunks(by_job, "2024-01-01T00:00:00+00:00")
+        assert len(result) == 1
+        chunk_name = list(result.keys())[0]
+        assert chunk_name.endswith("_0")
+        assert len(list(result.values())[0]) == 5
+
+    def test_splits_into_two_chunks_at_limit(self):
+        """Records exceeding the limit across distinct jobs split into two chunks."""
+        from apps.tasks.collectors.collect_hourly_metrics import _HOST_SUMMARY_RECORD_CHUNK_SIZE
+
+        # Each job has exactly 1 record; limit + 1 jobs → 2 chunks
+        by_job = {i: [{"id": i, "host_id": i, "host_name": f"h{i}"}] for i in range(_HOST_SUMMARY_RECORD_CHUNK_SIZE + 1)}
+        result = _build_host_summary_task_chunks(by_job, "2024-01-01T00:00:00+00:00")
+        assert len(result) == 2
+        names = list(result.keys())
+        assert names[0].endswith("_0")
+        assert names[1].endswith("_1")
+
+    def test_single_oversized_job_stays_in_one_chunk(self):
+        """A job with more records than the limit is never split across chunks."""
+        from apps.tasks.collectors.collect_hourly_metrics import _HOST_SUMMARY_RECORD_CHUNK_SIZE
+
+        oversized = [{"id": i} for i in range(_HOST_SUMMARY_RECORD_CHUNK_SIZE + 50)]
+        by_job = {42: oversized}
+        result = _build_host_summary_task_chunks(by_job, "2024-01-01T00:00:00+00:00")
+        assert len(result) == 1
+        assert len(list(result.values())[0]) == _HOST_SUMMARY_RECORD_CHUNK_SIZE + 50
+
+    def test_chunk_names_include_hour_ts_str(self):
+        """Chunk names embed the hour timestamp so stale-chunk cleanup targets the right hour."""
+        by_job = {1: [{"id": 1}]}
+        result = _build_host_summary_task_chunks(by_job, "2024-06-01T12:00:00+00:00")
+        name = list(result.keys())[0]
+        assert "2024-06-01T12:00:00+00:00" in name


### PR DESCRIPTION
## Summary

- Adds `_build_dashboard_host_summary_sync_hook` to the `job_host_summary_service` hourly collector registry entry, mirroring the `unified_jobs` hook pattern from PR #210
- Adds `sync_dashboard_host_summaries` task that remaps `host_remote_id → host_id`, looks up `JobData` by AWX job ID, and calls `_sync_host_summaries` per job
- Registers the new task in `TASK_FUNCTIONS`, `TASK_LOCKS`, `TASK_METADATA`, and `__all__` in `apps/tasks/tasks.py`

## Problem

After PR #210, the incremental hourly sync hardcoded `host_summaries=None` in `sync_dashboard_job_records`, which was intentional to preserve initial backfill records. However, jobs arriving after the backfill never got `JobHostSummary` records. The dashboard's `total_number_of_unique_hosts` metric queries `JobHostSummary` directly with cross-job de-duplication (`DISTINCT stable_host`) and cannot be computed from the per-job `num_hosts` count alone — so the metric was silently undercounted for post-backfill jobs (AAP-79242).

## How it works

`job_host_summary_service` already runs hourly and its raw DataFrame contains `id`, `host_name`, `host_remote_id`, and `job_remote_id` — exactly what `JobHostSummary` needs. The new hook reuses this data (no extra Controller DB queries) by:

1. Grouping rows by `job_remote_id` and chunking by total record count (up to 2,000 host summary records per task, keeping all records for a single job together — required because `_sync_host_summaries` deletes stale records, so splitting a job across tasks would cause the first task to delete the second's records)
2. Scheduling `sync_dashboard_host_summaries` Tasks via `update_or_create` (idempotent on retry)
3. After each run, deleting any pending chunk tasks for the same hour that were not re-created (prevents stale chunks from a prior run being dispatched with outdated payloads)
4. The task pre-fetches all matching `JobData` and `JobHostSummary` records in two bulk queries before processing, then uses dict lookups in the loop (2 queries per task vs. up to 1000 with the naive per-job approach)
5. The task skips jobs with no matching `JobData` (sync-type / non-terminal jobs not tracked by the dashboard) and returns `"error"` if any per-job sync fails so the task runner's retry mechanism fires — consistent with how `sync_dashboard_job_records` handles failures

## Review fixes (latest commit)

Three issues surfaced in code review and addressed before merge:

- **Error return on partial failure** — `sync_dashboard_host_summaries` previously returned `"success"` unconditionally even when individual job syncs failed, silently dropping failed records and preventing retries. Now tracks a `failed` counter and returns `"error"` when any job fails, consistent with `sync_dashboard_job_records`.
- **Stale-chunk guard** — Added `if not new_names: return` before the stale-chunk delete in `_build_dashboard_sync_hook` (the jobs hook). The host-summary hook was already guarded via `if not by_job: return`; the jobs hook was relying on an implicit invariant. Django's `.exclude(name__in=set())` generates `NOT IN ()` → `TRUE`, which would delete all pending chunks if `new_names` were ever empty.
- **Record-count chunking** — Replaced job-count chunking (500 jobs/chunk, unbounded records) with record-count chunking (2,000 records/chunk, ~300KB payload). A single job with more records than the limit stays in one chunk — splitting would break stale deletion.

## Test plan

- [ ] `pytest tests/unit/dashboard_reports/test_tasks.py tests/unit/tasks/collectors/test_collect_hourly_metrics.py` — 106 tests pass (26 new)
- [ ] Enable `DASHBOARD_COLLECTION`, run initial backfill, trigger `hourly_job_host_summary` — confirm `sync_dashboard_host_summaries` Tasks are created and `JobHostSummary` records appear for the hour's jobs
- [ ] Verify `/api/v1/dashboard_reports/report/` `total_number_of_unique_hosts` includes hosts from post-backfill jobs

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.