### PR TITLE
fix(dev): make tools/dev.sh compatible with macOS bash 3.2

### DIFF
--- a/tools/dev.sh
+++ b/tools/dev.sh
@@ -55,7 +55,13 @@ echo "Dev server running (runserver + dispatcherd + scheduler)"
 echo "Press Ctrl+C to stop"
 
 # Wait for any child to exit — if one crashes, cleanup trap stops the rest.
-wait -n
-code=$?
+# `wait -n` requires bash 4.3+; macOS ships with bash 3.2 so fall back to polling.
+if [[ "${BASH_VERSINFO[0]}" -gt 4 ]] || [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 3 ]]; then
+    wait -n
+    code=$?
+else
+    while kill -0 "${PIDS[@]}" 2>/dev/null; do sleep 1; done
+    code=1
+fi
 echo "A service exited with code $code, shutting down..."
 exit "$code"


### PR DESCRIPTION
## Summary

- `wait -n` (wait for any one child process to exit) requires bash 4.3+
- macOS ships with bash 3.2, so `tools/dev.sh` crashed immediately after starting all three services with `wait: -n: invalid option`
- Adds a `BASH_VERSINFO` version check and falls back to a `kill -0` polling loop on older bash

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.