### PR TITLE
AAP-8032 Using Controller's data retention period setting as a source of that setting for the Automation Dashboard

### DIFF
--- a/apps/dashboard_reports/awx_queries.py
+++ b/apps/dashboard_reports/awx_queries.py
@@ -28,6 +28,23 @@ class AWXQuery(enum.Enum):
     )
     LABELS = "SELECT id, name FROM main_label"
 
+    RETENTION_SETTINGS = (
+        "SELECT "
+        "sjt.job_type, "
+        "ujt.name AS template_name, "
+        "s.name AS schedule_name, "
+        "s.enabled AS schedule_enabled, "
+        "s.rrule, "
+        "s.next_run, "
+        "(s.extra_data::jsonb ->> 'days')::int AS retention_days "
+        "FROM main_systemjobtemplate sjt "
+        "JOIN main_unifiedjobtemplate ujt "
+        "ON ujt.id = sjt.unifiedjobtemplate_ptr_id "
+        "LEFT JOIN main_schedule s "
+        "ON s.unified_job_template_id = ujt.id "
+        "WHERE sjt.job_type IN ('cleanup_jobs', 'cleanup_activitystream')"
+    )
+
 
 def _build_where_clause(join_alias: str, search_str: str | None, pk: Any) -> tuple[str, list[Any]]:
     """Build WHERE clause and parameters for SQL query."""
@@ -139,3 +156,28 @@ def fetch_projects(**kwargs) -> tuple[list[dict[str, Any]], int]:
 def fetch_labels(**kwargs) -> tuple[list[dict[str, Any]], int]:
     """Fetch labels from DB, returning ``(items, total_count)``."""
     return fetch_id_name(AWXQuery.LABELS, error_msg="Error fetching labels from AWX database", **kwargs)
+
+
+def fetch_retention_settings(**kwargs) -> tuple[list[dict[str, Any]], int]:
+    """Fetch retention settings from DB, returning ``(items, total_count)``."""
+    rows, total = fetch_data_from_db(
+        AWXQuery.RETENTION_SETTINGS,
+        join_alias="s.",
+        db_connection=kwargs.get("db_connection"),
+    )
+    items = sorted(
+        [
+            {
+                "job_type": row[0],
+                "template_name": row[1],
+                "schedule_name": row[2],
+                "schedule_enabled": row[3],
+                "rrule": row[4],
+                "next_run": row[5],
+                "retention_days": row[6],
+            }
+            for row in rows
+        ],
+        key=lambda r: (r["job_type"] or "", r["schedule_name"] or ""),
+    )
+    return items, total

--- a/apps/dashboard_reports/awx_queries.py
+++ b/apps/dashboard_reports/awx_queries.py
@@ -36,7 +36,7 @@ class AWXQuery(enum.Enum):
         "s.enabled AS schedule_enabled, "
         "s.rrule, "
         "s.next_run, "
-        "(s.extra_data::jsonb ->> 'days')::int AS retention_days "
+        "(s.extra_data::jsonb ->> 'days') AS retention_days "
         "FROM main_systemjobtemplate sjt "
         "JOIN main_unifiedjobtemplate ujt "
         "ON ujt.id = sjt.unifiedjobtemplate_ptr_id "

--- a/apps/dashboard_reports/tasks.py
+++ b/apps/dashboard_reports/tasks.py
@@ -22,16 +22,67 @@ from metrics_utility.library.collectors.dashboard import (
     dashboard_jobs,
 )
 
+from apps.dashboard_reports.awx_queries import fetch_retention_settings
 from apps.dashboard_reports.models import DashboardTelemetry, JobData, JobHostSummary
 from apps.tasks.utils import create_task_result, get_db_connection, log_task_execution
 
-DEFAULT_DB_NAME = "awx"
+DEFAULT_AWX_DB_NAME = "awx"
+DEFAULT_RETENTION_DAYS = 90
 
 logger = logging.getLogger(__name__)
 
 
 class _PartialSyncRollbackError(Exception):
     """Sentinel raised inside a transaction.atomic() block to roll back all saves when any job fails to sync."""
+
+
+def get_retention_days(db_name: str = DEFAULT_AWX_DB_NAME) -> int:
+    """
+    Return the effective retention period in days derived from active AWX cleanup schedules.
+
+    Connects to the AWX database and queries
+    ``cleanup_jobs`` system job schedules (which govern job-run retention),
+    then applies the most aggressive (lowest) retention policy:
+
+    - Only enabled schedules (``schedule_enabled = True``) are considered.
+    - When multiple schedules exist, the one with the lowest ``retention_days`` wins;
+      ties are broken by the soonest ``next_run``.
+    - Falls back to ``DEFAULT_RETENTION_DAYS`` if the query fails or returns no active rows.
+
+    Note: ``cleanup_activitystream`` schedules are intentionally excluded — they govern
+    a different resource (activity stream entries) and must not drive ``JobData`` retention.
+    """
+    try:
+        db_connection = get_db_connection(db_name)
+        retention_data, _ = fetch_retention_settings(db_connection=db_connection)
+    except Exception:
+        logger.exception("Error fetching retention settings; using default %d days", DEFAULT_RETENTION_DAYS)
+        return DEFAULT_RETENTION_DAYS
+
+    active = [
+        row
+        for row in retention_data
+        if row.get("job_type") == "cleanup_jobs"
+        and row.get("schedule_enabled")
+        and row.get("retention_days") is not None
+    ]
+    if not active:
+        return DEFAULT_RETENTION_DAYS
+
+    best: dict = active[0]
+    for row in active[1:]:
+        if row["retention_days"] < best["retention_days"]:
+            best = row
+        elif row["retention_days"] == best["retention_days"]:
+            try:
+                row_next = _parse_dt(row.get("next_run"))
+                best_next = _parse_dt(best.get("next_run"))
+            except (TypeError, ValueError):
+                continue
+            if row_next is not None and (best_next is None or row_next < best_next):
+                best = row
+
+    return best["retention_days"]
 
 
 def _parse_dt(value: Any) -> datetime | None:
@@ -114,21 +165,24 @@ def _sync_jobs_atomically(job_results: list) -> list:
 
 
 def _resolve_collection_params(kwargs: dict) -> tuple[str, datetime, datetime, int]:
-    """Resolve db_name, since, until, and batch_size from task kwargs with defaults applied."""
+    """Resolve db_name, since, until, and batch_size from task kwargs with defaults applied.
+
+    When ``since`` is not provided and no prior ``JobData`` timestamp exists, the initial
+    backfill window is determined by ``get_retention_days`` (queried from active AWX cleanup
+    schedules) rather than a static setting.
+    """
     dashboard_cfg = getattr(settings, "DASHBOARD_COLLECTION", None) or {}
-    db_name = kwargs.get("database", DEFAULT_DB_NAME)
+    db_name = kwargs.get("database", DEFAULT_AWX_DB_NAME)
     until = _parse_dt(kwargs.get("until")) or datetime.now(tz=UTC)
     since = _parse_dt(kwargs.get("since")) or JobData.last_timestamp()
     if since is None:
-        raw_backfill_days = dashboard_cfg.get("INITIAL_BACKFILL_DAYS", 90)
+        raw_backfill_days = get_retention_days(db_name)
         try:
             backfill_days = int(raw_backfill_days)
         except (TypeError, ValueError) as e:
-            raise ValueError(
-                f"DASHBOARD_COLLECTION.INITIAL_BACKFILL_DAYS must be a positive integer, got {raw_backfill_days!r}"
-            ) from e
+            raise ValueError(f"get_retention_days returned a non-integer value: {raw_backfill_days!r}") from e
         if backfill_days <= 0:
