### PR TITLE
[AAP-80363] fix github token

### DIFF
--- a/.github/workflows/jira-pr-link.yml
+++ b/.github/workflows/jira-pr-link.yml
@@ -35,7 +35,7 @@ jobs:
         if: steps.jira.outputs.found == 'false'
         id: commit-check
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           TICKETS=$(gh pr view "$PR_NUMBER" \
@@ -56,7 +56,7 @@ jobs:
       - name: "Comment on PR if ticket is missing"
         if: steps.jira.outputs.found == 'false' && steps.commit-check.outputs.found == 'false'
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           gh pr comment "$PR_NUMBER" \
@@ -103,7 +103,7 @@ jobs:
       - name: "Comment on PR with linked ticket"
         if: steps.jira-update.outputs.linked == 'true'
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TICKET: ${{ steps.jira.outputs.ticket || steps.commit-check.outputs.ticket }}
         run: |


### PR DESCRIPTION
Github token was set to the bot's github token, but actions do not like that, and prefer the generated token given from the action run