### PR TITLE
AAP-80890 fix: align service_type with gateway ServiceType name for JWT claims auth

### DIFF
--- a/apps/core/resource_api.py
+++ b/apps/core/resource_api.py
@@ -14,7 +14,7 @@ from apps.core.models import Organization, Team, User
 class APIConfig(ServiceAPIConfig):
     """API configuration for the resource registry."""
 
-    service_type = "metrics_service"
+    service_type = "metrics"
 
 
 RESOURCE_LIST = [

--- a/tests/unit/core/test_resource_api_comprehensive.py
+++ b/tests/unit/core/test_resource_api_comprehensive.py
@@ -18,7 +18,7 @@ class TestResourceAPIConfiguration(TestCase):
         from apps.core.resource_api import APIConfig
 
         assert hasattr(APIConfig, "service_type")
-        assert APIConfig.service_type == "metrics_service"
+        assert APIConfig.service_type == "metrics"
 
     def test_resource_list_exists(self):
         """Test that RESOURCE_LIST exists and contains configurations."""


### PR DESCRIPTION
## Summary

- `APIConfig.service_type` was set to `"metrics_service"` but the gateway's `ServiceType` table has `name="metrics"`
- This mismatch caused `migrate_service_data` to skip metrics-service during install, leaving `ServiceCluster.service_id = None` in the gateway
- When a user's JWT claims hash mismatches (new users, permission changes), metrics-service calls `/api/gateway/v1/jwt_claims/` authenticated with a service JWT using its own UUID as the `iss` claim — the gateway validates by looking up `ServiceCluster(service_id=iss)`, which failed with 401, resulting in a 403 for affected users on endpoints like `collection_status`

## Root cause

`migrate_service_data` calls each service's `service-metadata` endpoint and does `ServiceType.objects.filter(name=service_type).first()` on the response. With `"metrics_service"` no match was found so the service was skipped and `ServiceCluster.service_id` was never populated. Changing to `"metrics"` matches the existing gateway `ServiceType` and allows the registration to complete.

## Test plan

- [ ] Deploy with this change and verify `ServiceCluster.service_id` is populated for metrics after `migrate_service_data` runs
- [ ] Confirm a system auditor (or any user whose claims hash mismatches) can access `collection_status` without receiving a 403

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.