### PR TITLE
feat: add INDIRECT_NODE_COLLECTION_GROUP task group

### DIFF
--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -51,6 +51,10 @@ def _inject_dispatch_timestamps(function_name: str, task_data: dict) -> dict:
         now = timezone.now()
         task_data["hour_timestamp"] = now.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
 
+    elif function_name == "collect_indirect_nodes" and "hour_timestamp" not in task_data:
+        now = timezone.now()
+        task_data["hour_timestamp"] = (now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)).isoformat()
+
     return task_data
 
 

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 
 STUCK_TASK_TIMEOUT_SECONDS: int = django_settings.TASK_TIMEOUT
 
+# Functions that pin hour_timestamp to the previous full hour at dispatch time.
+_PREVIOUS_HOUR_FUNCTIONS = {"collect_hourly_metrics", "collect_indirect_nodes"}
+
 
 def _inject_dispatch_timestamps(function_name: str, task_data: dict) -> dict:
     """
@@ -37,7 +40,7 @@ def _inject_dispatch_timestamps(function_name: str, task_data: dict) -> dict:
     """
     task_data = task_data.copy()
 
-    if function_name == "collect_hourly_metrics" and "hour_timestamp" not in task_data:
+    if function_name in _PREVIOUS_HOUR_FUNCTIONS and "hour_timestamp" not in task_data:
         now = timezone.now()
         task_data["hour_timestamp"] = (now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)).isoformat()
 
@@ -50,10 +53,6 @@ def _inject_dispatch_timestamps(function_name: str, task_data: dict) -> dict:
     elif function_name == "collect_daily_metrics" and "hour_timestamp" not in task_data:
         now = timezone.now()
         task_data["hour_timestamp"] = now.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
-
-    elif function_name == "collect_indirect_nodes" and "hour_timestamp" not in task_data:
-        now = timezone.now()
-        task_data["hour_timestamp"] = (now.replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)).isoformat()
 
     return task_data
 

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -302,6 +302,7 @@ ANONYMIZATION_GROUP = TaskGroup(
             "function": "daily_anonymize_and_prepare",
             "cron": "0 3 * * *",  # Daily at 3:00 AM
             "args": {},
+            "max_attempts": SEGMENT_MAX_ATTEMPTS,
             "enabled": True,
             "description": "Anonymize daily summary for Segment transmission",
         },
@@ -335,12 +336,33 @@ DASHBOARD_COLLECTION_GROUP = TaskGroup(
     ],
 )
 
+# Indirect Node Collection Group - automation-reports integration
+# Feature flag: INDIRECT_NODE_COLLECTION (default: False — customer opt-in)
+# Enable via METRICS_SERVICE_FEATURE__INDIRECT_NODE_COLLECTION, installer top-level
+# FEATURE_INDIRECT_NODE_COLLECTION_ENABLED, or dynamic_settings.Setting — see get_feature_enabled_from_db.
+INDIRECT_NODE_COLLECTION_GROUP = TaskGroup(
+    name="indirect_node_collection",
+    description="Indirect managed node hourly collection (INDIRECT_NODE_COLLECTION feature flag)",
+    feature_flag="INDIRECT_NODE_COLLECTION",
+    tasks=[
+        {
+            "task_id": "hourly_collect_indirect_nodes",
+            "function": "collect_indirect_nodes",
+            "cron": "30 * * * *",  # Every hour at XX:30
+            "args": {},
+            "enabled": True,
+            "description": "Collect indirect managed node audit data every hour",
+        },
+    ],
+)
+
 # Registry of all task groups
 TASK_GROUPS = [
     SYSTEM_TASKS_GROUP,
     METRICS_COLLECTION_GROUP,
     ANONYMIZATION_GROUP,
     DASHBOARD_COLLECTION_GROUP,
+    INDIRECT_NODE_COLLECTION_GROUP,
 ]
 
 

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -594,6 +594,23 @@ class TestInjectDispatchTimestamps:
         )
         assert result["hour_timestamp"] == fixed_ts
 
