### PR TITLE
AAP-80891 fix: coerce NaN string fields to None in dashboard record serializer

### DIFF
--- a/apps/tasks/collectors/collect_hourly_metrics.py
+++ b/apps/tasks/collectors/collect_hourly_metrics.py
@@ -167,6 +167,7 @@ _DASHBOARD_COLUMNS = [
 
 
 _INT_FIELDS = ("id", "organization_id", "unified_job_template_id", "launched_by_id", "project_id", "num_hosts")
+_STRING_FIELDS = ("name", "organization_name", "status", "launched_by_username", "project_name", "label_ids")
 
 
 def _serialize_dashboard_record(row: dict) -> None:
@@ -180,6 +181,10 @@ def _serialize_dashboard_record(row: dict) -> None:
     Nullable FK columns (organization_id, project_id, etc.) are upcast to float64 by pandas
     when NaN coexists with integers; .where(notna(), other=None) leaves NaN as float nan
     rather than None, so int(nan) would raise ValueError without the explicit nan guard here.
+
+    Nullable string columns (organization_name, project_name, etc.) can also arrive as
+    float nan from pandas when the entire column contains NaN values; they must be coerced
+    to None to produce valid JSON.
     """
     for field in ("started", "finished", "created", "modified"):
         val = row.get(field)
@@ -191,6 +196,10 @@ def _serialize_dashboard_record(row: dict) -> None:
             row[field] = None
         else:
             row[field] = int(val)
+    for field in _STRING_FIELDS:
+        val = row.get(field)
+        if isinstance(val, float) and math.isnan(val):
+            row[field] = None
     val = row.get("elapsed")
     if val is None or (isinstance(val, float) and math.isnan(val)):
         row["elapsed"] = None


### PR DESCRIPTION
## Summary

- `_serialize_dashboard_record` in `collect_hourly_metrics.py` handled `_INT_FIELDS` and datetime fields for NaN but not string fields
- Nullable string columns (`organization_name`, `project_name`, `launched_by_username`, `label_ids`) arrive as `float('nan')` from pandas when the column is entirely null for a given hour
- `DjangoJSONEncoder` serialised these as the token `NaN`, producing invalid JSON when `Task.task_data` was written to the DB
- The `post_collect_hook` failed silently (warning-only, doesn't abort the rollup pipeline) so no `sync_dashboard_job_records` tasks were created for affected hours — dashboard data was silently dropped

## Fix

Add `_STRING_FIELDS = ("name", "organization_name", "status", "launched_by_username", "project_name", "label_ids")` and coerce any `float NaN` values to `None` before serialisation.

## Test plan

- [ ] Run `collect_hourly_metrics` with `collector_type=unified_jobs` against a Controller with jobs that have null `organization_name` or `project_name` — verify `sync_dashboard_job_records` tasks are created without errors
- [ ] Verify `label_ids: null` (not `NaN`) appears in task data for unlabelled jobs
- [ ] Confirm no `post_collect_hook failed` warnings in the logs

## Related

Discovered during live validation of AAP-76647, AAP-79242, AAP-79243.

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.