### PR TITLE
fix: move Prometheus metrics endpoint to /api/v1/metrics (AAP-80895)

### DIFF
--- a/apps/urls.py
+++ b/apps/urls.py
@@ -29,9 +29,10 @@ from apps.core.views.metrics import PrometheusMetricsView
 
 urlpatterns = [
     # Prometheus metrics endpoint — requires system admin or auditor
-    path("api/metrics", PrometheusMetricsView.as_view(), name="prometheus-django-metrics"),
-    # Redirect /metrics to canonical /api/metrics for backwards compatibility
-    path("metrics", RedirectView.as_view(url="/api/metrics", permanent=False)),
+    path("api/v1/metrics", PrometheusMetricsView.as_view(), name="prometheus-django-metrics"),
+    # Backwards-compat redirects for old paths
+    path("api/metrics", RedirectView.as_view(url="/api/v1/metrics", permanent=True)),
+    path("metrics", RedirectView.as_view(url="/api/v1/metrics", permanent=False)),
     # Redirect bare feature_flags/ to the canonical states list
     path("api/v1/feature_flags/", RedirectView.as_view(url="/api/v1/feature_flags/states/", permanent=True)),
 ]

--- a/tests/unit/general/test_health_metrics.py
+++ b/tests/unit/general/test_health_metrics.py
@@ -138,11 +138,11 @@ class TestHealthEndpoint:
 @pytest.mark.unit
 @pytest.mark.django_db
 class TestMetricsEndpoint:
-    """Test cases for /api/metrics endpoint."""
+    """Test cases for /api/v1/metrics endpoint."""
 
     def test_metrics_endpoint_requires_authentication(self):
         """Unauthenticated requests must be denied."""
-        response = APIClient().get("/api/metrics")
+        response = APIClient().get("/api/v1/metrics")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_metrics_endpoint_denies_unprivileged_user(self):
@@ -153,12 +153,12 @@ class TestMetricsEndpoint:
         with patch("ansible_base.rbac.api.permissions.has_super_permission", return_value=False):
             client = APIClient()
             client.force_authenticate(user=user)
-            response = client.get("/api/metrics")
+            response = client.get("/api/v1/metrics")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_metrics_endpoint_allows_system_admin(self, admin_client):
         """System admin (is_superuser) must receive Prometheus output."""
-        response = admin_client.get("/api/metrics")
+        response = admin_client.get("/api/v1/metrics")
         assert response.status_code == status.HTTP_200_OK
 
     def test_metrics_endpoint_allows_system_auditor(self):
@@ -169,22 +169,28 @@ class TestMetricsEndpoint:
         with patch("ansible_base.rbac.api.permissions.has_super_permission", return_value=True):
             client = APIClient()
             client.force_authenticate(user=auditor)
-            response = client.get("/api/metrics")
+            response = client.get("/api/v1/metrics")
         assert response.status_code == status.HTTP_200_OK
 
     def test_metrics_endpoint_returns_prometheus_format(self, admin_client):
         """Response content type must be text/plain."""
-        response = admin_client.get("/api/metrics")
+        response = admin_client.get("/api/v1/metrics")
         assert response.status_code == status.HTTP_200_OK
         assert "text/plain" in response["Content-Type"]
 
     def test_metrics_endpoint_contains_django_metrics(self, admin_client):
         """Response body must contain Django metric names."""
-        response = admin_client.get("/api/metrics")
+        response = admin_client.get("/api/v1/metrics")
         assert "django_" in response.content.decode()
 
     def test_metrics_legacy_path_redirects(self, client):
-        """GET /metrics must redirect to /api/metrics for backwards compatibility."""
+        """GET /metrics must redirect to /api/v1/metrics for backwards compatibility."""
         response = client.get("/metrics")
         assert response.status_code == status.HTTP_302_FOUND
