### PR TITLE
CI - fix secrets checks in workflow if conditions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    env:
+      HAS_SONAR_TOKEN: ${{ secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != '' }}
+      HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
 
     services:
       postgres:
@@ -67,27 +70,27 @@ jobs:
           uv run pytest -s -v --cov --cov-branch --cov-report=xml
 
       - name: "Upload code coverage report"
-        if: github.event_name == 'pull_request' && secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != ''
+        if: github.event_name == 'pull_request' && env.HAS_SONAR_TOKEN == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: coverage.xml
 
       - name: "Save off PR number"
-        if: github.event_name == 'pull_request' && secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != ''
+        if: github.event_name == 'pull_request' && env.HAS_SONAR_TOKEN == 'true'
         env:
           PR_NUM: ${{ github.event.pull_request.number }}
         run: echo "PR $PR_NUM" > pr_number.txt
 
       - name: "Upload PR number"
-        if: github.event_name == 'pull_request' && secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != ''
+        if: github.event_name == 'pull_request' && env.HAS_SONAR_TOKEN == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr_number
           path: pr_number.txt
 
       - name: "Send code coverage report to SonarCloud (on push)"
-        if: github.event_name == 'push' && secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != ''
+        if: github.event_name == 'push' && env.HAS_SONAR_TOKEN == 'true'
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_HOST_URL: https://sonarcloud.io
@@ -100,7 +103,7 @@ jobs:
             -Dsonar.python.coverage.reportPaths=coverage.xml
 
       - name: Upload coverage reports to Codecov
-        if: secrets.CODECOV_TOKEN != ''
+        if: env.HAS_CODECOV_TOKEN == 'true'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -16,7 +16,9 @@ jobs:
   sonarcloud:
     name: SonarCloud Static Scans (PR)
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != ''
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    env:
+      HAS_SONAR_TOKEN: ${{ secrets.CICD_ORG_SONAR_TOKEN_CICD_BOT != '' }}
 
     steps:
       - name: Checkout Code
@@ -124,7 +126,7 @@ jobs:
           PR_NUMBER: ${{ env.PR_NUMBER }}
 
       - name: SonarCloud Scan
-        if: steps.pr_check.outputs.should_scan == 'true'
+        if: steps.pr_check.outputs.should_scan == 'true' && env.HAS_SONAR_TOKEN == 'true'
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
Fixes the workflow parse error introduced in #303 — `secrets` context in `if` conditions

Moves the check to an env var instead (not the secret, just whether its set).

Failing sonar: https://github.com/ansible/metrics-service/actions/runs/28115578828
Failing pytest: https://github.com/ansible/metrics-service/actions/runs/28117487214

pytest runs in this PR so looks like it should work :)