### PR TITLE
Milan reenable events collector

### DIFF
--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -138,6 +138,12 @@ URL_PREFIX = None
 # Task execution timeout in seconds (override via METRICS_SERVICE_TASK_TIMEOUT env var)
 TASK_TIMEOUT = 3600
 
+# Maximum number of job event rows fetched per hourly collection run.
+# At ~700–900 bytes/row in memory, 2 000 000 rows ≈ 1.4–1.8 GB.  Raise for
+# high-volume installations; lower for memory-constrained environments.
+# Override via METRICS_SERVICE_JOBEVENT_ROW_LIMIT env var.
+JOBEVENT_ROW_LIMIT = 2_000_000
+
 
 # Project-specific middleware additions
 MIDDLEWARE = "@merge_unique whitenoise.middleware.WhiteNoiseMiddleware"

--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -142,7 +142,7 @@ TASK_TIMEOUT = 3600
 # At ~700–900 bytes/row in memory, 2 000 000 rows ≈ 1.4–1.8 GB.  Raise for
 # high-volume installations; lower for memory-constrained environments.
 # Override via METRICS_SERVICE_JOBEVENT_ROW_LIMIT env var.
-JOBEVENT_ROW_LIMIT = 2_000_000
+JOBEVENT_ROW_LIMIT = 1_000_000
 
 
 # Project-specific middleware additions

--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -10,6 +10,7 @@ import math
 from datetime import timedelta
 from typing import Any
 
+from django.conf import settings
 from django.utils import timezone
 
 from ..utils import create_task_result, generic_collect_metrics, get_db_connection, parse_datetime_string
@@ -64,7 +65,6 @@ def _get_hourly_collectors():
             "collector_func": main_jobevent_service,
             "rollup_processor": EventModulesAnonymizedRollup,
             "description": "Job events (event modules) metrics",
