### PR TITLE
Feature/indirect managed nodes anonymization

### DIFF
--- a/apps/tasks/collectors/daily_anonymize_and_prepare.py
+++ b/apps/tasks/collectors/daily_anonymize_and_prepare.py
@@ -77,6 +77,7 @@ def daily_anonymize_and_prepare(**kwargs) -> dict[str, Any]:
             controller_version_rollup=metrics.get("controller_version_service", {}),
             feature_flags_rollup=metrics.get("feature_flags_service", {}),
             task_executions_rollup=metrics.get("task_executions_service", []),
+            indirect_managed_nodes_rollup=metrics.get("indirect_managed_nodes", {}),
         )
 
         # Add metadata

--- a/apps/tasks/collectors/daily_metrics_rollup.py
+++ b/apps/tasks/collectors/daily_metrics_rollup.py
@@ -100,6 +100,7 @@ def _merge_hourly_rollups(collections_by_type: dict[str, list]) -> tuple[dict, l
         # EventModulesAnonymizedRollup,
         ExecutionEnvironmentsAnonymizedRollup,
         FeatureFlagsAnonymizedRollup,
+        IndirectManagedNodesAnonymizedRollup,
         JobHostSummaryAnonymizedRollup,
         JobsAnonymizedRollup,
         TableMetadataAnonymizedRollup,
@@ -113,6 +114,7 @@ def _merge_hourly_rollups(collections_by_type: dict[str, list]) -> tuple[dict, l
         "job_host_summary_service": JobHostSummaryAnonymizedRollup(),
         # "main_jobevent_service": EventModulesAnonymizedRollup(),  # Disabled - hourly_job_events task disabled by default
         "unified_jobs": JobsAnonymizedRollup(),
+        "indirect_managed_nodes": IndirectManagedNodesAnonymizedRollup(),
     }
 
     # Daily snapshot collectors expect 1 collection per day.

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -218,6 +218,7 @@ TASK_METADATA = {
             {"name": "Unified jobs", "data": {"collector_type": "unified_jobs"}},
             {"name": "Credentials", "data": {"collector_type": "credentials_service"}},
             {"name": "Job events", "data": {"collector_type": "main_jobevent_service"}},
+            {"name": "Indirect managed nodes", "data": {"collector_type": "indirect_managed_nodes"}},
             {
                 "name": "Specific hour",
                 "data": {"collector_type": "job_host_summary_service", "hour_timestamp": "2024-01-01T00:00:00Z"},

--- a/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
@@ -39,10 +39,16 @@ class TestIndirectManagedNodesCollector:
         mock_collector = MagicMock()
         mock_collector.gather.return_value = sample_data
 
+        mock_rollup_processor = MagicMock()
+        mock_rollup_processor.return_value.prepare.return_value = {
+            "indirect_node_ids": ["remote1", "remote2"],
+            "indirect_nodes_total": 2,
+        }
+
         mock_registry = {
             "indirect_managed_nodes": {
                 "collector_func": MagicMock(return_value=mock_collector),
-                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "rollup_processor": mock_rollup_processor,
                 "description": "Test collector",
             }
         }

--- a/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
@@ -1,0 +1,233 @@
+"""Unit tests for indirect_managed_nodes hourly collector."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from psycopg2 import errors as pg_errors
+
+from apps.tasks.collectors.collect_hourly_metrics import _get_hourly_collectors, collect_hourly_metrics
+from apps.tasks.models import HourlyMetricsCollection
+
+
+@pytest.mark.unit
+class TestIndirectManagedNodesCollector:
+    """Tests for indirect_managed_nodes hourly collector."""
+
+    def test_collector_registered_in_hourly_registry(self):
+        """indirect_managed_nodes is present in hourly collector registry."""
+        registry = _get_hourly_collectors()
+        assert "indirect_managed_nodes" in registry
+        entry = registry["indirect_managed_nodes"]
+        assert entry.get("collector_func") is not None
+        assert entry.get("rollup_processor") is not None
+        assert "indirect" in entry.get("description", "").lower()
+
+    @pytest.mark.django_db
+    def test_successful_collection_stores_deduplicated_host_ids(self):
+        """Collector stores deduplicated host_remote_ids as a rollup dict."""
+        sample_data = pd.DataFrame(
+            {
+                "id": [1, 2],
+                "host_name": ["host1", "host2"],
+                "created": [datetime(2024, 1, 1, tzinfo=UTC)] * 2,
+                "host_remote_id": ["remote1", "remote2"],
+            }
+        )
+
+        mock_collector = MagicMock()
+        mock_collector.gather.return_value = sample_data
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": MagicMock(return_value=mock_collector),
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+        assert result["status"] == "success"
+
+        collection = HourlyMetricsCollection.objects.get(id=result["collection_id"])
+        raw_data = collection.raw_data
+
+        assert isinstance(raw_data, dict)
+        assert raw_data["indirect_node_ids"] == ["remote1", "remote2"]
+        assert raw_data["indirect_nodes_total"] == 2
+
+    @pytest.mark.django_db
+    def test_empty_result_set_succeeds(self):
+        """Empty DataFrame collection completes without error."""
+        empty_data = pd.DataFrame()
+
+        mock_collector = MagicMock()
+        mock_collector.gather.return_value = empty_data
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": MagicMock(return_value=mock_collector),
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+        assert result["status"] == "success"
+
+        collection = HourlyMetricsCollection.objects.get(id=result["collection_id"])
+        assert collection.status == "collected"
+
+    @pytest.mark.django_db
+    def test_missing_table_logs_error_and_fails_gracefully(self):
+        """When table doesn't exist, error is logged and collection fails gracefully."""
+
+        def raise_missing_table(**kwargs):
+            raise pg_errors.ProgrammingError('relation "main_indirectmanagednodeaudit" does not exist')
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": raise_missing_table,
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+        assert result["status"] == "error"
+
+        collection = HourlyMetricsCollection.objects.get(
+            collector_type="indirect_managed_nodes",
+            collection_timestamp=ts,
+        )
+        assert collection.status == "failed"
+        assert "main_indirectmanagednodeaudit" in collection.error_message
+
+    @pytest.mark.django_db
+    def test_retry_with_same_timestamp_uses_existing_record(self):
+        """Retry with same hour_timestamp returns existing collection due to unique constraint."""
+        sample_data = pd.DataFrame(
+            {
+                "id": [1],
+                "host_name": ["host1"],
+                "created": [datetime(2024, 1, 1, tzinfo=UTC)],
+            }
+        )
+
+        mock_collector = MagicMock()
+        mock_collector.gather.return_value = sample_data
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": MagicMock(return_value=mock_collector),
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result1 = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+            result2 = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+        assert result1["status"] == "success"
+        assert result2["status"] == "success"
+        assert result1["collection_id"] == result2["collection_id"]
+
+        collection_count = HourlyMetricsCollection.objects.filter(
+            collector_type="indirect_managed_nodes",
+            collection_timestamp=ts,
+        ).count()
+        assert collection_count == 1
+
+    @pytest.mark.django_db
+    def test_invalid_timestamp_format_returns_error(self):
+        """Invalid hour_timestamp format returns error without creating collection."""
+        result = collect_hourly_metrics(
+            collector_type="indirect_managed_nodes",
+            hour_timestamp="not-a-date",
+        )
+
+        assert result["status"] == "error"
+        assert "Invalid" in result["error"]
+
+    @pytest.mark.django_db
+    def test_missing_collector_type_returns_error(self):
+        """Missing collector_type parameter returns error."""
+        result = collect_hourly_metrics()
+
+        assert result["status"] == "error"
+        assert "collector_type" in result["error"]
+
+    @pytest.mark.django_db
+    def test_default_timestamp_when_not_provided(self):
+        """When no timestamp provided, collector uses previous full hour."""
+        sample_data = pd.DataFrame(
+            {
+                "id": [1],
+                "host_name": ["host1"],
+                "created": [datetime.now(UTC)],
+            }
+        )
+
+        mock_collector = MagicMock()
+        mock_collector.gather.return_value = sample_data
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": MagicMock(return_value=mock_collector),
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result = collect_hourly_metrics(collector_type="indirect_managed_nodes")
+
+        assert result["status"] == "success"
+
+        collection = HourlyMetricsCollection.objects.get(id=result["collection_id"])
+        assert collection.collection_timestamp.minute == 0
+        assert collection.collection_timestamp.second == 0
+        assert collection.collection_timestamp.microsecond == 0


### PR DESCRIPTION
[AAP-78074] Integrate indirect managed nodes into daily anonymization pipeline

## Description

- Adds `IndirectManagedNodesAnonymizedRollup` to `hourly_rollup_processors` in `daily_metrics_rollup.py` so the 24 hourly indirect node collections are merged into the `DailyMetricsSummary` each day.
- Passes `indirect_managed_nodes_rollup` to `anonymize_rollups()` in `daily_anonymize_and_prepare.py` so the merged rollup is included in the anonymized Segment payload.
- Adds an `indirect_managed_nodes` example entry to `collect_hourly_metrics` in `TASK_METADATA`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- metrics-utility `feature/indirect-managed-nodes-anonymization` must be merged and released to PyPI before this PR's CI will pass (the import of `IndirectManagedNodesAnonymizedRollup` fails against the current published version).

### Steps to Test

1. After metrics-utility is updated on PyPI: `uv run pytest tests/ -v`
2. Verify no new failures beyond the pre-existing baseline.

### Expected Results

Test suite passes. If `indirect_managed_nodes` hourly collections exist in the database, the daily rollup will include a deduplicated count of unique indirect managed nodes and the Segment payload will contain `indirect_managed_nodes` and `rollup_period_indirect_managed_nodes_total`.

## Additional Context

### Required Actions

- [ ] Blocked by PR/MR: #XXX
  - Blocked by metrics-utility `feature/indirect-managed-nodes-anonymization` being merged and released to PyPI.
