### PR TITLE
CI - skip sonar/codecov steps when secrets are missing

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -67,27 +67,27 @@ jobs:
           uv run pytest -s -v --cov --cov-branch --cov-report=xml
 
       - name: "Upload code coverage report"
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: coverage.xml
 
       - name: "Save off PR number"
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != ''
         env:
           PR_NUM: ${{ github.event.pull_request.number }}
         run: echo "PR $PR_NUM" > pr_number.txt
 
       - name: "Upload PR number"
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_number
           path: pr_number.txt
 
       - name: "Send code coverage report to SonarCloud (on push)"
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != ''
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_HOST_URL: https://sonarcloud.io
@@ -100,6 +100,7 @@ jobs:
             -Dsonar.python.coverage.reportPaths=coverage.xml
 
       - name: Upload coverage reports to Codecov
+        if: secrets.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -16,7 +16,7 @@ jobs:
   sonarcloud:
     name: SonarCloud Static Scans (PR)
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != ''
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Skip secret-dependent coverage upload steps in the test workflow,
mostly so the tests can still pass in repos without secrets set, such as downstream.