-            raise ValueError("DASHBOARD_COLLECTION.INITIAL_BACKFILL_DAYS must be > 0")
+            raise ValueError(f"Retention days must be > 0, got {backfill_days!r}")
         since = (
             (until - timedelta(days=backfill_days)).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(UTC)
         )
@@ -270,9 +324,13 @@ def collect_dashboard_reports_initial_data(**kwargs) -> dict[str, Any]:
     """
     Collect historical AWX job data as a one-time backfill.
 
-    The backfill window defaults to 90 days and can be overridden via
-    settings.DASHBOARD_COLLECTION['INITIAL_BACKFILL_DAYS']. After this task
-    Returns a task result dict with status, data, and any error details.
+    The backfill window is determined by ``get_retention_days`` (queried from active AWX
+    cleanup schedules), falling back to ``DEFAULT_RETENTION_DAYS`` when the AWX DB is
+    unreachable or no active schedules exist. The window can be overridden by passing
+    ``since`` or ``until`` in kwargs.
+
+    Records telemetry for each run via ``DashboardTelemetry``.
+    Returns a task result dict with status, date range, job count, and any error details.
     """
     task_name = "collect_dashboard_reports_initial_data"
     start_time = time.monotonic()
@@ -485,21 +543,27 @@ def cleanup_dashboard_reports_old_data(**kwargs) -> dict[str, Any]:
     """
     Delete JobData records with a finished date older than retention_period_days.
 
-    Defaults to settings.DASHBOARD_COLLECTION['INITIAL_BACKFILL_DAYS'] so the
-    retention window always matches the backfill window, falling back to 90 days.
+    The default retention period is resolved from active AWX ``cleanup_jobs`` schedules via
+    ``get_retention_days`` (lowest ``retention_days`` across enabled schedules), falling back
+    to ``DEFAULT_RETENTION_DAYS`` when the AWX DB is unreachable or no active schedules exist.
+    The caller may override this default by passing ``retention_period_days`` in kwargs.
+
     Returns a task result dict with the number of deleted records, cutoff date, and any error details.
     """
-    dashboard_cfg = getattr(settings, "DASHBOARD_COLLECTION", None) or {}
-    raw_default_retention = dashboard_cfg.get("INITIAL_BACKFILL_DAYS", 90)
-    try:
-        default_retention = int(raw_default_retention)
-    except (TypeError, ValueError):
-        logger.warning(
-            "cleanup_dashboard_reports_old_data: INITIAL_BACKFILL_DAYS=%r is not a valid integer; falling back to 90",
-            raw_default_retention,
-        )
-        default_retention = 90
-    retention_period_days = kwargs.get("retention_period_days", default_retention)
+    db_name = kwargs.get("database", DEFAULT_AWX_DB_NAME)
+    if "retention_period_days" in kwargs:
+        retention_period_days = kwargs["retention_period_days"]
+    else:
+        raw_default_retention = get_retention_days(db_name)
+        try:
+            retention_period_days = int(raw_default_retention)
+        except (TypeError, ValueError):
+            logger.warning(
+                "cleanup_dashboard_reports_old_data: get_retention_days returned %r which is not a valid integer; falling back to %d",
+                raw_default_retention,
+                DEFAULT_RETENTION_DAYS,
+            )
+            retention_period_days = DEFAULT_RETENTION_DAYS
     try:
         retention_period_days = int(retention_period_days)
     except (TypeError, ValueError):

--- a/apps/dashboard_reports/tasks.py
+++ b/apps/dashboard_reports/tasks.py
@@ -2,7 +2,7 @@
 Background tasks for dashboard reports data collection and cleanup.
 
 Provides five dispatcherd tasks:
