### PR TITLE
[AAP-78076] test(indirect-nodes): add OperationalError db connection failure test

### DIFF
--- a/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
@@ -241,7 +241,7 @@ class TestIndirectManagedNodesCollector:
             collection_timestamp=ts,
         )
         assert collection.status == "failed"
-        assert collection.error_message is not None
+        assert "could not connect to server" in collection.error_message
 
     @pytest.mark.django_db
     def test_default_timestamp_when_not_provided(self):

--- a/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
@@ -204,6 +204,46 @@ class TestIndirectManagedNodesCollector:
         assert "collector_type" in result["error"]
 
     @pytest.mark.django_db
+    def test_db_connection_failure_records_error(self):
+        """OperationalError from DB connection failure is recorded as failed, not silently dropped.
+
+        Distinct from ProgrammingError (missing table): ProgrammingError is caught and logged
+        as a warning in the metrics-utility CLI layer. OperationalError bypasses that catch
+        and must not be silently swallowed by the metrics-service task layer.
+        """
+        import psycopg2
+
+        def raise_connection_error(**kwargs):
+            raise psycopg2.OperationalError("could not connect to server")
+
+        mock_registry = {
+            "indirect_managed_nodes": {
+                "collector_func": raise_connection_error,
+                "rollup_processor": _get_hourly_collectors()["indirect_managed_nodes"]["rollup_processor"],
+                "description": "Test collector",
+            }
+        }
+
+        ts = datetime(2024, 1, 1, tzinfo=UTC)
+        with (
+            patch("apps.tasks.collectors.collect_hourly_metrics._get_hourly_collectors", return_value=mock_registry),
+            patch("apps.tasks.collectors.collect_hourly_metrics.get_db_connection", return_value=MagicMock()),
+        ):
+            result = collect_hourly_metrics(
+                collector_type="indirect_managed_nodes",
+                hour_timestamp=ts.isoformat(),
+            )
+
+        assert result["status"] == "error"
+
+        collection = HourlyMetricsCollection.objects.get(
+            collector_type="indirect_managed_nodes",
+            collection_timestamp=ts,
+        )
+        assert collection.status == "failed"
+        assert collection.error_message is not None
+
+    @pytest.mark.django_db
     def test_default_timestamp_when_not_provided(self):
         """When no timestamp provided, collector uses previous full hour."""
         sample_data = pd.DataFrame(

--- a/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
@@ -3,8 +3,8 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
-import psycopg2
 import pandas as pd
+import psycopg2
 import pytest
 from psycopg2 import errors as pg_errors
 
@@ -212,6 +212,7 @@ class TestIndirectManagedNodesCollector:
         as a warning in the metrics-utility CLI layer. OperationalError bypasses that catch
         and must not be silently swallowed by the metrics-service task layer.
         """
+
         def raise_connection_error(**kwargs):
             raise psycopg2.OperationalError("could not connect to server")
 

--- a/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
+++ b/tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+import psycopg2
 import pandas as pd
 import pytest
 from psycopg2 import errors as pg_errors
@@ -211,8 +212,6 @@ class TestIndirectManagedNodesCollector:
         as a warning in the metrics-utility CLI layer. OperationalError bypasses that catch
         and must not be silently swallowed by the metrics-service task layer.
         """
-        import psycopg2
-
         def raise_connection_error(**kwargs):
             raise psycopg2.OperationalError("could not connect to server")
 


### PR DESCRIPTION
# [AAP-78076] Add OperationalError handling test for indirect node collector

## Description

- Adds one unit test to `test_collect_hourly_indirect_nodes.py` covering
  general DB connection failure (Part 4 of indirect node collection).
- `test_db_connection_failure_records_error`: asserts that an
  `OperationalError` (e.g. connection refused) raised by the collector is
  recorded as a failed collection and is not silently swallowed. This is
  distinct from `ProgrammingError` (missing table), which is caught and
  logged as a warning at the metrics-utility CLI layer.

## Type of Change

- [x] Test update

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

No special setup required.

### Steps to Test

```
.venv/bin/pytest tests/unit/tasks/collectors/test_collect_hourly_indirect_nodes.py -v
```

### Expected Results

All 9 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of hourly metric collection failures so connection issues are reported as errors and recorded properly instead of being ignored.

* **Tests**
  * Added coverage for database connection failures to verify the error status and failure record are saved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->