### PR TITLE
fix(ci): remove --no-build from sync-openapi-specs workflow

### DIFF
--- a/.github/workflows/sync-openapi-specs.yml
+++ b/.github/workflows/sync-openapi-specs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7
 
       - name: Install dependencies
-        run: uv sync --frozen --no-build
+        run: uv sync --frozen
 
       - name: Generate OpenAPI schema
         env:
@@ -36,12 +36,12 @@ jobs:
           SECRET_KEY: "ci-placeholder-not-secret"
           DATABASE_URL: "sqlite://:memory:"
         run: |
-          uv run --frozen --no-build python manage.py spectacular \
+          uv run --frozen python manage.py spectacular \
             --color \
             --file openapi-schema.yaml \
             --validate
           # Produce both YAML and JSON for downstream consumers
-          uv run --frozen --no-build python manage.py spectacular \
+          uv run --frozen python manage.py spectacular \
             --color \
             --file openapi-schema.json \
             --validate \


### PR DESCRIPTION
## Summary

- Removes `--no-build` from `uv sync` and `uv run` calls in the `sync-openapi-specs` workflow
- The flag prevented uv from building the local editable `metrics-service` package, which always requires a build step as an `editable+.` install
- `--frozen` alone is the correct CI flag — it pins the lockfile without blocking source builds

## Test plan

- [ ] Verify the `Sync OpenAPI Spec` workflow completes successfully after merge

Made with [Cursor](https://cursor.com)