### PR TITLE
fix: replace pytz with stdlib UTC in dashboard_reports test

### DIFF
--- a/tests/unit/dashboard_reports/test_tasks.py
+++ b/tests/unit/dashboard_reports/test_tasks.py
@@ -4,7 +4,6 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-import pytz
 
 from apps.dashboard_reports.models import JobData
 from apps.dashboard_reports.tasks import (
@@ -556,7 +555,7 @@ class TestCleanupDashboardReportsOldData:
     @pytest.mark.django_db
     def test_cleanup_with_db_data(self, db):
         """Test cleanup_dashboard_reports_old_data with real JobData records in the database."""
-        cutoff = datetime.now().astimezone(pytz.utc) - timedelta(days=90)
+        cutoff = datetime.now().astimezone(UTC) - timedelta(days=90)
         old_job1 = JobData.objects.create(
             job_id=1001, finished=cutoff - timedelta(days=1), status="successful", elapsed=1.0
         )


### PR DESCRIPTION
Replacing pytz with UTC in dashboard reports tests.