-        assert response["Location"] == "/api/metrics"
+        assert response["Location"] == "/api/v1/metrics"
+
+    def test_metrics_old_api_path_redirects(self, client):
+        """GET /api/metrics must permanently redirect to /api/v1/metrics."""
+        response = client.get("/api/metrics")
+        assert response.status_code == status.HTTP_301_MOVED_PERMANENTLY
+        assert response["Location"] == "/api/v1/metrics"

--- a/tools/openapi-schema/metrics-service.json
+++ b/tools/openapi-schema/metrics-service.json
@@ -51,29 +51,6 @@
                 "x-ai-description": "Retrieve single api"
             }
         },
-        "/api/metrics": {
-            "get": {
-                "operationId": "api_metrics_retrieve",
-                "description": "Prometheus metrics endpoint restricted to system admins and auditors.",
-                "tags": [
-                    "api"
-                ],
-                "security": [
-                    {
-                        "cookieAuth": []
-                    },
-                    {
-                        "basicAuth": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "No response body"
-                    }
-                },
-                "x-ai-description": "Retrieve single api metric"
-            }
-        },
         "/api/v1/": {
             "get": {
                 "operationId": "root_retrieve_2",
@@ -2401,6 +2378,29 @@
                     }
                 },
                 "x-ai-description": "Retrieve single feature flags state"
+            }
+        },
+        "/api/v1/metrics": {
+            "get": {
+                "operationId": "metrics_retrieve",
+                "description": "Prometheus metrics endpoint restricted to system admins and auditors.",
+                "tags": [
+                    "metrics"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    },
+                    {
+                        "basicAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "No response body"
+                    }
+                },
+                "x-ai-description": "Retrieve single metric"
             }
         },
         "/api/v1/organizations/": {

--- a/tools/openapi-schema/metrics-service.yaml
+++ b/tools/openapi-schema/metrics-service.yaml
@@ -50,19 +50,6 @@ paths:
         '200':
           description: No response body
       x-ai-description: Retrieve single api
-  /api/metrics:
-    get:
-      operationId: api_metrics_retrieve
-      description: Prometheus metrics endpoint restricted to system admins and auditors.
-      tags:
-      - api
-      security:
-      - cookieAuth: []
-      - basicAuth: []
-      responses:
-        '200':
-          description: No response body
-      x-ai-description: Retrieve single api metric
   /api/v1/:
     get:
       operationId: root_retrieve_2
@@ -1573,6 +1560,19 @@ paths:
                   summary: featureflags
           description: ''
       x-ai-description: Retrieve single feature flags state
+  /api/v1/metrics:
+    get:
+      operationId: metrics_retrieve
+      description: Prometheus metrics endpoint restricted to system admins and auditors.
+      tags:
+      - metrics
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      responses:
+        '200':
+          description: No response body
+      x-ai-description: Retrieve single metric
   /api/v1/organizations/:
     get:
       operationId: organizations_list


### PR DESCRIPTION
## Summary

- Moves `PrometheusMetricsView` from `api/metrics` to `api/v1/metrics` so the canonical external URL is `gateway/api/metrics/v1/metrics`, consistent with all other versioned endpoints
- Adds a permanent 301 redirect from `api/metrics` → `/api/v1/metrics` for backwards compatibility
- Updates the existing `/metrics` → `/api/metrics` redirect to point to the new canonical path
- Updates all tests to use `/api/v1/metrics` and adds a test for the new 301 redirect

## Root Cause

`ServicePrefixMiddleware` strips `/api/metrics` from incoming requests and prepends `/api` before Django routing. The old registration at `api/metrics` meant the endpoint was only reachable externally via the confusing double-path `/api/metrics/metrics`, while `/api/metrics/v1/metrics` returned 404.

## Test plan

- [ ] `uv run pytest tests/unit/general/test_health_metrics.py -v` — all 15 tests pass
- [ ] `uv run pytest -m unit` — no regressions

Fixes: AAP-80895

## AI Assistance
This change was developed with assistance from Claude Code (Claude Sonnet 4.6).
All generated code was reviewed, tested, and validated before merging.