-- collect_dashboard_reports_initial_data: full historical backfill (default 90 days)
+- collect_dashboard_reports_initial_data: full historical backfill (window from the Controller's retention schedule, default 90 days)
 - collect_dashboard_reports_data: incremental sync from last known timestamp (deprecated)
 - sync_dashboard_job_records: writes unified_jobs data from the hourly hook to JobData
 - sync_dashboard_host_summaries: writes host summary data from the hourly hook to JobHostSummary
@@ -45,9 +45,13 @@ def get_retention_days(db_name: str = DEFAULT_AWX_DB_NAME) -> int:
     then applies the most aggressive (lowest) retention policy:
 
     - Only enabled schedules (``schedule_enabled = True``) are considered.
+    - Schedules whose ``retention_days`` is missing or not a valid integer are skipped
+      individually, so one malformed schedule doesn't affect the others.
     - When multiple schedules exist, the one with the lowest ``retention_days`` wins;
       ties are broken by the soonest ``next_run``.
-    - Falls back to ``DEFAULT_RETENTION_DAYS`` if the query fails or returns no active rows.
+    - Falls back to ``DEFAULT_RETENTION_DAYS`` if the query fails or no valid active rows remain.
+
+    Always returns a valid int, so callers don't need to re-validate the return value.
 
     Note: ``cleanup_activitystream`` schedules are intentionally excluded — they govern
     a different resource (activity stream entries) and must not drive ``JobData`` retention.
@@ -56,16 +60,22 @@ def get_retention_days(db_name: str = DEFAULT_AWX_DB_NAME) -> int:
         db_connection = get_db_connection(db_name)
         retention_data, _ = fetch_retention_settings(db_connection=db_connection)
     except Exception:
-        logger.exception("Error fetching retention settings; using default %d days", DEFAULT_RETENTION_DAYS)
+        logger.exception(f"Error fetching retention settings; using default {DEFAULT_RETENTION_DAYS} days")
         return DEFAULT_RETENTION_DAYS
 
-    active = [
-        row
-        for row in retention_data
-        if row.get("job_type") == "cleanup_jobs"
-        and row.get("schedule_enabled")
-        and row.get("retention_days") is not None
-    ]
+    active = []
+    for row in retention_data:
+        if row.get("job_type") != "cleanup_jobs" or not row.get("schedule_enabled"):
+            continue
+        raw_days = row.get("retention_days")
+        if raw_days is None:
+            continue
+        try:
+            days = int(raw_days)
+        except (TypeError, ValueError):
+            logger.warning(f"get_retention_days: skipping schedule with invalid retention_days={raw_days!r}")
+            continue
+        active.append({**row, "retention_days": days})
     if not active:
         return DEFAULT_RETENTION_DAYS
 
@@ -77,7 +87,7 @@ def get_retention_days(db_name: str = DEFAULT_AWX_DB_NAME) -> int:
             try:
                 row_next = _parse_dt(row.get("next_run"))
                 best_next = _parse_dt(best.get("next_run"))
-            except (TypeError, ValueError):
+            except TypeError:
                 continue
             if row_next is not None and (best_next is None or row_next < best_next):
                 best = row
@@ -168,23 +178,19 @@ def _resolve_collection_params(kwargs: dict) -> tuple[str, datetime, datetime, i
     """Resolve db_name, since, until, and batch_size from task kwargs with defaults applied.
 
     When ``since`` is not provided and no prior ``JobData`` timestamp exists, the initial
-    backfill window is determined by ``get_retention_days`` (queried from active AWX cleanup
+    retention window is determined by ``get_retention_days`` (queried from active AWX cleanup
     schedules) rather than a static setting.
     """
     dashboard_cfg = getattr(settings, "DASHBOARD_COLLECTION", None) or {}
-    db_name = kwargs.get("database", DEFAULT_AWX_DB_NAME)
+    db_name = kwargs.get("awx_database", DEFAULT_AWX_DB_NAME)
     until = _parse_dt(kwargs.get("until")) or datetime.now(tz=UTC)
     since = _parse_dt(kwargs.get("since")) or JobData.last_timestamp()
     if since is None:
-        raw_backfill_days = get_retention_days(db_name)
-        try:
-            backfill_days = int(raw_backfill_days)
-        except (TypeError, ValueError) as e:
-            raise ValueError(f"get_retention_days returned a non-integer value: {raw_backfill_days!r}") from e
-        if backfill_days <= 0:
-            raise ValueError(f"Retention days must be > 0, got {backfill_days!r}")
+        retention_days = get_retention_days(db_name)
+        if retention_days <= 0:
+            raise ValueError(f"Retention days must be > 0, got {retention_days!r}")
         since = (
-            (until - timedelta(days=backfill_days)).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(UTC)
+            (until - timedelta(days=retention_days)).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(UTC)
         )
     raw_batch_size = dashboard_cfg.get("BACKFILL_BATCH_SIZE", 5_000)
     try:
@@ -324,7 +330,7 @@ def collect_dashboard_reports_initial_data(**kwargs) -> dict[str, Any]:
     """
     Collect historical AWX job data as a one-time backfill.
 
-    The backfill window is determined by ``get_retention_days`` (queried from active AWX
+    The retention window is determined by ``get_retention_days`` (queried from active AWX
     cleanup schedules), falling back to ``DEFAULT_RETENTION_DAYS`` when the AWX DB is
     unreachable or no active schedules exist. The window can be overridden by passing
     ``since`` or ``until`` in kwargs.
@@ -521,7 +527,7 @@ def sync_dashboard_host_summaries(**kwargs) -> dict[str, Any]:
                 JobData._sync_host_summaries(job_data, host_summaries, existing)
             synced += 1
         except Exception:
-            logger.exception("Error syncing host summaries for job %s", job_remote_id)
+            logger.exception(f"Error syncing host summaries for job {job_remote_id}")
             failed += 1
 
     log_task_execution(
@@ -539,54 +545,48 @@ def sync_dashboard_host_summaries(**kwargs) -> dict[str, Any]:
     )
 
 
+def _normalize_retention_days(task_name: str, retention_days: Any) -> tuple[int, dict[str, Any] | None]:
+    """Validate and clamp a retention_days value shared by the cleanup tasks below.
+
+    Returns ``(retention_days, None)`` on success (negative values clamped to 0 with a
+    warning logged), or ``(0, error_result)`` when the value can't be coerced to an int —
+    callers must check ``error_result`` before using the returned int.
+    """
+    try:
+        retention_days = int(retention_days)
+    except (TypeError, ValueError):
+        logger.error(f"{task_name}: retention_days={retention_days!r} is not a valid integer; aborting cleanup")
+        return 0, create_task_result("error", error=f"Invalid retention_days value: {retention_days!r}")
+    if retention_days < 0:
+        logger.warning(f"{task_name}: retention_days={retention_days} is negative; clamping to 0")
+        retention_days = 0
+    return retention_days, None
+
+
 def cleanup_dashboard_reports_old_data(**kwargs) -> dict[str, Any]:
     """
-    Delete JobData records with a finished date older than retention_period_days.
+    Delete JobData records with a finished date older than retention_days.
 
     The default retention period is resolved from active AWX ``cleanup_jobs`` schedules via
     ``get_retention_days`` (lowest ``retention_days`` across enabled schedules), falling back
     to ``DEFAULT_RETENTION_DAYS`` when the AWX DB is unreachable or no active schedules exist.
-    The caller may override this default by passing ``retention_period_days`` in kwargs.
+    The caller may override this default by passing ``retention_days`` in kwargs.
 
     Returns a task result dict with the number of deleted records, cutoff date, and any error details.
     """
-    db_name = kwargs.get("database", DEFAULT_AWX_DB_NAME)
-    if "retention_period_days" in kwargs:
-        retention_period_days = kwargs["retention_period_days"]
-    else:
-        raw_default_retention = get_retention_days(db_name)
-        try:
-            retention_period_days = int(raw_default_retention)
-        except (TypeError, ValueError):
-            logger.warning(
-                "cleanup_dashboard_reports_old_data: get_retention_days returned %r which is not a valid integer; falling back to %d",
-                raw_default_retention,
-                DEFAULT_RETENTION_DAYS,
-            )
-            retention_period_days = DEFAULT_RETENTION_DAYS
-    try:
-        retention_period_days = int(retention_period_days)
-    except (TypeError, ValueError):
-        logger.error(
-            "cleanup_dashboard_reports_old_data: retention_period_days=%r is not a valid integer; aborting cleanup",
-            retention_period_days,
-        )
-        return create_task_result("error", error=f"Invalid retention_period_days value: {retention_period_days!r}")
-    if retention_period_days < 0:
-        logger.warning(
-            "cleanup_dashboard_reports_old_data: retention_period_days=%d is negative which would produce a future "
-            "cutoff date and delete current records; clamping to 0",
-            retention_period_days,
-        )
-        retention_period_days = 0
-    cutoff_date = datetime.now(tz=UTC) - timedelta(days=retention_period_days)
+    db_name = kwargs.get("awx_database", DEFAULT_AWX_DB_NAME)
+    retention_days = kwargs["retention_days"] if "retention_days" in kwargs else get_retention_days(db_name)
+    retention_days, error_result = _normalize_retention_days("cleanup_dashboard_reports_old_data", retention_days)
+    if error_result is not None:
+        return error_result
+    cutoff_date = datetime.now(tz=UTC) - timedelta(days=retention_days)
     cutoff_date = cutoff_date.replace(hour=0, minute=0, second=0, microsecond=0)
     cutoff_date_str = cutoff_date.isoformat()
 
     log_task_execution(
         task_name="cleanup_dashboard_reports_old_data",
         operation="processing",
-        details=f"Cleaning up JobData records older than {cutoff_date_str} (retention period: {retention_period_days} days)",
+        details=f"Cleaning up JobData records older than {cutoff_date_str} (retention period: {retention_days} days)",
     )
 
     start_time = time.monotonic()
@@ -621,7 +621,7 @@ def cleanup_dashboard_reports_old_data(**kwargs) -> dict[str, Any]:
             data={
                 "deleted_records": jobdata_count,
                 "cutoff_date": cutoff_date_str,
-                "retention_period_days": retention_period_days,
+                "retention_days": retention_days,
             },
         )
     except Exception as e:
@@ -640,36 +640,22 @@ def cleanup_dashboard_reports_old_data(**kwargs) -> dict[str, Any]:
 
 def cleanup_dashboard_telemetry(**kwargs) -> dict[str, Any]:
     """
-    Delete DashboardTelemetry rows older than retention_period_days (default: 60).
+    Delete DashboardTelemetry rows older than retention_days (default: 60).
 
     Keeps the telemetry table bounded; the API window is 30 days so rows beyond
     60 days are no longer surfaced and can safely be purged.
     Returns a task result dict with the number of deleted rows and cutoff date.
     """
     task_name = "cleanup_dashboard_telemetry"
-    retention_period_days = kwargs.get("retention_period_days", 60)
-    try:
-        retention_period_days = int(retention_period_days)
-    except (TypeError, ValueError):
-        logger.error(
-            "%s: retention_period_days=%r is not a valid integer; aborting cleanup",
-            task_name,
-            retention_period_days,
-        )
-        return create_task_result("error", error=f"Invalid retention_period_days value: {retention_period_days!r}")
-    if retention_period_days < 0:
-        logger.warning(
-            "%s: retention_period_days=%d is negative; clamping to 0",
-            task_name,
-            retention_period_days,
-        )
-        retention_period_days = 0
+    retention_days, error_result = _normalize_retention_days(task_name, kwargs.get("retention_days", 60))
+    if error_result is not None:
+        return error_result
 
-    cutoff_date = (datetime.now(tz=UTC) - timedelta(days=retention_period_days)).date()
+    cutoff_date = (datetime.now(tz=UTC) - timedelta(days=retention_days)).date()
     log_task_execution(
         task_name=task_name,
         operation="processing",
-        details=f"Deleting DashboardTelemetry rows with collection_run_date < {cutoff_date} (retention: {retention_period_days} days)",
+        details=f"Deleting DashboardTelemetry rows with collection_run_date < {cutoff_date} (retention: {retention_days} days)",
     )
 
     try:
@@ -684,7 +670,7 @@ def cleanup_dashboard_telemetry(**kwargs) -> dict[str, Any]:
             data={
                 "deleted_records": deleted_count,
                 "cutoff_date": str(cutoff_date),
-                "retention_period_days": retention_period_days,
+                "retention_days": retention_days,
             },
         )
     except Exception as e:

--- a/apps/tasks/task_groups.py
+++ b/apps/tasks/task_groups.py
@@ -323,13 +323,13 @@ DASHBOARD_COLLECTION_GROUP = TaskGroup(
             "cron": None,  # No schedule, run once on enable
             "args": {},
             "enabled": True,
-            "description": "Initial dashboard report collection (backfill; window controlled by DASHBOARD_COLLECTION['INITIAL_BACKFILL_DAYS'], default 90 days)",
+            "description": "Initial dashboard report collection (backfill; window controlled by the Controller's cleanup_jobs retention schedule, default 90 days)",
         },
         {
             "task_id": "cleanup_dashboard_reports_old_data",
             "function": "cleanup_dashboard_reports_old_data",
             "cron": "30 5 * * *",  # Daily at 5:30 AM
-            "args": {},  # retention_period_days defaults to DASHBOARD_COLLECTION.INITIAL_BACKFILL_DAYS
+            "args": {},  # retention_days defaults to the Controller's cleanup_jobs retention schedule
             "enabled": True,
             "description": "Clean up old dashboard report data based on retention policy",
         },
@@ -337,7 +337,7 @@ DASHBOARD_COLLECTION_GROUP = TaskGroup(
             "task_id": "cleanup_dashboard_telemetry",
             "function": "cleanup_dashboard_telemetry",
             "cron": "45 5 * * *",  # Daily at 5:45 AM
-            "args": {},  # retention_period_days defaults to 60
+            "args": {},  # retention_days defaults to 60
             "enabled": True,
             "description": "Delete DashboardTelemetry rows older than 60 days to prevent unbounded table growth",
         },

--- a/apps/tasks/tasks.py
+++ b/apps/tasks/tasks.py
@@ -350,7 +350,7 @@ TASK_METADATA = {
         "parameters": {
             "since": {
                 "type": "string",
-                "description": "Start datetime for collection (ISO format, defaults to last collected timestamp or 90 days ago)",
+                "description": "Start datetime for collection (ISO format, defaults to last collected timestamp or the Controller's retention period)",
                 "pattern": "datetime",
             },
             "until": {
@@ -360,7 +360,7 @@ TASK_METADATA = {
             },
         },
         "examples": [
-            {"name": "Default collection (last 90 days)", "data": {}},
+            {"name": "Default collection (last collected timestamp or Controller retention period)", "data": {}},
             {
                 "name": "Custom date range",
                 "data": {"since": "2024-01-30T00:00:00Z", "until": "2024-01-31T23:59:59Z"},
@@ -371,11 +371,11 @@ TASK_METADATA = {
     "collect_dashboard_reports_initial_data": {
         "queue": "dashboard",
         "category": _DASHBOARD_REPORTS_CATEGORY,
-        "description": "One-time backfill of historical AWX job data (window controlled by DASHBOARD_COLLECTION['INITIAL_BACKFILL_DAYS'], default 90 days). Ongoing incremental sync is driven automatically by the hourly_unified_jobs hook after this completes.",
+        "description": "One-time backfill of historical AWX job data (window controlled by the Controller's cleanup_jobs retention schedule, default 90 days). Ongoing incremental sync is driven automatically by the hourly_unified_jobs hook after this completes.",
         "parameters": {
             "since": {
                 "type": "string",
-                "description": "Start datetime for collection (ISO format, defaults to 90 days ago)",
+                "description": "Start datetime for collection (ISO format, defaults to the Controller's retention period, or 90 days ago if unavailable)",
                 "pattern": "datetime",
             },
             "until": {
@@ -385,7 +385,7 @@ TASK_METADATA = {
             },
         },
         "examples": [
-            {"name": "Default (last 90 days)", "data": {}},
+            {"name": "Default (Controller retention period)", "data": {}},
             {
                 "name": "Custom date range",
                 "data": {"since": "2024-01-01T00:00:00Z", "until": "2024-03-31T23:59:59Z"},
@@ -470,27 +470,27 @@ TASK_METADATA = {
     "cleanup_dashboard_reports_old_data": {
         "queue": "dashboard",
         "category": "Maintenance",  # dashboard report JobData
-        "description": "Delete dashboard report JobData records older than the retention period (defaults to DASHBOARD_COLLECTION.INITIAL_BACKFILL_DAYS)",
+        "description": "Delete dashboard report JobData records older than the retention period (defaults to the Controller's cleanup_jobs retention schedule)",
         "parameters": {
-            "retention_period_days": {
+            "retention_days": {
                 "type": "integer",
                 "default": None,
-                "description": "Number of days to retain dashboard report data. Defaults to DASHBOARD_COLLECTION.INITIAL_BACKFILL_DAYS (or 90 if unset).",
+                "description": "Number of days to retain dashboard report data. Defaults to the Controller's cleanup_jobs retention schedule (or 90 if unavailable).",
                 "min": 0,
                 "max": 365,
             },
         },
         "examples": [
-            {"name": "Default (matches INITIAL_BACKFILL_DAYS)", "data": {}},
-            {"name": "Extended retention", "data": {"retention_period_days": 180}},
+            {"name": "Default (matches Controller retention schedule)", "data": {}},
+            {"name": "Extended retention", "data": {"retention_days": 180}},
         ],
     },
     "cleanup_dashboard_telemetry": {
         "queue": "dashboard",
         "category": _DASHBOARD_REPORTS_CATEGORY,
-        "description": "Delete DashboardTelemetry rows older than retention_period_days (default: 60) to prevent unbounded table growth.",
+        "description": "Delete DashboardTelemetry rows older than retention_days (default: 60) to prevent unbounded table growth.",
         "parameters": {
-            "retention_period_days": {
+            "retention_days": {
                 "type": "integer",
                 "default": 60,
                 "description": "Number of days to retain telemetry rows. Rows with collection_run_date older than this are deleted.",
@@ -500,7 +500,7 @@ TASK_METADATA = {
         },
         "examples": [
             {"name": "Default (60 days)", "data": {}},
-            {"name": "30-day retention", "data": {"retention_period_days": 30}},
+            {"name": "30-day retention", "data": {"retention_days": 30}},
         ],
     },
 }

--- a/tests/coverage/dashboard_reports/test_dashboard_reports_tasks.py
+++ b/tests/coverage/dashboard_reports/test_dashboard_reports_tasks.py
@@ -168,6 +168,6 @@ def test_cleanup_dashboard_reports_no_data():
     from apps.dashboard_reports.tasks import cleanup_dashboard_reports_old_data
 
     JobData.objects.all().delete()
-    result = cleanup_dashboard_reports_old_data(retention_period_days=90)
+    result = cleanup_dashboard_reports_old_data(retention_days=90)
     assert result["status"] == "success"
     assert result.get("deleted_records", 0) == 0

--- a/tests/coverage/general/test_misc_coverage.py
+++ b/tests/coverage/general/test_misc_coverage.py
@@ -156,7 +156,7 @@ def test_cleanup_dashboard_reports_old_data_removes_old():
     from apps.dashboard_reports.tasks import cleanup_dashboard_reports_old_data
 
     # If JobData has any records, cleanup should run successfully
-    result = cleanup_dashboard_reports_old_data(retention_period_days=90)
+    result = cleanup_dashboard_reports_old_data(retention_days=90)
     assert result["status"] == "success"
 
 

--- a/tests/integration/dashboard_reports/test_collection_telemetry.py
+++ b/tests/integration/dashboard_reports/test_collection_telemetry.py
@@ -201,7 +201,7 @@ class TestTelemetryEndToEnd(TestCase):
             mock_model.objects.create.side_effect = Exception("telemetry DB failure")
             mock_jobdata.objects.filter.return_value.count.return_value = 0
 
-            result = cleanup_dashboard_reports_old_data(retention_period_days=90)
+            result = cleanup_dashboard_reports_old_data(retention_days=90)
 
         assert result["status"] == "success"
 

--- a/tests/unit/dashboard_reports/test_dashboard_telemetry.py
+++ b/tests/unit/dashboard_reports/test_dashboard_telemetry.py
@@ -402,7 +402,7 @@ class TestCleanupDashboardTelemetry:
 
     @pytest.mark.django_db
     def test_deletes_old_rows_and_returns_success(self):
-        """Rows older than retention_period_days are deleted; status is 'success'."""
+        """Rows older than retention_days are deleted; status is 'success'."""
         old_date = date.today() - timedelta(days=70)
         DashboardTelemetry.objects.create(
             task_name="old_task",
@@ -424,7 +424,7 @@ class TestCleanupDashboardTelemetry:
             cache_hit_rate=None,
         )
 
-        result = cleanup_dashboard_telemetry(retention_period_days=60)
+        result = cleanup_dashboard_telemetry(retention_days=60)
 
         assert result["status"] == "success"
         assert result["deleted_records"] == 1
@@ -432,7 +432,7 @@ class TestCleanupDashboardTelemetry:
         assert DashboardTelemetry.objects.first().task_name == "recent_task"
 
     def test_default_retention_is_60_days(self):
-        """When no retention_period_days kwarg is given, 60 days is used."""
+        """When no retention_days kwarg is given, 60 days is used."""
         with patch("apps.dashboard_reports.tasks.DashboardTelemetry") as mock_model:
             mock_qs = MagicMock()
             mock_qs.delete.return_value = (0, {})
@@ -445,14 +445,14 @@ class TestCleanupDashboardTelemetry:
         assert mock_model.objects.filter.called
 
     def test_invalid_retention_period_returns_error(self):
-        """A non-integer retention_period_days returns an error result."""
-        result = cleanup_dashboard_telemetry(retention_period_days="not_a_number")
+        """A non-integer retention_days returns an error result."""
+        result = cleanup_dashboard_telemetry(retention_days="not_a_number")
 
         assert result["status"] == "error"
-        assert "Invalid retention_period_days" in result["error"]
+        assert "Invalid retention_days" in result["error"]
 
     def test_negative_retention_period_is_clamped_to_zero(self):
-        """A negative retention_period_days is clamped to 0 (delete everything)."""
+        """A negative retention_days is clamped to 0 (delete everything)."""
         with patch("apps.dashboard_reports.tasks.DashboardTelemetry") as mock_model:
             mock_qs = MagicMock()
             mock_qs.delete.return_value = (5, {})
@@ -461,7 +461,7 @@ class TestCleanupDashboardTelemetry:
                 patch("apps.dashboard_reports.tasks.log_task_execution"),
                 patch("apps.dashboard_reports.tasks.logger") as mock_logger,
             ):
-                result = cleanup_dashboard_telemetry(retention_period_days=-10)
+                result = cleanup_dashboard_telemetry(retention_days=-10)
 
         assert result["status"] == "success"
         mock_logger.warning.assert_called_once()
@@ -476,20 +476,20 @@ class TestCleanupDashboardTelemetry:
                 patch("apps.dashboard_reports.tasks.log_task_execution"),
                 patch("apps.dashboard_reports.tasks.logger") as mock_logger,
             ):
-                result = cleanup_dashboard_telemetry(retention_period_days=60)
+                result = cleanup_dashboard_telemetry(retention_days=60)
 
         assert result["status"] == "error"
         assert "Cleanup failed" in result["error"]
         mock_logger.exception.assert_called_once()
 
     def test_result_contains_cutoff_date_and_retention(self):
-        """The success result includes cutoff_date and retention_period_days."""
+        """The success result includes cutoff_date and retention_days."""
         with patch("apps.dashboard_reports.tasks.DashboardTelemetry") as mock_model:
             mock_model.objects.filter.return_value.delete.return_value = (3, {})
             with patch("apps.dashboard_reports.tasks.log_task_execution"):
-                result = cleanup_dashboard_telemetry(retention_period_days=30)
+                result = cleanup_dashboard_telemetry(retention_days=30)
 
         assert result["status"] == "success"
         assert "cutoff_date" in result
-        assert result["retention_period_days"] == 30
+        assert result["retention_days"] == 30
         assert result["deleted_records"] == 3

--- a/tests/unit/dashboard_reports/test_tasks.py
+++ b/tests/unit/dashboard_reports/test_tasks.py
@@ -8,6 +8,7 @@ import pytest
 
 from apps.dashboard_reports.models import JobData
 from apps.dashboard_reports.tasks import (
+    DEFAULT_RETENTION_DAYS,
     _collect_data,
     _collect_jobs,
     _get_job_id_range,
@@ -18,6 +19,7 @@ from apps.dashboard_reports.tasks import (
     cleanup_dashboard_reports_old_data,
     collect_dashboard_reports_data,
     collect_dashboard_reports_initial_data,
+    get_retention_days,
     sync_dashboard_host_summaries,
     sync_dashboard_job_records,
 )
@@ -498,6 +500,12 @@ class TestCleanupDashboardReportsOldData:
         with patch("apps.dashboard_reports.tasks._save_telemetry_details"):
             yield
 
+    @pytest.fixture(autouse=True)
+    def mock_retention_days(self):
+        """Patch get_retention_days so cleanup tests don't need an AWX DB connection."""
+        with patch("apps.dashboard_reports.tasks.get_retention_days", return_value=DEFAULT_RETENTION_DAYS) as mock:
+            yield mock
+
     def test_cleanup_success(self, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup):
         """Successful deletion returns a success result with the correct record count."""
         mock_jobdata_objects.objects.filter.return_value.count.return_value = 5
@@ -527,29 +535,40 @@ class TestCleanupDashboardReportsOldData:
         assert args[0] == "error"
         assert "Cleanup failed" in kwargs["error"]
 
-    def test_cleanup_defaults_to_initial_backfill_days_setting(
-        self, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
+    def test_cleanup_defaults_to_get_retention_days(
+        self, mock_retention_days, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
     ):
-        """When retention_period_days is omitted, INITIAL_BACKFILL_DAYS from settings is used."""
-        from django.test import override_settings
-
+        """When retention_period_days is omitted, get_retention_days() determines the default."""
+        mock_retention_days.return_value = 60
         mock_jobdata_objects.objects.filter.return_value.count.return_value = 0
-        with override_settings(DASHBOARD_COLLECTION={"INITIAL_BACKFILL_DAYS": 60}):
-            cleanup_dashboard_reports_old_data()
+        cleanup_dashboard_reports_old_data()
         _, kwargs = mock_create_task_result_cleanup.call_args
         assert kwargs["data"]["retention_period_days"] == 60
 
-    def test_cleanup_defaults_to_90_when_no_setting(
+    def test_cleanup_passes_db_name_to_get_retention_days(
+        self, mock_retention_days, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
+    ):
+        """The 'database' kwarg is forwarded to get_retention_days so retention and collection use the same connection."""
+        mock_jobdata_objects.objects.filter.return_value.count.return_value = 0
+        cleanup_dashboard_reports_old_data(database="custom_db")
+        mock_retention_days.assert_called_once_with("custom_db")
+
+    def test_cleanup_passes_default_db_name_when_no_database_kwarg(
+        self, mock_retention_days, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
+    ):
+        """When 'database' kwarg is absent, get_retention_days is called with the 'awx' alias."""
+        mock_jobdata_objects.objects.filter.return_value.count.return_value = 0
+        cleanup_dashboard_reports_old_data()
+        mock_retention_days.assert_called_once_with("awx")
+
+    def test_cleanup_defaults_to_default_retention_days(
         self, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
     ):
-        """Falls back to 90 when DASHBOARD_COLLECTION is not configured."""
-        from django.test import override_settings
-
+        """Falls back to DEFAULT_RETENTION_DAYS when get_retention_days returns the default."""
         mock_jobdata_objects.objects.filter.return_value.count.return_value = 0
-        with override_settings(DASHBOARD_COLLECTION=None):
-            cleanup_dashboard_reports_old_data()
+        cleanup_dashboard_reports_old_data()
         _, kwargs = mock_create_task_result_cleanup.call_args
-        assert kwargs["data"]["retention_period_days"] == 90
+        assert kwargs["data"]["retention_period_days"] == DEFAULT_RETENTION_DAYS
 
     def test_cleanup_custom_retention(
         self, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
@@ -625,6 +644,7 @@ class TestResolveCollectionParams:
     @patch("apps.dashboard_reports.tasks.JobData")
     def test_explicit_since_until_used_directly(self, mock_jobdata):
         """When since and until are provided they are used without touching DB."""
+
         since = datetime(2024, 1, 1, tzinfo=UTC)
         until = datetime(2024, 2, 1, tzinfo=UTC)
         db_name, got_since, got_until, batch_size = _resolve_collection_params(
@@ -643,24 +663,35 @@ class TestResolveCollectionParams:
         _, got_since, _, _ = _resolve_collection_params({})
         assert got_since == ts
 
+    @patch("apps.dashboard_reports.tasks.get_retention_days", return_value=30)
     @patch("apps.dashboard_reports.tasks.JobData")
-    def test_since_computed_from_backfill_days_when_no_timestamp(self, mock_jobdata):
-        """When since is absent and last_timestamp() is None, compute since from INITIAL_BACKFILL_DAYS."""
+    def test_since_computed_from_retention_days_when_no_timestamp(self, mock_jobdata, mock_retention):
+        """When since is absent and last_timestamp() is None, compute since from get_retention_days()."""
         from django.test import override_settings
 
         mock_jobdata.last_timestamp.return_value = None
         until = datetime(2024, 6, 1, tzinfo=UTC)
 
-        with override_settings(DASHBOARD_COLLECTION={"INITIAL_BACKFILL_DAYS": 30, "BACKFILL_BATCH_SIZE": 500}):
+        with override_settings(DASHBOARD_COLLECTION={"BACKFILL_BATCH_SIZE": 500}):
             _, got_since, _, batch_size = _resolve_collection_params({"until": until.isoformat()})
 
         expected_since = (until - timedelta(days=30)).replace(hour=0, minute=0, second=0, microsecond=0).astimezone(UTC)
         assert got_since == expected_since
         assert batch_size == 500
+        mock_retention.assert_called_once_with("awx")
+
+    @patch("apps.dashboard_reports.tasks.get_retention_days", return_value=30)
+    @patch("apps.dashboard_reports.tasks.JobData")
+    def test_custom_database_kwarg_forwarded_to_retention(self, mock_jobdata, mock_retention):
+        """When 'database' kwarg is given and no prior timestamp exists, db_name is passed to get_retention_days."""
+        mock_jobdata.last_timestamp.return_value = None
+        until = datetime(2024, 6, 1, tzinfo=UTC)
+        _resolve_collection_params({"database": "custom_db", "until": until.isoformat()})
+        mock_retention.assert_called_once_with("custom_db")
 
     @patch("apps.dashboard_reports.tasks.JobData")
     def test_custom_database_kwarg(self, mock_jobdata):
-        """The 'database' kwarg overrides the DEFAULT_DB_NAME."""
+        """The 'database' kwarg overrides the DEFAULT_AWX_DB_NAME."""
         mock_jobdata.last_timestamp.return_value = datetime(2024, 1, 1, tzinfo=UTC)
         db_name, *_ = _resolve_collection_params({"database": "custom_db"})
         assert db_name == "custom_db"
@@ -684,17 +715,130 @@ class TestResolveCollectionParams:
         ):
             _resolve_collection_params({})
 
+    @patch("apps.dashboard_reports.tasks.get_retention_days", return_value=0)
     @patch("apps.dashboard_reports.tasks.JobData")
-    def test_invalid_backfill_days_raises_value_error(self, mock_jobdata):
-        """A non-integer INITIAL_BACKFILL_DAYS raises ValueError with a descriptive message."""
-        from django.test import override_settings
-
+    def test_zero_retention_days_raises_value_error(self, mock_jobdata, mock_retention):
+        """get_retention_days returning 0 raises ValueError (retention must be > 0)."""
         mock_jobdata.last_timestamp.return_value = None
-        with (
-            override_settings(DASHBOARD_COLLECTION={"INITIAL_BACKFILL_DAYS": "not-a-number"}),
-            pytest.raises(ValueError, match="INITIAL_BACKFILL_DAYS"),
-        ):
+        with pytest.raises(ValueError, match="Retention days must be > 0"):
             _resolve_collection_params({})
+
+
+# ---------------------------------------------------------------------------
+# get_retention_days
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestGetRetentionDays:
+    """Tests for get_retention_days — all branches, no real AWX DB needed."""
+
+    def _row(self, job_type="cleanup_jobs", enabled=True, retention_days=30, next_run=None):
+        return {
+            "job_type": job_type,
+            "template_name": "Cleanup",
+            "schedule_name": "Daily Cleanup",
+            "schedule_enabled": enabled,
+            "rrule": "FREQ=DAILY",
+            "next_run": next_run,
+            "retention_days": retention_days,
+        }
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings", side_effect=Exception("db down"))
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_db_error_returns_default(self, mock_conn, mock_fetch):
+        """Returns DEFAULT_RETENTION_DAYS when the AWX DB is unreachable."""
+        assert get_retention_days() == DEFAULT_RETENTION_DAYS
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings", return_value=([], 0))
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_empty_result_returns_default(self, mock_conn, mock_fetch):
+        """Returns DEFAULT_RETENTION_DAYS when no schedules are returned."""
+        assert get_retention_days() == DEFAULT_RETENTION_DAYS
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_no_active_schedules_returns_default(self, mock_conn, mock_fetch):
+        """Returns DEFAULT_RETENTION_DAYS when all cleanup_jobs schedules are disabled."""
+        mock_fetch.return_value = ([self._row(enabled=False, retention_days=7)], 1)
+        assert get_retention_days() == DEFAULT_RETENTION_DAYS
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_null_retention_days_ignored(self, mock_conn, mock_fetch):
+        """Rows with retention_days=None are excluded; falls back to DEFAULT_RETENTION_DAYS when all are None."""
+        mock_fetch.return_value = ([self._row(retention_days=None)], 1)
+        assert get_retention_days() == DEFAULT_RETENTION_DAYS
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_single_active_schedule(self, mock_conn, mock_fetch):
+        """Returns retention_days of the single active cleanup_jobs schedule."""
+        mock_fetch.return_value = ([self._row(retention_days=45)], 1)
+        assert get_retention_days() == 45
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_lowest_retention_days_wins(self, mock_conn, mock_fetch):
+        """When multiple schedules exist, the lowest retention_days is used."""
+        rows = [self._row(retention_days=60), self._row(retention_days=30), self._row(retention_days=90)]
+        mock_fetch.return_value = (rows, 3)
+        assert get_retention_days() == 30
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_tie_broken_by_soonest_next_run(self, mock_conn, mock_fetch):
+        """On equal retention_days, the schedule with the soonest next_run wins."""
+        rows = [
+            self._row(retention_days=30, next_run="2024-06-10T00:00:00+00:00"),
+            self._row(retention_days=30, next_run="2024-06-05T00:00:00+00:00"),
+        ]
+        mock_fetch.return_value = (rows, 2)
+        result = get_retention_days()
+        assert result == 30
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_bad_next_run_type_skips_tiebreak(self, mock_conn, mock_fetch):
+        """A TypeError from _parse_dt during tie-break is caught; current best is kept without crashing."""
+        rows = [
+            self._row(retention_days=30, next_run="2024-06-01T00:00:00+00:00"),
+            self._row(retention_days=30, next_run=99999),  # int → TypeError from _parse_dt
+        ]
+        mock_fetch.return_value = (rows, 2)
+        assert get_retention_days() == 30
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_activitystream_schedules_ignored(self, mock_conn, mock_fetch):
+        """cleanup_activitystream schedules do not influence JobData retention."""
+        rows = [
+            self._row(job_type="cleanup_activitystream", retention_days=7),
+            self._row(job_type="cleanup_jobs", retention_days=60),
+        ]
+        mock_fetch.return_value = (rows, 2)
+        assert get_retention_days() == 60
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_only_activitystream_present_returns_default(self, mock_conn, mock_fetch):
+        """Returns DEFAULT_RETENTION_DAYS when only cleanup_activitystream schedules exist."""
+        mock_fetch.return_value = ([self._row(job_type="cleanup_activitystream", retention_days=7)], 1)
+        assert get_retention_days() == DEFAULT_RETENTION_DAYS
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_default_awx_db_name_passed_to_connection(self, mock_conn, mock_fetch):
+        """get_db_connection is called with the 'awx' alias by default."""
+        mock_fetch.return_value = ([self._row(retention_days=30)], 1)
+        get_retention_days()
+        mock_conn.assert_called_once_with("awx")
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_custom_db_name_passed_to_connection(self, mock_conn, mock_fetch):
+        """A custom db_name argument is forwarded to get_db_connection."""
+        mock_fetch.return_value = ([self._row(retention_days=30)], 1)
+        get_retention_days("custom_db")
+        mock_conn.assert_called_once_with("custom_db")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/dashboard_reports/test_tasks.py
+++ b/tests/unit/dashboard_reports/test_tasks.py
@@ -516,7 +516,7 @@ class TestCleanupDashboardReportsOldData:
         assert args[0] == "success"
         assert kwargs["data"]["deleted_records"] == 5
         assert "cutoff_date" in kwargs["data"]
-        assert "retention_period_days" in kwargs["data"]
+        assert "retention_days" in kwargs["data"]
 
     def test_cleanup_no_records(self, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup):
         """Returns success with deleted_records=0 when nothing falls outside the retention window."""
@@ -538,25 +538,25 @@ class TestCleanupDashboardReportsOldData:
     def test_cleanup_defaults_to_get_retention_days(
         self, mock_retention_days, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
     ):
-        """When retention_period_days is omitted, get_retention_days() determines the default."""
+        """When retention_days is omitted, get_retention_days() determines the default."""
         mock_retention_days.return_value = 60
         mock_jobdata_objects.objects.filter.return_value.count.return_value = 0
         cleanup_dashboard_reports_old_data()
         _, kwargs = mock_create_task_result_cleanup.call_args
-        assert kwargs["data"]["retention_period_days"] == 60
+        assert kwargs["data"]["retention_days"] == 60
 
     def test_cleanup_passes_db_name_to_get_retention_days(
         self, mock_retention_days, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
     ):
-        """The 'database' kwarg is forwarded to get_retention_days so retention and collection use the same connection."""
+        """The 'awx_database' kwarg is forwarded to get_retention_days so retention and collection use the same connection."""
         mock_jobdata_objects.objects.filter.return_value.count.return_value = 0
-        cleanup_dashboard_reports_old_data(database="custom_db")
+        cleanup_dashboard_reports_old_data(awx_database="custom_db")
         mock_retention_days.assert_called_once_with("custom_db")
 
     def test_cleanup_passes_default_db_name_when_no_database_kwarg(
         self, mock_retention_days, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
     ):
-        """When 'database' kwarg is absent, get_retention_days is called with the 'awx' alias."""
+        """When 'awx_database' kwarg is absent, get_retention_days is called with the 'awx' alias."""
         mock_jobdata_objects.objects.filter.return_value.count.return_value = 0
         cleanup_dashboard_reports_old_data()
         mock_retention_days.assert_called_once_with("awx")
@@ -568,21 +568,21 @@ class TestCleanupDashboardReportsOldData:
         mock_jobdata_objects.objects.filter.return_value.count.return_value = 0
         cleanup_dashboard_reports_old_data()
         _, kwargs = mock_create_task_result_cleanup.call_args
-        assert kwargs["data"]["retention_period_days"] == DEFAULT_RETENTION_DAYS
+        assert kwargs["data"]["retention_days"] == DEFAULT_RETENTION_DAYS
 
     def test_cleanup_custom_retention(
         self, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
     ):
-        """An explicit retention_period_days kwarg overrides the settings default."""
+        """An explicit retention_days kwarg overrides the settings default."""
         mock_jobdata_objects.objects.filter.return_value.count.return_value = 2
-        cleanup_dashboard_reports_old_data(retention_period_days=30)
+        cleanup_dashboard_reports_old_data(retention_days=30)
         args, kwargs = mock_create_task_result_cleanup.call_args
-        assert kwargs["data"]["retention_period_days"] == 30
+        assert kwargs["data"]["retention_days"] == 30
 
     def test_cleanup_cutoff_date(self, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup):
         """Cutoff date in the result is midnight on the expected day."""
         mock_jobdata_objects.objects.filter.return_value.count.return_value = 1
-        cleanup_dashboard_reports_old_data(retention_period_days=1)
+        cleanup_dashboard_reports_old_data(retention_days=1)
         _, kwargs = mock_create_task_result_cleanup.call_args
         actual_cutoff = kwargs["data"]["cutoff_date"]
         expected_date = (datetime.now(tz=UTC) - timedelta(days=1)).date().isoformat()
@@ -591,21 +591,21 @@ class TestCleanupDashboardReportsOldData:
     def test_cleanup_invalid_retention_string(
         self, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
     ):
-        """Non-integer retention_period_days returns an error result."""
-        cleanup_dashboard_reports_old_data(retention_period_days="not-a-number")
+        """Non-integer retention_days returns an error result."""
+        cleanup_dashboard_reports_old_data(retention_days="not-a-number")
         args, kwargs = mock_create_task_result_cleanup.call_args
         assert args[0] == "error"
-        assert "Invalid retention_period_days" in kwargs["error"]
+        assert "Invalid retention_days" in kwargs["error"]
 
     def test_cleanup_negative_retention_clamped(
         self, mock_jobdata_objects, mock_log_task_execution, mock_create_task_result_cleanup
     ):
-        """Negative retention_period_days is clamped to 0 (deletes everything up to now)."""
+        """Negative retention_days is clamped to 0 (deletes everything up to now)."""
         mock_jobdata_objects.objects.filter.return_value.delete.return_value = (10, {})
-        cleanup_dashboard_reports_old_data(retention_period_days=-5)
+        cleanup_dashboard_reports_old_data(retention_days=-5)
         args, kwargs = mock_create_task_result_cleanup.call_args
         assert args[0] == "success"
-        assert kwargs["data"]["retention_period_days"] == 0
+        assert kwargs["data"]["retention_days"] == 0
 
     @pytest.mark.integration
     @pytest.mark.django_db
@@ -624,7 +624,7 @@ class TestCleanupDashboardReportsOldData:
         new_job2 = JobData.objects.create(
             job_id=1004, finished=cutoff + timedelta(days=10), status="successful", elapsed=1.0
         )
-        result = cleanup_dashboard_reports_old_data(retention_period_days=90)
+        result = cleanup_dashboard_reports_old_data(retention_days=90)
         assert result["deleted_records"] == 2
 
         remaining_ids = set(JobData.objects.values_list("id", flat=True))
@@ -683,17 +683,17 @@ class TestResolveCollectionParams:
     @patch("apps.dashboard_reports.tasks.get_retention_days", return_value=30)
     @patch("apps.dashboard_reports.tasks.JobData")
     def test_custom_database_kwarg_forwarded_to_retention(self, mock_jobdata, mock_retention):
-        """When 'database' kwarg is given and no prior timestamp exists, db_name is passed to get_retention_days."""
+        """When 'awx_database' kwarg is given and no prior timestamp exists, db_name is passed to get_retention_days."""
         mock_jobdata.last_timestamp.return_value = None
         until = datetime(2024, 6, 1, tzinfo=UTC)
-        _resolve_collection_params({"database": "custom_db", "until": until.isoformat()})
+        _resolve_collection_params({"awx_database": "custom_db", "until": until.isoformat()})
         mock_retention.assert_called_once_with("custom_db")
 
     @patch("apps.dashboard_reports.tasks.JobData")
     def test_custom_database_kwarg(self, mock_jobdata):
-        """The 'database' kwarg overrides the DEFAULT_AWX_DB_NAME."""
+        """The 'awx_database' kwarg overrides the DEFAULT_AWX_DB_NAME."""
         mock_jobdata.last_timestamp.return_value = datetime(2024, 1, 1, tzinfo=UTC)
-        db_name, *_ = _resolve_collection_params({"database": "custom_db"})
+        db_name, *_ = _resolve_collection_params({"awx_database": "custom_db"})
         assert db_name == "custom_db"
 
     @patch("apps.dashboard_reports.tasks.JobData")
@@ -773,6 +773,21 @@ class TestGetRetentionDays:
     def test_single_active_schedule(self, mock_conn, mock_fetch):
         """Returns retention_days of the single active cleanup_jobs schedule."""
         mock_fetch.return_value = ([self._row(retention_days=45)], 1)
+        assert get_retention_days() == 45
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_non_integer_retention_days_returns_default(self, mock_conn, mock_fetch):
+        """Falls back to DEFAULT_RETENTION_DAYS when the only schedule's retention_days isn't a valid integer."""
+        mock_fetch.return_value = ([self._row(retention_days="not-a-number")], 1)
+        assert get_retention_days() == DEFAULT_RETENTION_DAYS
+
+    @patch("apps.dashboard_reports.tasks.fetch_retention_settings")
+    @patch("apps.dashboard_reports.tasks.get_db_connection")
+    def test_invalid_retention_days_skipped_others_kept(self, mock_conn, mock_fetch):
+        """A schedule with a non-integer retention_days is skipped individually; other valid schedules still count."""
+        rows = [self._row(retention_days="not-a-number"), self._row(retention_days=45)]
+        mock_fetch.return_value = (rows, 2)
         assert get_retention_days() == 45
 
     @patch("apps.dashboard_reports.tasks.fetch_retention_settings")


### PR DESCRIPTION
# [AAP-80832](https://redhat.atlassian.net/browse/AAP-80832) Using Controller's data retention period setting as a source of that setting for the Automation Dashboard

## Description

 Instead of a static `DASHBOARD_COLLECTION['INITIAL_BACKFILL_DAYS']` setting,                                                                                                                                                                                                                                                                                 
  the retention period is now read dynamically from the AWX database — derived                                                                                                                                                                                                                                                                                 
  from active `cleanup_jobs` system job schedules configured in the Controller.                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                               
  ### Changes                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                               
  **`apps/dashboard_reports/awx_queries.py`**                                                                                                                                                                                                                                                                                                                  
  - Added `RETENTION_SETTINGS` SQL enum value that queries `cleanup_jobs` /                                                                                                                                                                                                                                                                                    
    `cleanup_activitystream` system job schedules from AWX                                                                                                                                                                                                                                                                                                     
    (`main_systemjobtemplate`, `main_schedule`).                                                                                                                                                                                                                                                                                                               
  - `fetch_data_from_db` now accepts a custom `order_clause` via kwargs instead                                                                                                                                                                                                                                                                                
    of always defaulting to `ORDER BY {join_alias}name`.                                                                                                                                                                                                                                                                                                       
  - Added `fetch_retention_settings()` helper.                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                               
  **`apps/dashboard_reports/tasks.py`**                                                                                                                                                                                                                                                                                                                        
  - Added `DEFAULT_RETENTION_DAYS = 90` constant (fallback value).                                                                                                                                                                                                                                                                                             
  - Added `get_retention_days(db_name)`:                                                                                                                                                                                                                                                                                                                       
    - Queries active `cleanup_jobs` schedules from the AWX DB.                                                                                                                                                                                                                                                                                                 
    - Picks the **lowest** `retention_days` (most aggressive policy); ties are                                                                                                                                                                                                                                                                                 
      broken by the soonest `next_run`.                                                                                                                                                                                                                                                                                                                        
    - `cleanup_activitystream` schedules are intentionally excluded — they govern                                                                                                                                                                                                                                                                              
      a different resource and must not drive `JobData` retention.                                                                                                                                                                                                                                                                                             
    - Falls back to `DEFAULT_RETENTION_DAYS` on DB error or when no active                                                                                                                                                                                                                                                                                     
      schedules exist.                                                                                                                                                                                                                                                                                                                                         
  - `_resolve_collection_params` and `cleanup_dashboard_reports_old_data` now                                                                                                                                                                                                                                                                                  
    call `get_retention_days()` instead of reading `INITIAL_BACKFILL_DAYS` from                                                                                                                                                                                                                                                                                
    Django settings.                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                               
  **`tests/unit/dashboard_reports/test_tasks.py`**                                                                                                                                                                                                                                                                                                             
  - Added `TestGetRetentionDays` with 11 tests covering all branches: DB errors,                                                                                                                                                                                                                                                                               
    empty results, disabled schedules, tie-break logic, and `activitystream`                                                                                                                                                                                                                                                                                   
    exclusion.                                                                                                                                                                                                                                                                                                                                                 
  - Updated existing tests to mock `get_retention_days` instead of using                                                                                                                                                                                                                                                                                       
    `override_settings(DASHBOARD_COLLECTION=...)`.   


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