+    def test_injects_hour_timestamp_for_indirect_nodes_collector(self):
+        """collect_indirect_nodes tasks get hour_timestamp set to the previous full hour."""
+        fixed_now = timezone.now().replace(minute=45, second=0, microsecond=0)
+        expected = (fixed_now.replace(minute=0) - timedelta(hours=1)).isoformat()
+
+        with patch("apps.tasks.cron_scheduler.timezone") as mock_tz:
+            mock_tz.now.return_value = fixed_now
+            result = _inject_dispatch_timestamps("collect_indirect_nodes", {})
+
+        assert result["hour_timestamp"] == expected
+
+    def test_does_not_overwrite_existing_hour_timestamp_for_indirect_nodes(self):
+        """An explicit hour_timestamp already in indirect nodes task_data must not be replaced."""
+        fixed_ts = "2024-01-15T09:00:00+00:00"
+        result = _inject_dispatch_timestamps("collect_indirect_nodes", {"hour_timestamp": fixed_ts})
+        assert result["hour_timestamp"] == fixed_ts
+
 
 @pytest.mark.unit
 @pytest.mark.django_db

--- a/tests/unit/tasks/test_task_groups.py
+++ b/tests/unit/tasks/test_task_groups.py
@@ -12,8 +12,10 @@ from django.test import TestCase, override_settings
 
 from apps.tasks.task_groups import (
     ANONYMIZATION_GROUP,
+    INDIRECT_NODE_COLLECTION_GROUP,
     METRICS_COLLECTION_GROUP,
     SYSTEM_TASKS_GROUP,
+    TASK_GROUPS,
     TaskGroup,
     get_all_enabled_tasks,
     get_all_tasks_for_init,
@@ -332,6 +334,32 @@ class TestTaskGroupFunctions(TestCase):
         assert "daily_metrics_rollup" not in task_ids
         assert "cleanup_metrics_data" not in task_ids
         assert "daily_anonymize" in task_ids
+
+
+class TestIndirectNodeCollectionGroup(TestCase):
+    """Test the INDIRECT_NODE_COLLECTION_GROUP task group."""
+
+    def test_indirect_node_collection_group_in_task_groups_registry(self):
+        """INDIRECT_NODE_COLLECTION_GROUP is registered in TASK_GROUPS."""
+        assert INDIRECT_NODE_COLLECTION_GROUP in TASK_GROUPS
+
+    @override_settings(FEATURE={"INDIRECT_NODE_COLLECTION": False})
+    def test_indirect_node_collection_group_disabled_by_default(self):
+        """When INDIRECT_NODE_COLLECTION is false, no tasks are returned."""
+        assert INDIRECT_NODE_COLLECTION_GROUP.feature_flag == "INDIRECT_NODE_COLLECTION"
+        assert INDIRECT_NODE_COLLECTION_GROUP.get_enabled_tasks() == []
+
+    @override_settings(FEATURE={"INDIRECT_NODE_COLLECTION": True})
+    def test_indirect_node_collection_group_enabled(self):
+        """When INDIRECT_NODE_COLLECTION is true, hourly_collect_indirect_nodes is returned."""
+        task_ids = [t["task_id"] for t in INDIRECT_NODE_COLLECTION_GROUP.get_enabled_tasks()]
+        assert "hourly_collect_indirect_nodes" in task_ids
+
+    def test_indirect_node_collection_group_uses_correct_cron(self):
+        """collect_indirect_nodes task is scheduled at 30 * * * *."""
+        task = next(t for t in INDIRECT_NODE_COLLECTION_GROUP.tasks if t["task_id"] == "hourly_collect_indirect_nodes")
+        assert task["cron"] == "30 * * * *"
+        assert task["function"] == "collect_indirect_nodes"
 
 
 class TestTaskGroupIntegration(TestCase):


### PR DESCRIPTION
[AAP-78074] Integrate indirect managed nodes into daily anonymization pipeline

## Description

- Adds `IndirectManagedNodesAnonymizedRollup` to `hourly_rollup_processors` in `daily_metrics_rollup.py` so the 24 hourly indirect node collections are merged into the `DailyMetricsSummary` each day.
- Passes `indirect_managed_nodes_rollup` to `anonymize_rollups()` in `daily_anonymize_and_prepare.py` so the merged rollup is included in the anonymized Segment payload.
- Adds an `indirect_managed_nodes` example entry to `collect_hourly_metrics` in `TASK_METADATA`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

- metrics-utility `feature/indirect-managed-nodes-anonymization` must be merged and released to PyPI before this PR's CI will pass (the import of `IndirectManagedNodesAnonymizedRollup` fails against the current published version).

### Steps to Test

1. After metrics-utility is updated on PyPI: `uv run pytest tests/ -v`
2. Verify no new failures beyond the pre-existing baseline.

### Expected Results

Test suite passes. If `indirect_managed_nodes` hourly collections exist in the database, the daily rollup will include a deduplicated count of unique indirect managed nodes and the Segment payload will contain `indirect_managed_nodes` and `rollup_period_indirect_managed_nodes_total`.