### PR TITLE
[AAP-80363] feat: github action for jira linking

### DIFF
--- a/.github/workflows/jira-pr-link.yml
+++ b/.github/workflows/jira-pr-link.yml
@@ -38,12 +38,11 @@ jobs:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          FIRST_COMMIT_MSG=$(gh pr view "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --json commits \
-            --jq '.commits[0].messageHeadline + " " + .commits[0].messageBody') || true
-
-          TICKET=$(echo "$FIRST_COMMIT_MSG" | grep -oP 'AAP-\d+' | head -1 || true)
+          TICKETS=$(gh pr view "$PR_NUMBER" \
+              --repo "${{ github.repository }}" \                                                                                                                                                                                                                            
+              --json commits \
+              --jq '[.commits[] | .messageHeadline + " " + .messageBody] | join("\n")' \
+              | grep -oP 'AAP-\d+' | sort -u || true)
 
           if [[ -z "$TICKET" ]]; then
             echo "found=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/jira-pr-link.yml
+++ b/.github/workflows/jira-pr-link.yml
@@ -60,10 +60,10 @@ jobs:
           gh pr comment "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --edit-last \
-            --body "No Jira ticket was found in the PR title, description, or first commit message. To link this PR to a Jira issue, add the ticket number to the title, e.g. \`[AAP-12345] Your PR title\`." || \
+            --body "No Jira ticket was found in the PR title, description, or first commit message. To link this PR to a Jira issue, add the ticket number to the description, e.g. \`[AAP-12345] Your PR description\`." || \
           gh pr comment "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
-            --body "No Jira ticket was found in the PR title, description, or first commit message. To link this PR to a Jira issue, add the ticket number to the title, e.g. \`[AAP-12345] Your PR title\`." || \
+            --body "No Jira ticket was found in the PR title, description, or first commit message. To link this PR to a Jira issue, add the ticket number to the description, e.g. \`[AAP-12345] Your PR description\`." || \
           echo "::warning::Failed to post missing-ticket comment"
 
       - name: "Update Jira Git Pull Request field"

--- a/.github/workflows/jira-pr-link.yml
+++ b/.github/workflows/jira-pr-link.yml
@@ -18,10 +18,10 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          TICKET=$(echo "$PR_TITLE" | grep -oP 'AAP-\d+' | head -1)
+          TICKET=$(echo "$PR_TITLE" | grep -oP 'AAP-\d+' | head -1 || true)
 
           if [[ -z "$TICKET" ]]; then
-            TICKET=$(echo "$PR_BODY" | grep -oP 'AAP-\d+' | head -1)
+            TICKET=$(echo "$PR_BODY" | grep -oP 'AAP-\d+' | head -1 || true)
           fi
 
           if [[ -z "$TICKET" ]]; then
@@ -41,9 +41,9 @@ jobs:
           FIRST_COMMIT_MSG=$(gh pr view "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --json commits \
-            --jq '.commits[0].messageHeadline + " " + .commits[0].messageBody')
+            --jq '.commits[0].messageHeadline + " " + .commits[0].messageBody') || true
 
-          TICKET=$(echo "$FIRST_COMMIT_MSG" | grep -oP 'AAP-\d+' | head -1)
+          TICKET=$(echo "$FIRST_COMMIT_MSG" | grep -oP 'AAP-\d+' | head -1 || true)
 
           if [[ -z "$TICKET" ]]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
@@ -64,7 +64,8 @@ jobs:
             --body "No Jira ticket was found in the PR title, description, or first commit message. To link this PR to a Jira issue, add the ticket number to the title, e.g. \`[AAP-12345] Your PR title\`." || \
           gh pr comment "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
-            --body "No Jira ticket was found in the PR title, description, or first commit message. To link this PR to a Jira issue, add the ticket number to the title, e.g. \`[AAP-12345] Your PR title\`."
+            --body "No Jira ticket was found in the PR title, description, or first commit message. To link this PR to a Jira issue, add the ticket number to the title, e.g. \`[AAP-12345] Your PR title\`." || \
+          echo "::warning::Failed to post missing-ticket comment"
 
       - name: "Update Jira Git Pull Request field"
         id: jira-update
@@ -77,17 +78,19 @@ jobs:
           TICKET: ${{ steps.jira.outputs.ticket || steps.commit-check.outputs.ticket }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          if [[ -z "$JIRA_BASE_URL" || -z "$JIRA_API_TOKEN" ]]; then
-            echo "::warning::JIRA_BASE_URL (repo variable) and JIRA_API_TOKEN (repo secret) must be configured"
+          if [[ -z "$JIRA_BASE_URL" || -z "$JIRA_USER_EMAIL" || -z "$JIRA_API_TOKEN" ]]; then
+            echo "::warning::JIRA_BASE_URL, BOT_JIRA_EMAIL, and BOT_JIRA_API_TOKEN must be configured"
             exit 0
           fi
 
           HTTP_CODE=$(curl -s -o response.json -w "%{http_code}" \
+            --connect-timeout 10 \
+            --max-time 30 \
             -X PUT \
             -H "Content-Type: application/json" \
             -u "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
             "${JIRA_BASE_URL}/rest/api/2/issue/${TICKET}" \
-            -d "{\"fields\": {\"${JIRA_PR_FIELD_ID}\": \"${PR_URL}\"}}")
+            -d "{\"fields\": {\"${JIRA_PR_FIELD_ID}\": \"${PR_URL}\"}}") || true
 
           if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
             echo "Updated ${TICKET} Git Pull Request field with ${PR_URL}"
@@ -99,7 +102,7 @@ jobs:
       - name: "Comment on PR with linked ticket"
         if: steps.jira-update.outputs.linked == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TICKET: ${{ steps.jira.outputs.ticket || steps.commit-check.outputs.ticket }}
         run: |
@@ -109,4 +112,5 @@ jobs:
             --body "This PR has been automatically linked to \`${TICKET}\` in Jira." || \
           gh pr comment "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
-            --body "This PR has been automatically linked to \`${TICKET}\` in Jira."
+            --body "This PR has been automatically linked to \`${TICKET}\` in Jira." || \
+          echo "::warning::Failed to post linked-ticket comment"

--- a/.github/workflows/jira-pr-link.yml
+++ b/.github/workflows/jira-pr-link.yml
@@ -1,0 +1,112 @@
+name: "Jira PR Link"
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  jira-pr-link:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Extract Jira ticket from PR"
+        id: jira
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          TICKET=$(echo "$PR_TITLE" | grep -oP 'AAP-\d+' | head -1)
+
+          if [[ -z "$TICKET" ]]; then
+            TICKET=$(echo "$PR_BODY" | grep -oP 'AAP-\d+' | head -1)
+          fi
+
+          if [[ -z "$TICKET" ]]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "ticket=$TICKET" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Check first commit message for ticket"
+        if: steps.jira.outputs.found == 'false'
+        id: commit-check
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          FIRST_COMMIT_MSG=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json commits \
+            --jq '.commits[0].messageHeadline + " " + .commits[0].messageBody')
+
+          TICKET=$(echo "$FIRST_COMMIT_MSG" | grep -oP 'AAP-\d+' | head -1)
+
+          if [[ -z "$TICKET" ]]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "ticket=$TICKET" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Comment on PR if ticket is missing"
+        if: steps.jira.outputs.found == 'false' && steps.commit-check.outputs.found == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --edit-last \
+            --body "No Jira ticket was found in the PR title, description, or first commit message. To link this PR to a Jira issue, add the ticket number to the title, e.g. \`[AAP-12345] Your PR title\`." || \
+          gh pr comment "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --body "No Jira ticket was found in the PR title, description, or first commit message. To link this PR to a Jira issue, add the ticket number to the title, e.g. \`[AAP-12345] Your PR title\`."
+
+      - name: "Update Jira Git Pull Request field"
+        id: jira-update
+        if: steps.jira.outputs.found == 'true' || steps.commit-check.outputs.found == 'true'
+        env:
+          JIRA_BASE_URL: ${{ vars.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.BOT_JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.BOT_JIRA_API_TOKEN }}
+          JIRA_PR_FIELD_ID: "customfield_10875"
+          TICKET: ${{ steps.jira.outputs.ticket || steps.commit-check.outputs.ticket }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if [[ -z "$JIRA_BASE_URL" || -z "$JIRA_API_TOKEN" ]]; then
+            echo "::warning::JIRA_BASE_URL (repo variable) and JIRA_API_TOKEN (repo secret) must be configured"
+            exit 0
+          fi
+
+          HTTP_CODE=$(curl -s -o response.json -w "%{http_code}" \
+            -X PUT \
+            -H "Content-Type: application/json" \
+            -u "${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}" \
+            "${JIRA_BASE_URL}/rest/api/2/issue/${TICKET}" \
+            -d "{\"fields\": {\"${JIRA_PR_FIELD_ID}\": \"${PR_URL}\"}}")
+
+          if [[ "$HTTP_CODE" -ge 200 && "$HTTP_CODE" -lt 300 ]]; then
+            echo "Updated ${TICKET} Git Pull Request field with ${PR_URL}"
+            echo "linked=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Failed to update Jira ticket ${TICKET} (HTTP ${HTTP_CODE})"
+          fi
+
+      - name: "Comment on PR with linked ticket"
+        if: steps.jira-update.outputs.linked == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TICKET: ${{ steps.jira.outputs.ticket || steps.commit-check.outputs.ticket }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --edit-last \
+            --body "This PR has been automatically linked to \`${TICKET}\` in Jira." || \
+          gh pr comment "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --body "This PR has been automatically linked to \`${TICKET}\` in Jira."

--- a/.github/workflows/jira-pr-link.yml
+++ b/.github/workflows/jira-pr-link.yml
@@ -44,6 +44,8 @@ jobs:
               --jq '[.commits[] | .messageHeadline + " " + .messageBody] | join("\n")' \
               | grep -oP 'AAP-\d+' | sort -u || true)
 
+          TICKET=$(echo "$TICKETS" | head -1)
+
           if [[ -z "$TICKET" ]]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
# [AAP-80363] Github Action for linking jira MRs to jira tickets automatically

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?

Action which automatically links MRs in jira tickets under the `Git Pull Request` section

The action leaves a comment in both cases, when a ticket is found, and when it is not found, in one of 3 places (1. Title, 2. Description, 3. First commit msg). It edits the comments so that it does not spam the MR, and never fails so it does not mock MRs

- Why is this change needed?

The migration to jira cloud got rid of the automatic linking we used to have

- How does this change address the issue?

It links automatically through a script

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Merge this, create an MR without a ticket, add the ticket after the "negative case" comment is left. It should update the comment and link the MR to the right jira ticket

### Expected Results
<!-- Describe what should happen after following the steps -->

The action leaves a comment in both cases, when a ticket is found, and when it is not found, in one of 3 places (1. Title, 2. Description, 3. First commit msg). It edits the comments so that it does not spam the MR, and never fails so it does not mock MRs

## Additional Context
<!-- Optional but helpful information -->

Uses secrets in this repository for jira API + github API access to act as our current bot
