### PR TITLE
Jobs limit for event collector

### DIFF
--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -144,6 +144,14 @@ TASK_TIMEOUT = 3600
 # Override via METRICS_SERVICE_JOBEVENT_ROW_LIMIT env var.
 JOBEVENT_ROW_LIMIT = 1_000_000
 
+# Maximum number of jobs whose events are collected per hourly run.
+# Caps the job_id IN (...) list size, which directly controls query planning
+# time and total event volume processed.  At 46 000+ jobs the IN list is
+# ~270 KB and event parsing can exceed 12 minutes; capping at 10 000 jobs
+# keeps the query well under 3 minutes for typical event densities.
+# Override via METRICS_SERVICE_JOBEVENT_JOB_LIMIT env var.
+JOBEVENT_JOB_LIMIT = 10_000
+
 
 # Project-specific middleware additions
 MIDDLEWARE = "@merge_unique whitenoise.middleware.WhiteNoiseMiddleware"

--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -142,12 +142,12 @@ TASK_TIMEOUT = 3600
 # At ~700–900 bytes/row in memory, 2 000 000 rows ≈ 1.4–1.8 GB.  Raise for
 # high-volume installations; lower for memory-constrained environments.
 # Override via METRICS_SERVICE_JOBEVENT_ROW_LIMIT env var.
-JOBEVENT_ROW_LIMIT = 400_000
+JOBEVENT_ROW_LIMIT = 200_000
 
 # Maximum finished jobs processed per hourly window by main_jobevent_service.
 # Keeps the SQL IN clause manageable; jobs are sorted by created time (oldest first).
 # Override via METRICS_SERVICE_JOBEVENT_JOB_LIMIT env var.
-JOBEVENT_JOB_LIMIT = 2_000
+JOBEVENT_JOB_LIMIT = 1_000
 
 
 # Project-specific middleware additions

--- a/apps/settings/defaults.py
+++ b/apps/settings/defaults.py
@@ -142,15 +142,12 @@ TASK_TIMEOUT = 3600
 # At ~700–900 bytes/row in memory, 2 000 000 rows ≈ 1.4–1.8 GB.  Raise for
 # high-volume installations; lower for memory-constrained environments.
 # Override via METRICS_SERVICE_JOBEVENT_ROW_LIMIT env var.
-JOBEVENT_ROW_LIMIT = 1_000_000
+JOBEVENT_ROW_LIMIT = 400_000
 
-# Maximum number of jobs whose events are collected per hourly run.
-# Caps the job_id IN (...) list size, which directly controls query planning
-# time and total event volume processed.  At 46 000+ jobs the IN list is
-# ~270 KB and event parsing can exceed 12 minutes; capping at 10 000 jobs
-# keeps the query well under 3 minutes for typical event densities.
+# Maximum finished jobs processed per hourly window by main_jobevent_service.
+# Keeps the SQL IN clause manageable; jobs are sorted by created time (oldest first).
 # Override via METRICS_SERVICE_JOBEVENT_JOB_LIMIT env var.
-JOBEVENT_JOB_LIMIT = 10_000
+JOBEVENT_JOB_LIMIT = 2_000
 
 
 # Project-specific middleware additions

--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -124,6 +124,7 @@ def collect_hourly_metrics(**kwargs) -> dict[str, Any]:
     collector_kwargs: dict[str, Any] = {"since": start_datetime, "until": end_datetime}
     if collector_type == "main_jobevent_service":
         collector_kwargs["row_limit"] = settings.JOBEVENT_ROW_LIMIT
+        collector_kwargs["job_limit"] = settings.JOBEVENT_JOB_LIMIT
 
     # Use generic collector with hourly-specific time window
     return generic_collect_metrics(

--- a/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
@@ -393,6 +393,7 @@ class TestCollectHourlyMetricsRowLimit:
             patch("apps.tasks.collectors.collect_hourly_metrics.settings") as mock_settings,
         ):
             mock_settings.JOBEVENT_ROW_LIMIT = 2_000_000
+            mock_settings.JOBEVENT_JOB_LIMIT = 10_000
             kwargs = {"collector_type": collector_type}
             if hour_ts:
                 kwargs["hour_timestamp"] = hour_ts.isoformat()
