### PR TITLE
fix(tasks): fix hourly_collect_indirect_nodes task using unregistered…

### DIFF
--- a/apps/core/models/user.py
+++ b/apps/core/models/user.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 from ansible_base.lib.abstract_models.user import AbstractDABUser
 
 
@@ -10,7 +12,7 @@ class User(AbstractDABUser):
 
     encrypted_fields = ["password"]
 
-    @property
+    @cached_property
     def is_platform_auditor(self) -> bool:
         """True if the user holds the Platform Auditor global RBAC role.
 

--- a/apps/core/models/user.py
+++ b/apps/core/models/user.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 from ansible_base.lib.abstract_models.user import AbstractDABUser
 
 
@@ -12,7 +10,7 @@ class User(AbstractDABUser):
 
     encrypted_fields = ["password"]
 
-    @cached_property
+    @property
     def is_platform_auditor(self) -> bool:
         """True if the user holds the Platform Auditor global RBAC role.
 

--- a/apps/tasks/cron_scheduler.py
+++ b/apps/tasks/cron_scheduler.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 STUCK_TASK_TIMEOUT_SECONDS: int = django_settings.TASK_TIMEOUT
 
 # Functions that pin hour_timestamp to the previous full hour at dispatch time.
-_PREVIOUS_HOUR_FUNCTIONS = {"collect_hourly_metrics", "collect_indirect_nodes"}
+_PREVIOUS_HOUR_FUNCTIONS = {"collect_hourly_metrics"}
 
 
 def _inject_dispatch_timestamps(function_name: str, task_data: dict) -> dict:

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -355,9 +355,9 @@ INDIRECT_NODE_COLLECTION_GROUP = TaskGroup(
     tasks=[
         {
             "task_id": "hourly_collect_indirect_nodes",
-            "function": "collect_indirect_nodes",
+            "function": "collect_hourly_metrics",
             "cron": "30 * * * *",  # Every hour at XX:30
-            "args": {},
+            "args": {"collector_type": "indirect_managed_nodes"},
             "enabled": True,
             "description": "Collect indirect managed node audit data every hour",
         },

--- a/tests/unit/tasks/test_cron_scheduler.py
+++ b/tests/unit/tasks/test_cron_scheduler.py
@@ -599,20 +599,22 @@ class TestInjectDispatchTimestamps:
         assert result["hour_timestamp"] == fixed_ts
 
     def test_injects_hour_timestamp_for_indirect_nodes_collector(self):
-        """collect_indirect_nodes tasks get hour_timestamp set to the previous full hour."""
+        """collect_hourly_metrics indirect_managed_nodes tasks get hour_timestamp set to the previous full hour."""
         fixed_now = timezone.now().replace(minute=45, second=0, microsecond=0)
         expected = (fixed_now.replace(minute=0) - timedelta(hours=1)).isoformat()
 
         with patch("apps.tasks.cron_scheduler.timezone") as mock_tz:
             mock_tz.now.return_value = fixed_now
-            result = _inject_dispatch_timestamps("collect_indirect_nodes", {})
+            result = _inject_dispatch_timestamps("collect_hourly_metrics", {"collector_type": "indirect_managed_nodes"})
 
         assert result["hour_timestamp"] == expected
 
     def test_does_not_overwrite_existing_hour_timestamp_for_indirect_nodes(self):
-        """An explicit hour_timestamp already in indirect nodes task_data must not be replaced."""
+        """An explicit hour_timestamp in indirect_managed_nodes task_data must not be replaced."""
         fixed_ts = "2024-01-15T09:00:00+00:00"
-        result = _inject_dispatch_timestamps("collect_indirect_nodes", {"hour_timestamp": fixed_ts})
+        result = _inject_dispatch_timestamps(
+            "collect_hourly_metrics", {"collector_type": "indirect_managed_nodes", "hour_timestamp": fixed_ts}
+        )
         assert result["hour_timestamp"] == fixed_ts
 
 

--- a/tests/unit/tasks/test_task_groups.py
+++ b/tests/unit/tasks/test_task_groups.py
@@ -356,10 +356,11 @@ class TestIndirectNodeCollectionGroup(TestCase):
         assert "hourly_collect_indirect_nodes" in task_ids
 
     def test_indirect_node_collection_group_uses_correct_cron(self):
-        """collect_indirect_nodes task is scheduled at 30 * * * *."""
+        """hourly_collect_indirect_nodes task is scheduled at 30 * * * * via collect_hourly_metrics."""
         task = next(t for t in INDIRECT_NODE_COLLECTION_GROUP.tasks if t["task_id"] == "hourly_collect_indirect_nodes")
         assert task["cron"] == "30 * * * *"
-        assert task["function"] == "collect_indirect_nodes"
+        assert task["function"] == "collect_hourly_metrics"
+        assert task["args"]["collector_type"] == "indirect_managed_nodes"
 
 
 class TestTaskGroupIntegration(TestCase):


### PR DESCRIPTION
… function

## Description

- The `INDIRECT_NODE_COLLECTION_GROUP` task was configured with `"function": "collect_indirect_nodes"`, a function that was never registered in `TASK_FUNCTIONS`. The cron scheduler dispatches tasks by looking up the function name in that registry, so the `hourly_collect_indirect_nodes` task would fail at execution time - it was never actually running.
- Without this fix, indirect managed node audit data is silently never collected on the hourly schedule.
- The task is re-pointed to `collect_hourly_metrics` with `args: {"collector_type": "indirect_managed_nodes"}`, which is how every other hourly collector works. `collect_hourly_metrics` is already registered in `TASK_FUNCTIONS` and its internal registry already maps `indirect_managed_nodes` to `main_indirectmanagednodeaudit`. The `_PREVIOUS_HOUR_FUNCTIONS` set is cleaned up to remove the never-real `collect_indirect_nodes` entry - since the task now dispatches under `collect_hourly_metrics` (already in that set), `hour_timestamp` injection continues to work correctly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

A running metrics-service environment with the `INDIRECT_NODE_COLLECTION` feature flag enabled.

### Steps to Test

1. Run `python manage.py metrics_service init-system-tasks` to sync the updated task group to the DB.
2. Confirm the `hourly_collect_indirect_nodes` task record has `function_name = "collect_hourly_metrics"` and `task_data` contains `collector_type: "indirect_managed_nodes"`.
3. Manually trigger the task and confirm it completes without a `KeyError` from `TASK_FUNCTIONS`.
4. Run the unit test suite: `uv run pytest tests/unit/tasks/`.

### Expected Results

The `hourly_collect_indirect_nodes` task dispatches successfully and indirect managed node audit data is collected for the previous full hour.