-            # FIXME(AAP-78081): pass row limit / time-budget cap to collector_func
         },
         "indirect_managed_nodes": {
             "collector_func": main_indirectmanagednodeaudit,
@@ -121,6 +121,10 @@ def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
     hook_factory = collector_registry.get(collector_type, {}).get("post_collect_hook_factory")
     post_collect_hook = hook_factory(start_datetime) if hook_factory else None
 
+    collector_kwargs: dict[str, Any] = {"since": start_datetime, "until": end_datetime}
+    if collector_type == "main_jobevent_service":
+        collector_kwargs["row_limit"] = settings.JOBEVENT_ROW_LIMIT
+
     # Use generic collector with hourly-specific time window
     return generic_collect_metrics(
         collector_type=collector_type,
@@ -128,7 +132,7 @@ def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
         collection_mode="hourly",
         timestamp=start_datetime,
         db_connection=db_connection,
-        collector_kwargs={"since": start_datetime, "until": end_datetime},
+        collector_kwargs=collector_kwargs,
         task_execution_id=execution_id,
         post_collect_hook=post_collect_hook,
     )

--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -64,6 +64,7 @@ def _get_hourly_collectors():
             "collector_func": main_jobevent_service,
             "rollup_processor": EventModulesAnonymizedRollup,
             "description": "Job events (event modules) metrics",
+            # FIXME(AAP-78081): pass row limit / time-budget cap to collector_func
         },
         "indirect_managed_nodes": {
             "collector_func": main_indirectmanagednodeaudit,

--- a/apps/tasks/collectors/daily_metrics_rollup.py
+++ b/apps/tasks/collectors/daily_metrics_rollup.py
@@ -97,7 +97,7 @@ def _merge_hourly_rollups(collections_by_type: dict[str, list]) -> tuple[dict, l
     from metrics_utility.anonymized_rollups import (
         ControllerVersionAnonymizedRollup,
         CredentialsAnonymizedRollup,
-        # EventModulesAnonymizedRollup,
+        EventModulesAnonymizedRollup,
         ExecutionEnvironmentsAnonymizedRollup,
         FeatureFlagsAnonymizedRollup,
         JobHostSummaryAnonymizedRollup,
@@ -111,7 +111,7 @@ def _merge_hourly_rollups(collections_by_type: dict[str, list]) -> tuple[dict, l
     hourly_rollup_processors = {
         "credentials_service": CredentialsAnonymizedRollup(),
         "job_host_summary_service": JobHostSummaryAnonymizedRollup(),
-        # "main_jobevent_service": EventModulesAnonymizedRollup(),  # Disabled - hourly_job_events task disabled by default
+        "main_jobevent_service": EventModulesAnonymizedRollup(),
         "unified_jobs": JobsAnonymizedRollup(),
     }
 

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -302,7 +302,6 @@ ANONYMIZATION_GROUP = TaskGroup(
             "function": "daily_anonymize_and_prepare",
             "cron": "0 3 * * *",  # Daily at 3:00 AM
             "args": {},
-            "max_attempts": SEGMENT_MAX_ATTEMPTS,
             "enabled": True,
             "description": "Anonymize daily summary for Segment transmission",
         },

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -204,7 +204,7 @@ METRICS_COLLECTION_GROUP = TaskGroup(
             "function": "collect_hourly_metrics",
             "cron": "20 * * * *",  # Every hour at XX:20
             "args": {"collector_type": "main_jobevent_service"},
-            "enabled": False,  # NOT enabled by default, for performance
+            "enabled": True,
             "description": "Collect job events (event modules) metrics every hour",
         },
         {

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -302,6 +302,7 @@ ANONYMIZATION_GROUP = TaskGroup(
             "function": "daily_anonymize_and_prepare",
             "cron": "0 3 * * *",  # Daily at 3:00 AM
             "args": {},
+            "max_attempts": SEGMENT_MAX_ATTEMPTS,
             "enabled": True,
             "description": "Anonymize daily summary for Segment transmission",
         },

--- a/metrics_service/tools/performance_tests/benchmark_internal_collection_rollup_benchmark_hourly.py
+++ b/metrics_service/tools/performance_tests/benchmark_internal_collection_rollup_benchmark_hourly.py
@@ -10,7 +10,6 @@ Snapshot collectors (run once):
 
 Hourly collectors (run 24x):
     job_host_summary_service, unified_jobs, credentials_service, main_jobevent_service
-    (note: main_jobevent_service is disabled in production by default)
 
 """
 
@@ -52,7 +51,7 @@ HOURLY_COLLECTOR_TYPES = [
     "job_host_summary_service",
     "unified_jobs",
     "credentials_service",
-    "main_jobevent_service",  # disabled in production by default; included for perf testing
+    "main_jobevent_service",
 ]
 
 

--- a/tests/coverage/tasks/test_task_groups.py
+++ b/tests/coverage/tasks/test_task_groups.py
@@ -210,6 +210,7 @@ def test_get_all_enabled_tasks_excludes_disabled_group():
 
     tasks = get_all_enabled_tasks()
     assert "hourly_job_host_summary" not in tasks
+    assert "hourly_job_events" not in tasks
     assert "daily_metrics_rollup" not in tasks
 
 
@@ -247,12 +248,11 @@ def test_get_all_tasks_for_init_ignores_feature_flags():
 
 
 @pytest.mark.unit
-def test_get_all_tasks_for_init_excludes_individually_disabled():
+def test_get_all_tasks_for_init_includes_all_enabled_tasks():
     from apps.tasks.task_groups import get_all_tasks_for_init
 
     tasks = get_all_tasks_for_init()
-    # hourly_job_events has enabled=False in METRICS_COLLECTION_GROUP.tasks
-    assert "hourly_job_events" not in tasks
+    assert "hourly_job_events" in tasks
 
 
 @pytest.mark.unit

--- a/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
@@ -374,6 +374,53 @@ class TestGenericCollectMetricsHook:
 
 
 @pytest.mark.unit
+class TestCollectHourlyMetricsRowLimit:
+    """Cover the row_limit injection branch added for main_jobevent_service."""
+
+    def _run(self, collector_type, mock_generic, hour_ts=None):
+        """Call collect_hourly_metrics with all heavy deps patched out."""
+        from apps.tasks.collectors.collect_hourly_metrics import collect_hourly_metrics
+
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+            patch(
+                "apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors",
+                return_value={
+                    collector_type: {"collector_func": MagicMock(), "rollup_processor": None},
+                },
+            ),
+            patch("apps.tasks.collectors.collect_hourly_metrics.generic_collect_metrics", mock_generic),
+            patch("apps.tasks.collectors.collect_hourly_metrics.settings") as mock_settings,
+        ):
+            mock_settings.JOBEVENT_ROW_LIMIT = 2_000_000
+            kwargs = {"collector_type": collector_type}
+            if hour_ts:
+                kwargs["hour_timestamp"] = hour_ts.isoformat()
+            collect_hourly_metrics(**kwargs)
+
+    def test_row_limit_injected_for_main_jobevent_service(self):
+        """row_limit must be added to collector_kwargs for main_jobevent_service."""
+        mock_generic = MagicMock(return_value={"status": "success"})
+        self._run("main_jobevent_service", mock_generic, hour_ts=datetime(2024, 1, 1, tzinfo=UTC))
+
+        _, call_kwargs = mock_generic.call_args
+        assert "row_limit" in call_kwargs["collector_kwargs"], (
+            "row_limit should be injected into collector_kwargs for main_jobevent_service"
+        )
+        assert call_kwargs["collector_kwargs"]["row_limit"] == 2_000_000
+
+    def test_row_limit_not_injected_for_other_collectors(self):
+        """row_limit must NOT appear in collector_kwargs for other collector types."""
+        mock_generic = MagicMock(return_value={"status": "success"})
+        self._run("unified_jobs", mock_generic, hour_ts=datetime(2024, 1, 1, tzinfo=UTC))
+
+        _, call_kwargs = mock_generic.call_args
+        assert "row_limit" not in call_kwargs["collector_kwargs"], (
+            "row_limit should not be injected for non-jobevent collectors"
+        )
+
+
+@pytest.mark.unit
 class TestHourlyCollectorRegistry:
     """Pin the registry wiring so a key rename doesn't silently drop the hook."""
 

--- a/tests/unit/tasks/collectors/test_daily_anonymize_and_prepare.py
+++ b/tests/unit/tasks/collectors/test_daily_anonymize_and_prepare.py
@@ -36,6 +36,7 @@ class TestDailyAnonymizeAndPrepare:
             status="aggregated",
             aggregated_metrics={
                 "job_host_summary_service": {"test": "rollup1"},
+                "main_jobevent_service": {"test": "rollup2"},
                 "unified_jobs": {"test": "rollup3"},
                 "execution_environments": {"test": "rollup4"},
                 "credentials_service": {"test": "rollup5"},

--- a/tests/unit/tasks/test_task_groups.py
+++ b/tests/unit/tasks/test_task_groups.py
@@ -182,6 +182,7 @@ class TestPredefinedTaskGroups(TestCase):
         assert len(task_ids) > 0
         # Hourly collection tasks
         assert "hourly_job_host_summary" in task_ids
+        assert "hourly_job_events" in task_ids
         assert "hourly_unified_jobs" in task_ids
         assert "hourly_credentials" in task_ids
         # Daily snapshot collection
@@ -272,6 +273,7 @@ class TestTaskGroupFunctions(TestCase):
 
         # Metrics collection tasks (METRICS_COLLECTION still true)
         assert "hourly_job_host_summary" in task_ids
+        assert "hourly_job_events" in task_ids
         assert "daily_metrics_rollup" in task_ids
         assert "cleanup_metrics_data" in task_ids
 
@@ -292,6 +294,7 @@ class TestTaskGroupFunctions(TestCase):
 
         assert "daily_anonymize" in task_ids
         assert "hourly_job_host_summary" in task_ids
+        assert "hourly_job_events" in task_ids
         assert "daily_metrics_rollup" in task_ids
 
     @override_settings(FEATURE=_FLAGS_METRICS_ON_ANON_OFF)
@@ -312,11 +315,10 @@ class TestTaskGroupFunctions(TestCase):
         assert "daily_metrics_rollup" in task_ids
         assert "daily_task_cleanup" in task_ids
 
-    def test_get_all_tasks_for_init_excludes_individually_disabled_tasks(self):
-        """get_all_tasks_for_init() still respects per-task enabled=False."""
+    def test_get_all_tasks_for_init_includes_all_enabled_tasks(self):
+        """get_all_tasks_for_init() includes all tasks with enabled=True."""
         all_tasks = get_all_tasks_for_init()
-        # hourly_job_events has enabled=False in METRICS_COLLECTION_GROUP
-        assert "hourly_job_events" not in all_tasks
+        assert "hourly_job_events" in all_tasks
 
     @override_settings(FEATURE={"METRICS_COLLECTION": False, "ANONYMIZED_DATA_COLLECTION": True})
     def test_get_all_enabled_tasks_metrics_collection_false_excludes_pipeline(self):
@@ -326,6 +328,7 @@ class TestTaskGroupFunctions(TestCase):
 
         assert "daily_task_cleanup" in task_ids
         assert "hourly_job_host_summary" not in task_ids
+        assert "hourly_job_events" not in task_ids
         assert "daily_metrics_rollup" not in task_ids
         assert "cleanup_metrics_data" not in task_ids
         assert "daily_anonymize" in task_ids
@@ -376,6 +379,7 @@ class TestTaskGroupIntegration(TestCase):
 
         # Metrics collection tasks must still be present
         assert "hourly_job_host_summary" in task_ids
+        assert "hourly_job_events" in task_ids
         assert "hourly_unified_jobs" in task_ids
         assert "hourly_credentials" in task_ids
         assert "daily_metrics_rollup" in task_ids


### PR DESCRIPTION
# [AAP-78080] Reenable events collector
# [AAP-78081] Turn on SQL limit for events collector

This is eneabling events collector along with SQL line limit.

Also pytz was failing to be imported because of recent bump, rewritten to be using something else in tests.

Assisted by Cursor AI.