@@ -409,14 +410,28 @@ class TestCollectHourlyMetricsRowLimit:
         )
         assert call_kwargs["collector_kwargs"]["row_limit"] == 2_000_000
 
+    def test_job_limit_injected_for_main_jobevent_service(self):
+        """job_limit must be added to collector_kwargs for main_jobevent_service."""
+        mock_generic = MagicMock(return_value={"status": "success"})
+        self._run("main_jobevent_service", mock_generic, hour_ts=datetime(2024, 1, 1, tzinfo=UTC))
+
+        _, call_kwargs = mock_generic.call_args
+        assert "job_limit" in call_kwargs["collector_kwargs"], (
+            "job_limit should be injected into collector_kwargs for main_jobevent_service"
+        )
+        assert call_kwargs["collector_kwargs"]["job_limit"] == 10_000
+
     def test_row_limit_not_injected_for_other_collectors(self):
-        """row_limit must NOT appear in collector_kwargs for other collector types."""
+        """row_limit and job_limit must NOT appear in collector_kwargs for other collector types."""
         mock_generic = MagicMock(return_value={"status": "success"})
         self._run("unified_jobs", mock_generic, hour_ts=datetime(2024, 1, 1, tzinfo=UTC))
 
         _, call_kwargs = mock_generic.call_args
         assert "row_limit" not in call_kwargs["collector_kwargs"], (
             "row_limit should not be injected for non-jobevent collectors"
+        )
+        assert "job_limit" not in call_kwargs["collector_kwargs"], (
+            "job_limit should not be injected for non-jobevent collectors"
         )
 
 

--- a/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_metrics.py
@@ -393,7 +393,6 @@ class TestCollectHourlyMetricsRowLimit:
             patch("apps.tasks.collectors.collect_hourly_metrics.settings") as mock_settings,
         ):
             mock_settings.JOBEVENT_ROW_LIMIT = 2_000_000
-            mock_settings.JOBEVENT_JOB_LIMIT = 10_000
             kwargs = {"collector_type": collector_type}
             if hour_ts:
                 kwargs["hour_timestamp"] = hour_ts.isoformat()
@@ -410,28 +409,14 @@ class TestCollectHourlyMetricsRowLimit:
         )
         assert call_kwargs["collector_kwargs"]["row_limit"] == 2_000_000
 
-    def test_job_limit_injected_for_main_jobevent_service(self):
-        """job_limit must be added to collector_kwargs for main_jobevent_service."""
-        mock_generic = MagicMock(return_value={"status": "success"})
-        self._run("main_jobevent_service", mock_generic, hour_ts=datetime(2024, 1, 1, tzinfo=UTC))
-
-        _, call_kwargs = mock_generic.call_args
-        assert "job_limit" in call_kwargs["collector_kwargs"], (
-            "job_limit should be injected into collector_kwargs for main_jobevent_service"
-        )
-        assert call_kwargs["collector_kwargs"]["job_limit"] == 10_000
-
     def test_row_limit_not_injected_for_other_collectors(self):
-        """row_limit and job_limit must NOT appear in collector_kwargs for other collector types."""
+        """row_limit must NOT appear in collector_kwargs for other collector types."""
         mock_generic = MagicMock(return_value={"status": "success"})
         self._run("unified_jobs", mock_generic, hour_ts=datetime(2024, 1, 1, tzinfo=UTC))
 
         _, call_kwargs = mock_generic.call_args
         assert "row_limit" not in call_kwargs["collector_kwargs"], (
             "row_limit should not be injected for non-jobevent collectors"
-        )
-        assert "job_limit" not in call_kwargs["collector_kwargs"], (
-            "job_limit should not be injected for non-jobevent collectors"
         )
 
 


### PR DESCRIPTION
[[AAP-78080](https://issues.redhat.com/browse/AAP-78080)] Reenable events collector
[[AAP-78081](https://issues.redhat.com/browse/AAP-78081)] Turn on SQL limit for events collector

It was discovered that jobs limit is also needed, without it, the IN clause in event collector can bloat for very large number of jobs and the execution time is unacceptable.

Lowered events limit, just to be sure.

Assisted by: Cursor AI
